### PR TITLE
add montecarlo-jl and example

### DIFF
--- a/examples/07-pi.jl
+++ b/examples/07-pi.jl
@@ -1,0 +1,38 @@
+#=
+Simple example of use of montecarlo.jl
+From the system prompt, execute
+mpirun -np X julia pi_mpi.jl
+setting X to the number of ranks you'd
+like to use, subject to  X-1 being an even divisor
+of 1e6, e.g., set X=5.
+=#
+
+include("montecarlo.jl")
+
+function pi_wrapper()
+    pihat = 4.*float((norm(rand(2,1)) .< 1.))
+end
+
+# this function reports intermediate results during MC runs
+function pi_monitor(sofar, results)
+    # examine results every 2.5*10^5 draws
+    if mod(sofar,2.5e5)==0.
+        m = mean(results[1:sofar,:],1)
+        println("reps so far: ", sofar)
+        println("pihat: ", m)
+        println()
+        #if sofar == size(results,1)
+        #    writedlm("mcresults.out", results)
+        #end
+    end
+end    
+
+# do the monte carlo: 10^6 reps of single draws
+function main()
+    reps = Int(1e6)  # desired number of MC reps
+    nreturns = 1
+    pooled = Int(50000)
+    montecarlo(pi_wrapper, pi_monitor, reps, nreturns, pooled)
+end
+
+main()

--- a/examples/montecarlo.jl
+++ b/examples/montecarlo.jl
@@ -1,0 +1,66 @@
+import MPI
+function montecarlo(mc_eval::Function, mc_monitor::Function, reps, n_returns, pooled=1, sleeptime=0.)
+    blas_set_num_threads(1)
+    # set up the MPI communicator
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+    MPI.Barrier(comm)
+    rank = MPI.Comm_rank(comm)
+    commsize = MPI.Comm_size(comm)
+
+    # containers and book keeping
+    contrib = zeros(pooled, n_returns)
+    results = zeros(reps, n_returns)
+    pernode = reps / (commsize - 1)
+    if mod(pernode,1) != 0
+        if rank == 0
+            println("error \(montecarlo\)")
+            println("reps is set to ", reps)
+            println("choose ranks so that  reps/(ranks-1) is an integer")
+        end
+        MPI.Barrier(comm)
+        MPI.Finalize()
+        return 0
+    end
+
+    if mod(pernode,pooled) != 0
+        pooled = div(pernode, commsize-1)
+    end    
+
+    # workers' code
+    if rank > 0
+        @inbounds for i = 1:pernode/pooled
+            # do work
+            for j = 1:pooled
+                contrib[j,:] = mc_eval()
+            end
+            MPI.Isend(contrib, 0, rank, comm)
+        end
+
+    else # frontend
+        sofar = 0 # results collected so far
+        done = false
+        while ~done
+            sleep(sleeptime) # flood control if job is costly 
+            @inbounds for node = 1:commsize-1
+                # check for results
+                ready = false
+                ready, junk = MPI.Iprobe(node, node, comm)
+                if ready # get them if they're ready
+                    sofar +=1
+                    if sofar*pooled <= reps
+                        MPI.Recv!(contrib, node, node, comm)
+                        results[sofar*pooled-pooled+1:sofar*pooled,:] = contrib
+                        mc_monitor(sofar*pooled, results)  
+                    end
+                    if sofar == reps/pooled
+                        done = true
+                        break
+                    end    
+                end    
+            end
+        end    
+    end    
+    MPI.Barrier(comm)
+    MPI.Finalize()
+end


### PR DESCRIPTION
montecarlo.jl is a framework for simple Monte Carlo using MPI-only mode. This can serve as an example of MPI usage for beginners, but it's also a framework that can be adapted easily to do work of real interest. 07-pi.jl is an example of approximating pi which uses the framework.