### PR TITLE
added Comm_split, Comm_split_type

### DIFF
--- a/deps/make_f2c.c
+++ b/deps/make_f2c.c
@@ -21,6 +21,7 @@ int main (int argc, char *argv[])
   printf("const MPI_COMM_RANK          = dlsym(libmpi, \"%s\")\n", STRING(MPI_COMM_RANK));
   printf("const MPI_COMM_SIZE          = dlsym(libmpi, \"%s\")\n", STRING(MPI_COMM_SIZE));
   printf("const MPI_COMM_SPLIT         = dlsym(libmpi, \"%s\")\n", STRING(MPI_COMM_SPLIT));
+  printf("const MPI_COMM_SPLIT_TYPE    = dlsym(libmpi, \"%s\")\n", STRING(MPI_COMM_SPLIT_TYPE));
   printf("const MPI_FINALIZE           = dlsym(libmpi, \"%s\")\n", STRING(MPI_FINALIZE));
   printf("const MPI_FINALIZED          = dlsym(libmpi, \"%s\")\n", STRING(MPI_FINALIZED));
   printf("const MPI_GATHER             = dlsym(libmpi, \"%s\")\n", STRING(MPI_GATHER));

--- a/deps/make_f_const.f
+++ b/deps/make_f_const.f
@@ -45,6 +45,8 @@
       call output("MPI_TAG_UB       ", MPI_TAG_UB)
       call output("MPI_UNDEFINED    ", MPI_UNDEFINED)
 
+      call output("COMM_TYPE_SHARED ", COMM_TYPE_SHARED)
+
       end
 
       subroutine output(name, value)

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -113,6 +113,22 @@ function Comm_size(comm::Comm)
     int(size[1])
 end
 
+function Comm_split_type(comm::Comm, split_type::Int64, key::Int64)
+    new_comm = Comm(0)
+    stat = Status()
+    ccall(MPI_COMM_SPLIT_TYPE, Void, (Ptr{Cint},  Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint} ),
+          &comm.val, &split_type, &key, stat.val, &new_comm.val, &0)
+    return (new_comm,stat)
+end
+
+function Comm_split(comm::Comm, color::Int64, key::Int64)
+    new_comm = Comm(0)
+
+    ccall(MPI_COMM_SPLIT, Void, (Ptr{Cint},  Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint} ),
+          &comm.val, &color, &key, &new_comm.val, &0)
+    return new_comm
+end
+
 # Point-to-point communication
 
 function Probe(src::Integer, tag::Integer, comm::Comm)


### PR DESCRIPTION
Hello,
an experienced c/c++ R software writer would like to add functionality to this great MPI implementation. This is 
my initial pull request; and it seems after commit, jlmpi_f2c.h is not updated.  see .gitignore. 