### PR TITLE
Evaluate expressions in @mpi_do in Main module

### DIFF
--- a/test/test_cman_julia.jl
+++ b/test/test_cman_julia.jl
@@ -24,3 +24,6 @@ s = @parallel (+) for i in 1:10
     i^2
 end
 @test s == 385
+
+@mpi_do mgr n = 2
+@mpi_do mgr n + 2


### PR DESCRIPTION
 and don't run `localize_vars` on the expression. This is similar to how @everywhere evaluates.