### PR TITLE
Restructure MPI cluster manager

### DIFF
--- a/examples/05-juliacman.jl
+++ b/examples/05-juliacman.jl
@@ -1,35 +1,36 @@
+# Note: Run this script without using `mpirun`
+
 using MPI
 
-manager=MPIManager(np=4)
+manager = MPIManager(np=4)
 addprocs(manager)
 
 println("Added procs $(procs())")
 
 println("Running 01-hello as part of a Julia cluster")
-@mpi_do  manager (include("01-hello-impl.jl"); do_hello())
+@mpi_do manager (include("01-hello-impl.jl"); do_hello())
 
-#Interspersed julia parallel call
+# Interspersed julia parallel call
 nheads = @parallel (+) for i=1:10^8
   Int(rand(Bool))
 end
 println("@parallel nheads $nheads")
 
 println("Running 02-broadcast as part of a Julia cluster")
-@mpi_do  manager (include("02-broadcast-impl.jl"); do_broadcast())
+@mpi_do manager (include("02-broadcast-impl.jl"); do_broadcast())
 
 M = [rand(10,10) for i=1:10]
 pmap(svd, M)
 println("pmap successful")
 
 println("Running 03-reduce as part of a Julia cluster")
-@mpi_do  manager (include("03-reduce-impl.jl"); do_reduce())
+@mpi_do manager (include("03-reduce-impl.jl"); do_reduce())
 
 pids = [remotecall_fetch(myid, p) for p in workers()]
 println("julia pids $pids")
 
 println("Running 04-sendrecv as part of a Julia cluster")
-@mpi_do  manager (include("04-sendrecv-impl.jl"); do_sendrecv())
+@mpi_do manager (include("04-sendrecv-impl.jl"); do_sendrecv())
 
 println("Exiting")
 exit()
-

--- a/examples/06-cman-transport.jl
+++ b/examples/06-cman-transport.jl
@@ -1,6 +1,8 @@
 using MPI
 
-comm, comm_size, rank = MPI.init_mpi()
+MPI.Init()
+rank = MPI.Comm_rank(MPI.COMM_WORLD)
+size = MPI.Comm_size(MPI.COMM_WORLD)
 
 include("01-hello-impl.jl")
 include("02-broadcast-impl.jl")
@@ -8,52 +10,50 @@ include("03-reduce-impl.jl")
 include("04-sendrecv-impl.jl")
 
 if length(ARGS) == 0
-    print("Please specify a transport option to use [MPI|TCP]\n")
-    exit()
+    println("Please specify a transport option to use [MPI|TCP]")
+    MPI.Finalize()
+    exit(1)
 elseif ARGS[1] == "TCP"
-    manager = MPI.start(TCP_TRANSPORT_ALL) # does not return on worker
+    manager = MPI.start_main_loop(TCP_TRANSPORT_ALL) # does not return on worker
 elseif ARGS[1] == "MPI"
-    manager = MPI.start(MPI_TRANSPORT_ALL) # does not return on worker
+    manager = MPI.start_main_loop(MPI_TRANSPORT_ALL) # does not return on worker
 else
-    print("Valid transport options are [MPI|TCP]\n")
-    exit()
+    println("Valid transport options are [MPI|TCP]")
+    MPI.Finalize()
+    exit(1)
 end
 
-if rank == 0
-    nloops = 10^2
-    function foo(n)
-        a=ones(n)
-        remotecall_fetch(x->x, 2, a);
+# Check whether a worker accidentally returned
+@assert rank == 0
 
-        @elapsed for i in 1:nloops
-            remotecall_fetch(x->x, 2, a)
-        end
-    end
-
-    n=10^3
-    foo(1)
-    t=foo(n)
-    println("$t seconds for $nloops loops of send-recv of array size $n")
-
-    n=10^6
-    foo(1)
-    t=foo(n)
-    println("$t seconds for $nloops loops of send-recv of array size $n")
-
-
-    print("EXAMPLE: HELLO\n")
-    @mpi_do manager do_hello()
-    print("EXAMPLE: BROADCAST\n")
-    @mpi_do manager do_broadcast()
-    print("EXAMPLE: REDUCE\n")
-    @mpi_do manager do_reduce()
-    print("EXAMPLE: SENDRECV\n")
-    @mpi_do manager do_sendrecv()
-
-    # Abscence of a MPI Finalize causes the cluster to hang - don't yet know why
-    if ARGS[1] == "TCP"
-        @mpi_do manager MPI.Finalize()
-    elseif ARGS[1] == "MPI"
-        @everywhere (MPI.Finalize(); exit())
+nloops = 10^2
+function foo(n)
+    a=ones(n)
+    remotecall_fetch(x->x, mod1(2, size), a);
+    @elapsed for i in 1:nloops
+        remotecall_fetch(x->x, mod1(2, size), a)
     end
 end
+
+n=10^3
+foo(1)
+t=foo(n)
+println("$t seconds for $nloops loops of send-recv of array size $n")
+
+n=10^6
+foo(1)
+t=foo(n)
+println("$t seconds for $nloops loops of send-recv of array size $n")
+
+# We cannot run these examples since they use MPI.Barrier and other blocking
+# communication, disabling our event loop
+# print("EXAMPLE: HELLO\n")
+# @mpi_do manager do_hello()
+# print("EXAMPLE: BROADCAST\n")
+# @mpi_do manager do_broadcast()
+# print("EXAMPLE: REDUCE\n")
+# @mpi_do manager do_reduce()
+# print("EXAMPLE: SENDRECV\n")
+# @mpi_do manager do_sendrecv()
+
+MPI.stop_main_loop(manager)

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -1,55 +1,88 @@
-import Base: launch, manage, procs, connect
-export MPIManager, launch, manage, @mpi_do, procs, mpiprocs, start
-export MPI_ON_WORKERS, TCP_TRANSPORT_ALL, MPI_TRANSPORT_ALL
+import Base: launch, manage, kill, procs, connect
+export MPIManager, launch, manage, kill, procs, connect, mpiprocs, @mpi_do
+export TransportMode, MPI_ON_WORKERS, TCP_TRANSPORT_ALL, MPI_TRANSPORT_ALL
 
-const MPI_ON_WORKERS = 0
-const MPI_TRANSPORT_ALL  = 1
-const TCP_TRANSPORT_ALL  = 2
+
+
+################################################################################
+# MPI Cluster Manager
+# Note: The cluster manager object lives only in the manager process,
+# except for MPI_TRANSPORT_ALL
+
+# There are three different transport modes:
+
+# MPI_ON_WORKERS: Use MPI between the workers only, not for the manager. This
+# allows interactive use from a Julia shell, using the familiar `addprocs`
+# interface.
+
+# MPI_TRANSPORT_ALL: Use MPI on all processes; there is no separate manager
+# process. This corresponds to the "usual" way in which MPI is used in a
+# headless mode, e.g. submitted as a script to a queueing system.
+
+# TCP_TRANSPORT_ALL: Same as MPI_TRANSPORT_ALL, but Julia uses TCP for its
+# communication between processes. MPI can still be used by the user.
+
+@enum TransportMode MPI_ON_WORKERS MPI_TRANSPORT_ALL TCP_TRANSPORT_ALL
 
 type MPIManager <: ClusterManager
-    np::Int
-    mpi2j::Dict
-    j2mpi::Dict
-    mode::Int
+    np::Int # number of worker processes (excluding the manager process)
+    mpi2j::Dict{Int,Int} # map MPI ranks to Julia processes
+    j2mpi::Dict{Int,Int} # map Julia to MPI ranks
+    mode::TransportMode
 
-    mpi_cmd::Cmd
+    launched::Bool # Are the MPI processes running?
+    mpirun_cmd::Cmd # How to start MPI processes
+    launch_timeout::Int # seconds
 
-    launch_timeout::Integer
-    initialized::Bool
-    cond_initialized::Condition
-    launched::Bool
+    initialized::Bool # All workers registered with us
+    cond_initialized::Condition # notify this when all workers registered
 
     # TCP Transport
     port::UInt16
     stdout_ios::Array
 
     # MPI transport
-    id_to_streams::Dict
-    ranks::Array
+    rank2streams::Dict{Int,Tuple{IO,IO}} # map MPI ranks to (input,output) streams
+    ranks_left::Array{Int,1} # MPI ranks for which there is no stream pair yet
 
+    # MPI_TRANSPORT_ALL
+    comm::MPI.Comm
+    initiate_shutdown::Channel{Void}
+    sending_done::Channel{Void}
+    receiving_done::Channel{Void}
 
-    function MPIManager(;np=Sys.CPU_CORES,
-                         mpi_cmd=`mpirun -np $np`,
-                         launch_timeout=60.0,
-                         mode=MPI_ON_WORKERS)
-        launched = false
-        if mode != MPI_ON_WORKERS
-            launched = true
-            mpi_cmd = ``
+    function MPIManager(; np::Integer = Sys.CPU_CORES,
+                          mpirun_cmd::Cmd = `mpiexec -n $np`,
+                          launch_timeout::Real = 60.0,
+                          mode::TransportMode = MPI_ON_WORKERS)
+        mgr = new()
+        mgr.np = np
+        mgr.mpi2j = Dict{Int,Int}()
+        mgr.j2mpi = Dict{Int,Int}()
+        mgr.mode = mode
+
+        # Only start MPI processes for MPI_ON_WORKERS
+        mgr.launched = mode != MPI_ON_WORKERS
+        @assert MPI.Initialized() == mgr.launched
+        mgr.mpirun_cmd = mpirun_cmd
+        mgr.launch_timeout = launch_timeout
+
+        mgr.initialized = false
+        mgr.cond_initialized = Condition()
+        if np == 0
+            # Special case: no workers
+            mgr.initialized = true
+            if mgr.mode != MPI_ON_WORKERS
+                # Set up mapping for the manager
+                mgr.j2mpi[1] = 0
+                mgr.mpi2j[0] = 1
+            end
         end
-        mgr = new(Int(np),
-                  Dict{Int,Int}(),
-                  Dict{Int,Int}(),
-                  mode,
-                  mpi_cmd,
-                  launch_timeout,
-                  false,
-                  Condition(),
-                  launched)
 
+        # Listen to TCP sockets if necessary
         if mode != MPI_TRANSPORT_ALL
-            # Start a listener for capturing stdout's from the workers
-            (port, server) = listenany(11000)
+            # Start a listener for capturing stdout from the workers
+            port, server = listenany(11000)
             @schedule begin
                 while true
                     sock = accept(server)
@@ -59,268 +92,388 @@ type MPIManager <: ClusterManager
             mgr.port = port
             mgr.stdout_ios = IO[]
         else
-            mgr.id_to_streams = Dict()
-            comm, comm_size, rank = comm_info()
-            mgr.ranks = [i for i in 1:(comm_size-1)]
+            mgr.rank2streams = Dict{Int,Tuple{IO,IO}}()
+            size = MPI.Comm_size(MPI.COMM_WORLD)
+            mgr.ranks_left = collect(1:size-1)
         end
+
+        if mode == MPI_TRANSPORT_ALL
+            mgr.initiate_shutdown = Channel{Void}(1)
+            mgr.sending_done = Channel{Void}(np)
+            mgr.receiving_done = Channel{Void}(1)
+            global initiate_shutdown = mgr.initiate_shutdown
+        end
+        mgr.initiate_shutdown = Channel{Void}(1)
+        global initiate_shutdown = mgr.initiate_shutdown
+
         return mgr
     end
 end
 
-function Base.show(io::IO, man::MPIManager)
-    mode = if man.mode == 0
-        "MPI_ON_WORKERS"
-    elseif man.mode == 1
-        "MPI_TRANSPORT_ALL"
-    elseif man.mode == 2
-        "TCP_TRANSPORT_ALL"
-    else
-        error("invalid MPIManager mode: $(man.mode)")
-    end
-    print(io, "MPI.MPIManager(np=$(man.np),launched=$(man.launched),mode=$(mode))")
+function Base.show(io::IO, mgr::MPIManager)
+    print(io, "MPI.MPIManager(np=$(mgr.np),launched=$(mgr.launched),mode=$(mgr.mode))")
 end
 
-function launch(manager::MPIManager, params::Dict, instances_arr::Array, c::Condition)
+################################################################################
+# Cluster Manager functionality required by Base, mostly targeting the
+# MPI_ON_WORKERS case
+
+# Launch a new worker, called from Base.addprocs
+function launch(mgr::MPIManager, params::Dict,
+                instances::Array, cond::Condition)
     try
-        if manager.mode == MPI_ON_WORKERS
-            if manager.launched
+        if mgr.mode == MPI_ON_WORKERS
+            # Start the workers
+            if mgr.launched
                 println("Reuse of an MPIManager is not allowed.")
                 println("Try again with a different instance of MPIManager.")
                 throw(ErrorException("Reuse of MPIManager is not allowed."))
             end
 
-            setup_cmds = "using MPI; MPI.setup_worker($(getipaddr().host), $(manager.port))"
-            open(detach(`$(manager.mpi_cmd) $(params[:exename]) -e "$setup_cmds"`))
+            setup_cmds = "using MPI; MPI.setup_worker($(getipaddr().host), $(mgr.port))"
+            open(detach(`$(mgr.mpirun_cmd) $(params[:exename]) -e $setup_cmds`))
+            mgr.launched = true
         end
 
-        if manager.mode != MPI_TRANSPORT_ALL
-            t0=time()
-            while (time() - t0) < manager.launch_timeout
-                (length(manager.stdout_ios) == manager.np) && break
+        if mgr.mode != MPI_TRANSPORT_ALL
+            # Wait for the workers to connect back to the manager
+            t0 = time()
+            while (length(mgr.stdout_ios) < mgr.np &&
+                   time() - t0 < mgr.launch_timeout)
                 sleep(1.0)
             end
+            if length(mgr.stdout_ios) != mgr.np
+                error("Timeout -- the workers did not connect to the manager")
+            end
 
-            @assert length(manager.stdout_ios) == manager.np
-
-            configs = Array(WorkerConfig, manager.np)
+            # Traverse all worker I/O streams and receive their MPI rank
+            configs = Array{WorkerConfig}(mgr.np)
             @sync begin
-                for io in manager.stdout_ios
+                for io in mgr.stdout_ios
                     @async let io=io
                         config = WorkerConfig()
                         config.io = io
-
-                        # Add it to the right slot so that MPI ranks and Julia pids are in the same order
+                        # Add config to the correct slot so that MPI ranks and
+                        # Julia pids are in the same order
                         rank = Base.deserialize(io)
-                        idx = (manager.mode == MPI_ON_WORKERS ? rank+1 : rank)
+                        idx = mgr.mode == MPI_ON_WORKERS ? rank+1 : rank
                         configs[idx] = config
                     end
                 end
             end
 
-            append!(instances_arr, configs)
-            notify(c)
-
-            manager.launched = true
+            # Append our configs and notify the caller
+            append!(instances, configs)
+            notify(cond)
         else
-            for cnt in 1:manager.np
-                push!(instances_arr, WorkerConfig())
+            # This is a pure MPI configuration -- we don't need any bookkeeping
+            for cnt in 1:mgr.np
+                push!(instances, WorkerConfig())
             end
-            notify(c)
+            notify(cond)
         end
 
     catch e
         println("Error in MPI launch $e")
         rethrow(e)
     end
-
-#   @everywhere using MPI
-
 end
 
-function manage(manager::MPIManager, id::Integer, config::WorkerConfig, op::Symbol)
-    if op == :register
-        mpi_id = remotecall_fetch(()->MPI.Comm_rank(MPI.COMM_WORLD), id)
-        manager.j2mpi[id] = mpi_id
-        manager.mpi2j[mpi_id] = id
-
-        if length(manager.j2mpi) == manager.np
-            manager.initialized = true
-            notify(manager.cond_initialized)
-            if manager.mode != MPI_ON_WORKERS
-                manager.j2mpi[1] = 0
-                manager.mpi2j[0] = 1
-            end
-        end
-    elseif op == :finalize
-#         if !isnull(config.io)
-#             close(config.io)
-#         end
-    elseif op == :interrupt
-#        warn("Interrupting MPI workers is currently unsupported")
-    end
-end
-
+# Entry point for MPI worker processes for MPI_ON_WORKERS and TCP_TRANSPORT_ALL
 function setup_worker(host, port)
-    comm, comm_size, rank = init_mpi()
+    !MPI.Initialized() && MPI.Init()
+    # Connect to the manager
+    io = connect(IPv4(host), port)
+    Base.wait_connected(io)
+    redirect_stdout(io)
+    redirect_stderr(io)
 
-    c = connect(IPv4(host), port)
-    Base.wait_connected(c)
-    redirect_stdout(c)
-    redirect_stderr(c)
+    # Send our MPI rank to the manager
+    rank = MPI.Comm_rank(MPI.COMM_WORLD)
+    Base.serialize(io, rank)
 
-    Base.serialize(c, rank)
-
-    Base.start_worker(c)
+    # Hand over control to Base
+    Base.start_worker(io)
 end
 
-macro mpi_do(manager, expr)
-    quote
-        mgr = $(esc(manager))
-        !mgr.initialized && wait(mgr.cond_initialized)
-        jpids = keys(mgr.j2mpi)
-        refs = cell(length(jpids))
-        for (i,p) in enumerate(filter(x->x!=myid(), jpids))
-            refs[i] = remotecall(()->eval(Main,$(Expr(:quote,expr))), p)
-        end
-        # Execution on local process should be last, since it can block the main event loop
-        if myid() in jpids
-            refs[end] = remotecall(()->eval(Main,$(Expr(:quote,expr))), myid())
-        end
+# Manage a worker (e.g. register / deregister it)
+function manage(mgr::MPIManager, id::Integer, config::WorkerConfig, op::Symbol)
+    if op == :register
+        # Retrieve MPI rank from worker
+        # TODO: Why is this necessary? The workers already sent their rank.
+        rank = remotecall_fetch(()->MPI.Comm_rank(MPI.COMM_WORLD), id)
+        mgr.j2mpi[id] = rank
+        mgr.mpi2j[rank] = id
 
-        # Retrieve remote exceptions if any
-        @sync begin
-            for r in refs
-                @async begin
-                    resp = remotecall_fetch(r.where, r) do rr
-                        wrkr_result = take!(rr)
-                        # Only return result if it is an exception, i.e.,
-                        # Don't return a valid result of worker computation.
-                        # The call is a mpi_do and not mpi_callfetch
-                        return isa(wrkr_result, Exception) ? wrkr_result : nothing
-                    end
-                    isa(resp, Exception) && throw(resp)
-                end
+        if length(mgr.j2mpi) == mgr.np
+            # All workers registered
+            mgr.initialized = true
+            notify(mgr.cond_initialized)
+            if mgr.mode != MPI_ON_WORKERS
+                # Set up mapping for the manager
+                mgr.j2mpi[1] = 0
+                mgr.mpi2j[0] = 1
             end
         end
-        nothing
+    elseif op == :deregister
+        info("pid=$(getpid()) id=$id op=$op")
+        # TODO: terminate the worker
+    elseif op == :interrupt
+        # TODO: This should never happen if we rmprocs the workers properly
+        info("pid=$(getpid()) id=$id op=$op")
+        @assert false
+    elseif op == :finalize
+        # This is called from within a finalizer after deregistering; do nothing
+    else
+        info("pid=$(getpid()) id=$id op=$op")
+        @assert false # Unsupported operation
     end
 end
 
-procs(manager::MPIManager) = sort([p for p in keys(manager.j2mpi)])
-mpiprocs(manager::MPIManager) = sort([p for p in keys(manager.mpi2j)])
-
-
-function start(mode=TCP_TRANSPORT_ALL)
-    comm, comm_size, rank = init_mpi()
-    if mode == TCP_TRANSPORT_ALL
-        if rank == 0
-            cman = MPIManager(;np=comm_size-1, mode=TCP_TRANSPORT_ALL)
-            for j in 1:(comm_size-1)
-                MPI.send((getipaddr().host, cman.port), j, j, comm)
-            end
-
-            addprocs(cman)
-            return cman
-         else
-            (obj, status) = MPI.recv(0, rank, comm)
-            (host, port) = obj
-            setup_worker(host, port) # does not return
-         end
-     elseif mode == MPI_TRANSPORT_ALL
-        if rank == 0
-            cman = MPIManager(;np=comm_size-1, mode=MPI_TRANSPORT_ALL)
-            @schedule main_loop(cman, comm)
-            addprocs(cman)
-            return cman
-        else
-            cman = MPIManager(;np=comm_size-1, mode=MPI_TRANSPORT_ALL)
-            Base.init_worker(cman)
-            main_loop(cman, comm) # does not return
-        end
-     else
-        error("Unknown Mode $mode")
-     end
+# Kill a worker
+function kill(mgr::MPIManager, pid::Int, config::WorkerConfig)
+    # Do nothing, as the worker will self-terminate after calling MPI.Finalize
+    Base.set_worker_state(Base.Worker(pid), Base.W_TERMINATED)
 end
 
-function main_loop(manager, comm)
-    while !MPI.Finalized()
-        (hasdata, stat) = MPI.Iprobe(ANY_SOURCE, 0, comm)
-        if hasdata
-            count = Get_count(stat, UInt8)
-            buf = Array(UInt8, count)
-            from_rank = Get_source(stat)
-            MPI.Recv!(buf, from_rank, 0, comm)
+# Set up a connection to a worker
+function connect(mgr::MPIManager, pid::Int, config::WorkerConfig)
+    if mgr.mode != MPI_TRANSPORT_ALL
+        # Forward the call to the connect function in Base
+        return invoke(connect, (ClusterManager, Int, WorkerConfig),
+                      mgr, pid, config)
+    end
 
-            streams = get(manager.id_to_streams, from_rank, nothing)
-            if streams == nothing
-                # First time..
-                (r_s, w_s) = setup_connection(manager, from_rank)
-                Base.process_messages(r_s, w_s)
-            else
-                (r_s, w_s) = streams
-            end
-            write(r_s, buf)
-        else
-            # FIXME : Need a better way to integrate with libuv's event loop
-            yield()
-        end
+    rank = MPI.Comm_rank(mgr.comm)
+    if rank == 0
+        # Choose a rank for this worker
+        to_rank = pop!(mgr.ranks_left)
+        config.connect_at = to_rank
+        return start_send_event_loop(mgr, to_rank)
+    else
+        return start_send_event_loop(mgr, get(config.connect_at))
     end
 end
 
-function setup_connection(manager, to_rank)
+# Event loop for sending data to one other process, for the MPI_TRANSPORT_ALL
+# case
+function start_send_event_loop(mgr::MPIManager, rank::Int)
     try
-        r_s=BufferStream()
-        w_s=BufferStream()
+        r_s = BufferStream()
+        w_s = BufferStream()
+        mgr.rank2streams[rank] = (r_s, w_s)
 
-        manager.id_to_streams[to_rank] = (r_s, w_s)
-
+        # TODO: There is one task per communication partner -- this can be
+        # quite expensive when there are many workers. Design something better.
+        # For example, instead of maintaining two streams per worker, provide
+        # only abstract functions to write to / read from these streams.
         @schedule begin
-            comm, comm_size, rank = comm_info()
-            while !MPI.Finalized()
-                if nb_available(w_s) > 0
+            rr = MPI.Comm_rank(mgr.comm)
+            reqs = MPI.Request[]
+            while !isready(mgr.initiate_shutdown)
+                # When data are available, send them
+                while nb_available(w_s) > 0
                     data = takebuf_array(w_s.buffer)
-                    !MPI.Finalized() && MPI.Isend(data, to_rank, 0, comm)
-                else
-                    yield()
+                    push!(reqs, MPI.Isend(data, rank, 0, mgr.comm))
                 end
+                if !isempty(reqs)
+                    (indices, stats) = MPI.Testsome!(reqs)
+                    filter!(req -> req != MPI.REQUEST_NULL, reqs)
+                end
+                # TODO: Need a better way to integrate with libuv's event loop
+                yield()
             end
+            put!(mgr.sending_done, nothing)
         end
         (r_s, w_s)
     catch e
-        Base.show_backtrace(STDOUT,catch_backtrace())
+        Base.show_backtrace(STDOUT, catch_backtrace())
         println(e)
         rethrow(e)
     end
 end
 
+################################################################################
+# Alternative startup model: All Julia processes are started via an external
+# mpirun, and the user does not call addprocs.
 
-function init_mpi()
+# Enter the MPI cluster manager's main loop (does not return on the workers)
+function start_main_loop(mode::TransportMode=TCP_TRANSPORT_ALL;
+                         comm::MPI.Comm=MPI.COMM_WORLD)
     !MPI.Initialized() && MPI.Init()
-    atexit(() -> (!MPI.Finalized()) && MPI.Finalize())
-
-    return comm_info()
-end
-
-function comm_info()
-    comm = MPI.COMM_WORLD
-    comm_size = MPI.Comm_size(comm)
-    rank = MPI.Comm_rank(comm)
-
-    (comm, comm_size, rank)
-end
-
-function connect(manager::MPIManager, pid::Int, config::WorkerConfig)
-    if manager.mode != MPI_TRANSPORT_ALL
-        return invoke(connect, (ClusterManager, Int, WorkerConfig), manager, pid, config)
-    end
-
-    comm, comm_size, rank = comm_info()
-    if rank == 0
-        to_rank = pop!(manager.ranks)
-        config.connect_at = to_rank
-        return setup_connection(manager, to_rank)
+    @assert MPI.Initialized() && !MPI.Finalized()
+    if mode == TCP_TRANSPORT_ALL
+        # Base is handling the workers and their event loop
+        # The workers have no manager object where to store the communicator.
+        # TODO: Use a global variable?
+        comm = MPI.COMM_WORLD
+        rank = MPI.Comm_rank(comm)
+        size = MPI.Comm_size(comm)
+        if rank == 0
+            # On the manager: Perform the usual steps
+            # Create manager object
+            mgr = MPIManager(np=size-1, mode=mode)
+            mgr.comm = comm
+            # Send connection information to all workers
+            # TODO: Use Bcast
+            for j in 1:size-1
+                MPI.send((getipaddr().host, mgr.port), j, 0, comm)
+            end
+            # Tell Base about the workers
+            addprocs(mgr)
+            return mgr
+        else
+            # On a worker: Receive connection information
+            (obj, status) = MPI.recv(0, 0, comm)
+            (host, port) = obj
+            # Call the regular worker entry point
+            setup_worker(host, port) # does not return
+        end
+    elseif mode == MPI_TRANSPORT_ALL
+        #TODO comm = MPI.Comm_dup(comm)
+        rank = MPI.Comm_rank(comm)
+        size = MPI.Comm_size(comm)
+        # We are handling the workers and their event loops on our own
+        if rank == 0
+            # On the manager:
+            # Create manager object
+            mgr = MPIManager(np=size-1, mode=mode)
+            mgr.comm = comm
+            # Start event loop for the workers
+            @schedule receive_event_loop(mgr)
+            # Tell Base about the workers
+            addprocs(mgr)
+            return mgr
+        else
+            # On a worker:
+            # Create a "fake" manager object since Base wants one
+            mgr = MPIManager(np=size-1, mode=mode)
+            mgr.comm = comm
+            Base.init_worker(mgr)
+            # Start a worker event loop
+            receive_event_loop(mgr)
+            MPI.Finalize()
+            exit()
+        end
     else
-        return setup_connection(manager, get(config.connect_at))
+        error("Unknown mode $mode")
     end
 end
 
+# Event loop for receiving data, for the MPI_TRANSPORT_ALL case
+function receive_event_loop(mgr::MPIManager)
+    num_send_loops = 0
+    while !isready(mgr.initiate_shutdown)
+        (hasdata, stat) = MPI.Iprobe(MPI.ANY_SOURCE, 0, mgr.comm)
+        if hasdata
+            count = Get_count(stat, UInt8)
+            buf = Array(UInt8, count)
+            from_rank = Get_source(stat)
+            MPI.Recv!(buf, from_rank, 0, mgr.comm)
+
+            streams = get(mgr.rank2streams, from_rank, nothing)
+            if streams == nothing
+                # This is the first time we communicate with this rank.
+                # Set up a new connection.
+                (r_s, w_s) = start_send_event_loop(mgr, from_rank)
+                Base.process_messages(r_s, w_s)
+                num_send_loops += 1
+            else
+                (r_s, w_s) = streams
+            end
+            write(r_s, buf)
+        else
+            # TODO: Need a better way to integrate with libuv's event loop
+            yield()
+        end
+    end
+    for i in 1:num_send_loops
+        fetch(mgr.sending_done)
+    end
+    put!(mgr.receiving_done, nothing)
+end
+
+# Stop the main loop
+# This function should be called by the main process only.
+function stop_main_loop(mgr::MPIManager)
+    if mgr.mode == TCP_TRANSPORT_ALL
+        # Shut down all workers
+        for i in workers()
+            if i != myid()
+                @spawnat i begin
+                    MPI.Finalize()
+                    exit()
+                end
+            end
+        end
+        # Poor man's flush of the send queue
+        sleep(1)
+        put!(mgr.initiate_shutdown, nothing)
+        MPI.Finalize()
+    elseif mgr.mode == MPI_TRANSPORT_ALL
+        # Shut down all workers, but not ourselves yet
+        for i in workers()
+            if i != myid()
+                @spawnat i begin
+                    global initiate_shutdown
+                    put!(initiate_shutdown, nothing)
+                end
+            end
+        end
+        # Poor man's flush of the send queue
+        sleep(1)
+        # Shut down ourselves
+        put!(mgr.initiate_shutdown, nothing)
+        wait(mgr.receiving_done)
+        MPI.Finalize()
+    else
+        @assert false
+    end
+end
+
+################################################################################
+# MPI-specific communication methods
+
+# Execute a command on all MPI ranks
+# This uses MPI as communication method even if @everywhere uses TCP
+function mpi_do(mgr::MPIManager, expr)
+    !mgr.initialized && wait(mgr.cond_initialized)
+    jpids = keys(mgr.j2mpi)
+    refs = cell(length(jpids))
+    for (i,p) in enumerate(filter(x->x!=myid(), jpids))
+        refs[i] = remotecall(expr, p)
+    end
+    # Execution on local process should be last, since it can block the main
+    # event loop
+    if myid() in jpids
+        refs[end] = remotecall(expr, myid())
+    end
+
+    # Retrieve remote exceptions if any
+    @sync begin
+        for r in refs
+            @async begin
+                resp = remotecall_fetch(r.where, r) do rr
+                    wrkr_result = take!(rr)
+                    # Only return result if it is an exception, i.e. don't
+                    # return a valid result of a worker computation. This is
+                    # a mpi_do and not mpi_callfetch.
+                    isa(wrkr_result, Exception) ? wrkr_result : nothing
+                end
+                isa(resp, Exception) && throw(resp)
+            end
+        end
+    end
+    nothing
+end
+
+macro mpi_do(mgr, expr)
+    expr = Base.localize_vars(:(()->$expr), false)
+    :(mpi_do($(esc(mgr)), $(esc(expr))))
+end
+
+# All managed Julia processes
+procs(mgr::MPIManager) = sort(keys(mgr.j2mpi))
+
+# All managed MPI ranks
+mpiprocs(mgr::MPIManager) = sort(keys(mgr.mpi2j))

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -217,7 +217,11 @@ function manage(mgr::MPIManager, id::Integer, config::WorkerConfig, op::Symbol)
         end
     elseif op == :deregister
         info("pid=$(getpid()) id=$id op=$op")
-        # TODO: terminate the worker
+        # TODO: Sometimes -- very rarely -- Julia calls this `deregister`
+        # function, and then outputs a warning such as """error in running
+        # finalizer: ErrorException("no process with id 3 exists")""". These
+        # warnings seem harmless; still, we should find out what is going wrong
+        # here.
     elseif op == :interrupt
         # TODO: This should never happen if we rmprocs the workers properly
         info("pid=$(getpid()) id=$id op=$op")

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -330,7 +330,7 @@ function start_main_loop(mode::TransportMode=TCP_TRANSPORT_ALL;
             setup_worker(host, port) # does not return
         end
     elseif mode == MPI_TRANSPORT_ALL
-        #TODO comm = MPI.Comm_dup(comm)
+        comm = MPI.Comm_dup(comm)
         rank = MPI.Comm_rank(comm)
         size = MPI.Comm_size(comm)
         # We are handling the workers and their event loops on our own

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,11 @@ function runtests()
     for f in testfiles
         try
             coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
-            run(`mpirun -np $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            if f == "test_cman_julia.jl"
+                run(`$exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            else
+                run(`mpiexec -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            end
             Base.with_output_color(:green,STDOUT) do io
                 println(io,"\tSUCCESS: $f")
             end

--- a/test/test_cman_julia.jl
+++ b/test/test_cman_julia.jl
@@ -1,0 +1,26 @@
+using Base.Test
+using MPI
+
+# Start workers via `mpiexec` that communicate among themselves via MPI;
+# communicate with the workers via TCP
+mgr = MPI.MPIManager(np=4)
+addprocs(mgr)
+
+refs = []
+for w in workers()
+    push!(refs, @spawnat w MPI.Comm_rank(MPI.COMM_WORLD))
+end
+ids = falses(nworkers())
+for r in refs
+    id = fetch(r)
+    @test !ids[id+1]
+    ids[id+1] = true
+end
+for id in ids
+    @test id
+end
+
+s = @parallel (+) for i in 1:10
+    i^2
+end
+@test s == 385

--- a/test/test_cman_mpi.jl
+++ b/test/test_cman_mpi.jl
@@ -1,0 +1,32 @@
+using Base.Test
+using MPI
+
+# This uses MPI to communicate with the workers
+mgr = MPI.start_main_loop(MPI.MPI_TRANSPORT_ALL)
+
+comm = MPI.COMM_WORLD
+rank = MPI.Comm_rank(comm)
+size = MPI.Comm_size(comm)
+
+refs = []
+for w in workers()
+    push!(refs, @spawnat w MPI.Comm_rank(MPI.COMM_WORLD))
+end
+ids = falses(size)
+for r in refs
+    id = fetch(r)
+    @test !ids[id+1]
+    ids[id+1] = true
+end
+@test ids[1] == (length(procs()) == 1)
+ids[1] = true
+for id in ids
+    @test id
+end
+
+s = @parallel (+) for i in 1:10
+    i^2
+end
+@test s == 385
+
+MPI.stop_main_loop(mgr)

--- a/test/test_cman_tcp.jl
+++ b/test/test_cman_tcp.jl
@@ -1,0 +1,32 @@
+using Base.Test
+using MPI
+
+# This uses TCP to communicate with the workers
+mgr = MPI.start_main_loop(MPI.TCP_TRANSPORT_ALL)
+
+comm = MPI.COMM_WORLD
+rank = MPI.Comm_rank(comm)
+size = MPI.Comm_size(comm)
+
+refs = []
+for w in workers()
+    push!(refs, @spawnat w MPI.Comm_rank(MPI.COMM_WORLD))
+end
+ids = falses(size)
+for r in refs
+    id = fetch(r)
+    @test !ids[id+1]
+    ids[id+1] = true
+end
+@test ids[1] == (length(procs()) == 1)
+ids[1] = true
+for id in ids
+    @test id
+end
+
+s = @parallel (+) for i in 1:10
+    i^2
+end
+@test s == 385
+
+MPI.stop_main_loop(mgr)


### PR DESCRIPTION
Rename some functions for clarity.
Add many comments.
Clean up / correct termination handling.
Avoid blocking MPI communication in example.
Add test cases.