### PR TITLE
Make the tests runnable with Pkg.test()

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,24 @@
+using Base.Test
+using MPI
+
+import MPI
+
+MPI.Init()
+
+comm = MPI.COMM_WORLD
+size = MPI.Comm_size(comm)
+rank = MPI.Comm_rank(comm)
+
+rank == 0 && println("Testing bcast...")
+include("test_bcast.jl")
+test_bcast()
+
+rank == 0 && println("Testing reduce...")
+include("test_reduce.jl")
+test_reduce()
+
+rank == 0 && println("Testing sendrecv...")
+include("test_sendrecv.jl")
+test_sendrecv()
+
+MPI.Finalize()

--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -1,8 +1,3 @@
-using Base.Test
-import MPI
-
-MPI.Init()
-
 function bcast_array(A, root)
     comm = MPI.COMM_WORLD
 
@@ -16,43 +11,42 @@ function bcast_array(A, root)
     B
 end
 
-root = 0
+function test_bcast()
+    root = 0
 
-srand(17)
+    srand(17)
 
-matsize = (17,17)
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
-    A = rand(typ, matsize...)
+    matsize = (17,17)
+    for typ in ( Float32, Float64, Complex64, Complex128,
+                Int8, Int16, Int32, Int64,
+                Uint8, Uint16, Uint32, Uint64)
+        A = rand(typ, matsize...)
+        @test bcast_array(A, root) == A
+    end
+
+    # Char
+    A = ['s', 't', 'a', 'r', ' ', 'w', 'a', 'r', 's']
     @test bcast_array(A, root) == A
+
+    g = x -> x^2 + 2x - 1
+    if MPI.Comm_rank(comm) == root
+        f = copy(g)
+    else
+        f = nothing
+    end
+    f = MPI.bcast(f, root, comm)
+    @test f(3) == g(3)
+    @test f(5) == g(5)
+    @test f(7) == g(7)
+
+
+    A = Dict("foo" => "bar")
+    if MPI.Comm_rank(comm) == root
+        B = A
+    else
+        B = nothing
+    end
+    B = MPI.bcast(B, root, comm)
+    @test B["foo"] == "bar"
+
 end
-
-# Char
-A = ['s', 't', 'a', 'r', ' ', 'w', 'a', 'r', 's']
-@test bcast_array(A, root) == A
-
-comm = MPI.COMM_WORLD
-
-g = x -> x^2 + 2x - 1
-if MPI.Comm_rank(comm) == root
-    f = copy(g)
-else
-    f = nothing
-end
-f = MPI.bcast(f, root, comm)
-@test f(3) == g(3)
-@test f(5) == g(5)
-@test f(7) == g(7)
-
-
-A = {"foo" => "bar"}
-if MPI.Comm_rank(comm) == root
-    B = A
-else
-    B = nothing
-end
-B = MPI.bcast(B, root, comm)
-@test B["foo"] == "bar"
-
-MPI.Finalize()

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -1,26 +1,17 @@
-using Base.Test
+function test_reduce()
 
-import MPI
+    root = size-1
+    val = rank == root ? sum([0:size-1]) : nothing
+    @test MPI.Reduce(rank, MPI.SUM, root, comm) == val
 
-MPI.Init()
+    val = rank == root ? size-1 : nothing
+    @test MPI.Reduce(rank, MPI.MAX, root, comm) == val
 
-comm = MPI.COMM_WORLD
-size = MPI.Comm_size(comm)
-rank = MPI.Comm_rank(comm)
+    val = rank == root ? 0 : nothing
+    @test MPI.Reduce(rank, MPI.MIN, root, comm) == val
 
-root = size-1
-val = rank == root ? sum([0:size-1]) : nothing
-@test MPI.Reduce(rank, MPI.SUM, root, comm) == val
-
-val = rank == root ? size-1 : nothing
-@test MPI.Reduce(rank, MPI.MAX, root, comm) == val
-
-val = rank == root ? 0 : nothing
-@test MPI.Reduce(rank, MPI.MIN, root, comm) == val
-
-mesg = [1.0:5.0]
-sum_mesg = MPI.Reduce(mesg, MPI.SUM, root, comm)
-sum_mesg = rank == root ? sum_mesg : size*mesg
-@test isapprox(norm(sum_mesg-size*mesg), 0.0)
-
-MPI.Finalize()
+    mesg = [1.0:5.0]
+    sum_mesg = MPI.Reduce(mesg, MPI.SUM, root, comm)
+    sum_mesg = rank == root ? sum_mesg : size*mesg
+    @test isapprox(norm(sum_mesg-size*mesg), 0.0)
+end


### PR DESCRIPTION
I brought this up in #28, but started implementing myself. It is nice to be able to run the tests with Pkg.test(). Currently, this requires

mpirun -np <np> julia runtests.jl

Eventually, we can move to the MPIManager so that mpirun is also not necessary.

