### PR TITLE
Set cmake policies to avoid cmake warnings

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -4,6 +4,9 @@ include(InstallRequiredSystemLibraries)
 find_package(Git)
 find_package(MPI REQUIRED)
 
+cmake_policy(SET CMP0042 OLD)   # MACOSX_RPATH
+cmake_policy(SET CMP0053 OLD) # variable reference and escape sequence evaluation
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/.julia/v0.4/MPI/deps/src" CACHE PATH
     "Julia-MPI install prefix" FORCE)


### PR DESCRIPTION
Once these cmake policies will become unsupported, we will receive errors instead of silent breakage.