### PR TITLE
Add windows support for more MPI functions

### DIFF
--- a/src/win_mpiconstants.jl
+++ b/src/win_mpiconstants.jl
@@ -77,5 +77,8 @@ const MPI_PROBE = (:MPI_PROBE, "msmpi.dll")
 const MPI_COMM_FREE = (:MPI_COMM_FREE, "msmpi.dll")
 const MPI_GET_COUNT = (:MPI_GET_COUNT, "msmpi.dll")
 const MPI_TESTSOME = (:MPI_TESTSOME, "msmpi.dll")
+const MPI_TYPE_CREATE_STRUCT = (:MPI_TYPE_CREATE_STRUCT, "msmpi.dll")
+const MPI_TYPE_COMMIT = (:MPI_TYPE_COMMIT, "msmpi.dll")
+const MPI_WAIT = (:MPI_WAIT, "msmpi.dll")
 
 bitstype 32 CComm


### PR DESCRIPTION
This will make the windows tests pass once #124 is merged.