### PR TITLE
Make some informative output when tests fail

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,15 +9,9 @@ function runtests()
     print_with_color(:white, "Running MPI.jl tests\n")
     for f in testfiles
         try
-            if success(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
-                Base.with_output_color(:green,STDOUT) do io
-                    println(io,"\tSUCCESS: $f")
-                end
-            else
-                Base.with_output_color(:red,STDERR) do io
-                    println(io, "\tFAILED: $(joinpath(testdir, f))")
-                end
-                nfail += 1
+            run(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
+            Base.with_output_color(:green,STDOUT) do io
+                println(io,"\tSUCCESS: $f")
             end
         catch ex
             Base.with_output_color(:red,STDERR) do io


### PR DESCRIPTION
Right now the actual error messages are suppressed because of `success`, but I think it would be useful to get some output from failed tests. All tests are still run because of the try/catch block.