### PR TITLE
fixed test_bcast.jl

### DIFF
--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -20,59 +20,17 @@ root = 0
 
 srand(17)
 
-# Float64
-A = rand(13)
-@test bcast_array(A, root) == A
-#@testfails bcast_array(A, root) == rand(13)
-
-# Complex128
-A = rand(13) + im * rand(13)
-@test bcast_array(A, root) == A
-
-# Float32
-A = float32(rand(15))
-@test bcast_array(A, root) == A
-
-# Complex64
-A = float32(rand(15)) + im * float32(rand(15))
-@test bcast_array(A, root) == A
+matsize = (17,17)
+for typ in ( Float32, Float64, Complex64, Complex128,
+             Int8, Int16, Int32, Int64,
+             Uint8, Uint16, Uint32, Uint64)
+    A = rand(typ, matsize...)
+    @test bcast_array(A, root) == A
+end
 
 # Char
 A = ['s', 't', 'a', 'r', ' ', 'w', 'a', 'r', 's']
 @test bcast_array(A, root) == A
-
-# Int8
-A = int8(rand(1:143, 34))
-@test bcast_array(A, root) == A
-
-# Uint8
-A = uint8(rand(34, 123))
-@test bcast_array(A, root) == A
-
-# Int16
-A = int16(rand(1430, 340))
-@test bcast_array(A, root) == A
-
-# Uint16
-A = uint16(rand(340, 1230))
-@test bcast_array(A, root) == A
-
-# Int32
-A = rand(34,123)
-@test bcast_array(A, root) == A
-
-# Uint32
-A = uint32(rand(34, 28))
-@test bcast_array(A, root) == A
-
-# Int64
-A = int64(rand(1:400, 33))
-@test bcast_array(A, root) == A
-
-# Uint64
-A = uint64(rand(1:8000, 128))
-@test bcast_array(A, root) == A
-
 
 comm = MPI.COMM_WORLD
 


### PR DESCRIPTION
In Julia0.4-dev, we can build MPI.jl but fail to test.

```
The following tests FAILED:
      1 - test_bcast.jl_np:2 (Failed)
      4 - test_bcast.jl_np:5 (Failed)
Errors while running CTest
```

This is caused by the change of behavior of integer conversion functions; Now these throws `InexactError()` when an overflow occurs,  for example, `int8(128)`.

see https://github.com/JuliaLang/julia/pull/8420.
