### PR TITLE
Delete build and usr directories if they exist when calling Pkg.build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,6 +7,13 @@ builddir = joinpath(BinDeps.depsdir(mpi), "build")
 prefix = joinpath(BinDeps.depsdir(mpi), "usr")
 src = joinpath(BinDeps.depsdir(mpi), "src")
 
+if isdir(builddir)
+    rm(builddir, recursive = true)
+end
+if isdir(prefix)
+    rm(prefix, recursive = true)
+end
+
 provides(SimpleBuild,
     (@build_steps begin
         CreateDirectory(builddir)


### PR DESCRIPTION
Old builds can often cause trouble so I routinely delete these manually and thought it would make sense to automate the process.