### PR TITLE
add MPI.CComm type for interoperability with the C API

### DIFF
--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -135,6 +135,16 @@ endif(MPI_Fortran_LINK_FLAGS)
 
 target_link_libraries(juliampi ${MPI_Fortran_LIBRARIES})
 
+include(CheckFunctionExists)
+set(CMAKE_REQUIRED_LIBRARIES ${MPI_C_LIBRARIES})
+check_function_exists(MPI_Comm_c2f HAVE_MPI_COMM_C2F)
+unset(CMAKE_REQUIRED_LIBRARIES)
+if(${HAVE_MPI_COMM_C2F})
+  set(HAVE_MPI_COMM_C2F_BOOL "true")
+else()
+  set(HAVE_MPI_COMM_C2F_BOOL "false")
+endif()
+
 add_executable(gen_functions gen_functions.c)
 add_dependencies(gen_functions version)
 
@@ -150,6 +160,7 @@ file(APPEND \${DST} \${FTWOC})
 file(APPEND \${DST} \"\n\")
 file(APPEND \${DST} \${FCONS})
 file(APPEND \${DST} \"\n\")
+file(APPEND \${DST} \"const HAVE_MPI_COMM_C2F = ${HAVE_MPI_COMM_C2F_BOOL}\n\")
 ")
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/compile-time.jl

--- a/deps/gen_functions.c
+++ b/deps/gen_functions.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "jlmpi_f2c.h"
+#include "mpi.h"
 #include "version.h"
 
 #define STRING1(s) #s
@@ -58,5 +59,6 @@ int main(int argc, char *argv[])
   printf("const MPI_WAITANY            = Libdl.dlsym(libmpi, \"%s\")\n", STRING(MPI_WAITANY));
   printf("const MPI_WTIME              = Libdl.dlsym(libmpi, \"%s\")\n", STRING(MPI_WTIME));
 
+  printf("bitstype %lu CComm\n", sizeof(MPI_Comm) * 8);
   return 0;
 }

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -5,6 +5,8 @@ using MPI
 MPI.Init()
 @test MPI.Initialized()
 
+@test MPI.Comm(MPI.CComm(MPI.COMM_WORLD)).val == MPI.COMM_WORLD.val
+
 @test !MPI.Finalized()
 MPI.Finalize()
 @test MPI.Finalized()


### PR DESCRIPTION
Because MPI.jl uses the Fortran interface, it is a bit challenging to use with a library like PETSc that relies on the C MPI interface.   In particular, PETSc and similar libraries require you to supply a C `MPI_Comm` object, which in general is a different type than the Fortran object (just a `Cint`).  This PR rectifies the situation by adding an `MPI.CComm` type and ~~functions `MPI.Comm2C` and `MPI.C2Comm`~~ `convert` methods to convert between that and the `Comm` type.

If/when #59 is addressed, these functions can become no-ops.

cc: @JaredCrean2 