### PR TITLE
Fix deprecation warnings and tests.

### DIFF
--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1,18 +1,18 @@
-typealias MPIDatatype Union(Char,
-                            Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64,
-                            Uint64,
-                            Float32, Float64, Complex64, Complex128)
+typealias MPIDatatype Union{Char,
+                            Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64,
+                            UInt64,
+                            Float32, Float64, Complex64, Complex128}
 
 const datatypes = Dict{DataType, Any}(
     Char => MPI_WCHAR,
     Int8 => MPI_INT8_T,
-    Uint8 => MPI_UINT8_T,
+    UInt8 => MPI_UINT8_T,
     Int16 => MPI_INT16_T,
-    Uint16 => MPI_UINT16_T,
+    UInt16 => MPI_UINT16_T,
     Int32 => MPI_INT32_T,
-    Uint32 => MPI_UINT32_T,
+    UInt32 => MPI_UINT32_T,
     Int64 => MPI_INT64_T,
-    Uint64 => MPI_UINT64_T,
+    UInt64 => MPI_UINT64_T,
     Float32 => MPI_REAL4,
     Float64 => MPI_REAL8,
     Complex64 => MPI_COMPLEX8,
@@ -214,8 +214,8 @@ end
 
 function recv(src::Integer, tag::Integer, comm::Comm)
     stat = Probe(src, tag, comm)
-    count = Get_count(stat, Uint8)
-    buf = Array(Uint8, count)
+    count = Get_count(stat, UInt8)
+    buf = Array(UInt8, count)
     stat = Recv!(buf, Get_source(stat), Get_tag(stat), comm)
     (deserialize(buf), stat)
 end
@@ -240,8 +240,8 @@ function irecv(src::Integer, tag::Integer, comm::Comm)
     if !flag
         return (false, nothing, nothing)
     end
-    count = Get_count(stat, Uint8)
-    buf = Array(Uint8, count)
+    count = Get_count(stat, UInt8)
+    buf = Array(UInt8, count)
     stat = Recv!(buf, Get_source(stat), Get_tag(stat), comm)
     (true, deserialize(buf), stat)
 end
@@ -342,7 +342,7 @@ function bcast(obj, root::Integer, comm::Comm)
     end
     Bcast!(count, root, comm)
     if !isroot
-        buf = Array(Uint8, count[1])
+        buf = Array(UInt8, count[1])
     end
     Bcast!(buf, root, comm)
     if !isroot

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,24 +3,26 @@ using Base.Test
 function runtests()
     nprocs = min(4, CPU_CORES)
     exename = joinpath(JULIA_HOME, Base.julia_exename())
-    testfiles = sort(filter(x->x!="runtests.jl", readdir(dirname(@__FILE__))))
+    testdir = dirname(@__FILE__)
+    testfiles = sort(filter(x->x!="runtests.jl", readdir(testdir)))
     nfail = 0
     print_with_color(:white, "Running MPI.jl tests\n")
     for f in testfiles
         try
-            if success(`mpirun -np $nprocs $exename $f`)
+            run(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
+            if success(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
                 Base.with_output_color(:green,STDOUT) do io
                     println(io,"\tSUCCESS: $f")
                 end
             else
                 Base.with_output_color(:red,STDERR) do io
-                    println("\tFAILED: $f")
+                    println(io, "\tFAILED: $(joinpath(testdir, f))")
                 end
                 nfail += 1
             end
         catch ex
             Base.with_output_color(:red,STDERR) do io
-                println(io,"\tError: $f")
+                println(io,"\tError: $(joinpath(testdir, f))")
                 showerror(io,ex,backtrace())
             end
             nfail += 1

--- a/test/test_allgather.jl
+++ b/test/test_allgather.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -12,9 +12,7 @@ end
 
 comm = MPI.COMM_WORLD
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in MPI.MPIDatatype.types
     A = typ[MPI.Comm_rank(comm) + 1]
     C = allgather_array(A)
     @test C == collect(1:MPI.Comm_size(comm))

--- a/test/test_allgatherv.jl
+++ b/test/test_allgatherv.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -12,9 +12,10 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+# Defining this to make ones work for Char
+Base.one(::Type{Char}) = '\01'
+
+for typ in MPI.MPIDatatype.types
 
     A = ones(typ, mod(rank,2) + 1)
     counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]

--- a/test/test_alltoall.jl
+++ b/test/test_alltoall.jl
@@ -1,6 +1,6 @@
 using Base.Test
 
-import MPI
+using MPI
 
 MPI.Init()
 comm = MPI.COMM_WORLD

--- a/test/test_alltoallv.jl
+++ b/test/test_alltoallv.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -12,9 +12,7 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in MPI.MPIDatatype.types
     A = typ[]
     B = typ[]
     for i in 1:size

--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -21,9 +21,7 @@ root = 0
 srand(17)
 
 matsize = (17,17)
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in MPI.MPIDatatype.types
     A = rand(typ, matsize...)
     @test bcast_array(A, root) == A
 end

--- a/test/test_exscan.jl
+++ b/test/test_exscan.jl
@@ -1,6 +1,6 @@
 using Base.Test
 
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -8,9 +8,7 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in setdiff([MPI.MPIDatatype.types...], [Char]) # Not possible to PROD a Char
     val = convert(typ,rank+1)
     B = MPI.ExScan(val, MPI.PROD, comm)
     if rank > 0

--- a/test/test_gather.jl
+++ b/test/test_gather.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -13,9 +13,7 @@ end
 comm = MPI.COMM_WORLD
 root = 0
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in MPI.MPIDatatype.types
     A = typ[MPI.Comm_rank(comm) + 1]
     C = gather_array(A, root)
     if MPI.Comm_rank(comm) == root

--- a/test/test_gatherv.jl
+++ b/test/test_gatherv.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -13,16 +13,17 @@ size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 root = 0
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+# Defining this to make ones work for Char
+Base.one(::Type{Char}) = '\01'
+
+for typ in MPI.MPIDatatype.types
 
     A = ones(typ, mod(rank,2) + 1)
     counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]
     B = gatherv_array(A, counts, root)
     if rank == root
         @test B == ones(typ, 3 * div(size,2) + mod(size,2))
-    end 
+    end
 end
 
 MPI.Finalize()

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -1,6 +1,6 @@
 using Base.Test
 
-import MPI
+using MPI
 
 MPI.Init()
 

--- a/test/test_scan.jl
+++ b/test/test_scan.jl
@@ -1,6 +1,6 @@
 using Base.Test
 
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -8,9 +8,7 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in setdiff([MPI.MPIDatatype.types...], [Char]) # Not possible to PROD a Char
     val = convert(typ,rank + 1)
     B = MPI.Scan(val, MPI.PROD, comm)
     @test_approx_eq B[1] factorial(val)

--- a/test/test_scatter.jl
+++ b/test/test_scatter.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -20,9 +20,7 @@ root = 0
 A = collect(1:MPI.Comm_size(comm))
 B = scatter_array(A, root)
 @test B[1] == MPI.Comm_rank(comm) + 1
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+for typ in MPI.MPIDatatype.types
     A = convert(Vector{typ},collect(1:MPI.Comm_size(comm)))
     B = scatter_array(A, root)
     @test B[1] == convert(typ,MPI.Comm_rank(comm) + 1)

--- a/test/test_scatterv.jl
+++ b/test/test_scatterv.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 
@@ -19,9 +19,10 @@ size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 root = 0
 
-for typ in ( Float32, Float64, Complex64, Complex128,
-             Int8, Int16, Int32, Int64,
-             Uint8, Uint16, Uint32, Uint64)
+# Defining this to make ones work for Char
+Base.one(::Type{Char}) = '\01'
+
+for typ in MPI.MPIDatatype.types
 
     A = ones(typ, 3 * div(size,2) + mod(size,2))
     counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]

--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -1,5 +1,5 @@
 using Base.Test
-import MPI
+using MPI
 
 MPI.Init()
 


### PR DESCRIPTION
This changes `runtests.jl` to use the full path to the test files. They often failed for me because of this.