### PR TITLE
Mpitype

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ Julia Function (assuming `import MPI`) | Fortran Function
  `MPI.Finalized`                       | [`MPI_Finalized`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Finalized.3.php)
  `MPI.Init`                            | [`MPI_Init`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Init.3.php)
  `MPI.Initialized`                     | [`MPI_Initialized`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Initialized.3.php)
+ `MPI.mpitype`                         | [`MPI_Type_create_struct`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Type_create_struct.3.php) and [`MPI_Type_commit`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Type_commit.3.php) (see: [mpitype note](#mpitypenote))
+
+<a name="mpitypenote">mpitype note</a>: This is not strictly a wrapper for
+`MPI_Type_create_struct` and `MPI_Type_commit`, it also is an accessor for
+previously created types.
 
 #### Point-to-point communication
 Julia Function (assuming `import MPI`) | Fortran Function
@@ -234,6 +239,7 @@ Julia Function (assuming `import MPI`) | Fortran Function
  `MPI.Scan`                            | [`MPI_Scan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scan.3.php)
  `MPI.Scatter`                         | [`MPI_Scatter`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatter.3.php)
  `MPI.Scatterv`                        | [`MPI_Scatterv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatterv.3.php)
+
 
 
 [Julia]: http://julialang.org/

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Julia Function (assuming `import MPI`) | Fortran Function
  `MPI.Alltoallv`                       | [`MPI_Alltoallv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoallv.3.php)
  `MPI.Barrier`                         | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)
  `MPI.Bcast!`                          | [`MPI_Bcast`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Bcast.3.php)
- `MPI.ExScan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)
+ `MPI.Exscan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)
  `MPI.Gather`                          | [`MPI_Gather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gather.3.php)
  `MPI.Gatherv`                         | [`MPI_Gatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gatherv.3.php)
  `MPI.Reduce`                          | [`MPI_Reduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Reduce.3.php)

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -11,12 +11,13 @@ typealias MPIBuffertype{T} Union{Ptr{T}, Array{T}, Ref{T}}
 
 # accessor and creation function for getting MPI datatypes
 function mpitype{T}(::Type{T})
-    if !isbits(T)
-        throw(ArgumentError("Type must be isbits()"))
-    end
 
     if haskey(mpitype_dict, T)  # if the datatype already exists
       return mpitype_dict[T]
+    end
+
+    if !isbits(T)
+        throw(ArgumentError("Type must be isbits()"))
     end
 
     # get the data from the type

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -9,7 +9,6 @@ typealias MPIBuffertype{T} Union{Ptr{T}, Array{T}, Ref{T}}
 # can be precompiled
 
 # accessor function for getting MPI datatypes
-mpitype{T}(::Type{T}) = mpitype_dict[T]
 
 type Comm
     val::Cint
@@ -116,13 +115,13 @@ function Comm_size(comm::Comm)
     Int(size[])
 end
 
-function type_create(T::DataType)
+function mpitype{T}(::Type{T})
     if !isbits(T)
         throw(ArgumentError("Type must be isbits()"))
     end
 
     if haskey(mpitype_dict, T)  # if the datatype already exists
-        return nothing
+      return mpitype_dict[T]
     end
 
     # get the data from the type
@@ -137,9 +136,6 @@ function type_create(T::DataType)
     for i=1:nfields
         displacements[i] = offsets[i]
         # create an MPI_Datatype for the current field if it does not exist yet
-        if !haskey(mpitype_dict, fieldtypes[i])
-            type_create(fieldtypes[i])
-        end
         types[i] = mpitype(fieldtypes[i])
     end
 
@@ -165,7 +161,7 @@ function type_create(T::DataType)
     # add it to the dictonary of known types
     mpitype_dict[T] = newtype_ref[]
 
-    return nothing
+    return mpitype_dict[T]
 end
 
 # Point-to-point communication

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -640,7 +640,7 @@ function Scan{T}(object::T, op::Op, comm::Comm)
     Scan(sendbuf,1,op,comm)
 end
 
-function ExScan{T}(sendbuf::MPIBuffertype{T}, count::Integer,
+function Exscan{T}(sendbuf::MPIBuffertype{T}, count::Integer,
                    op::Op, comm::Comm)
     recvbuf = Array(T, count)
     ccall(MPI_EXSCAN, Void,
@@ -649,9 +649,9 @@ function ExScan{T}(sendbuf::MPIBuffertype{T}, count::Integer,
     recvbuf
 end
 
-function ExScan{T}(object::T, op::Op, comm::Comm)
+function Exscan{T}(object::T, op::Op, comm::Comm)
     sendbuf = T[object]
-    ExScan(sendbuf,1,op,comm)
+    Exscan(sendbuf,1,op,comm)
 end
 
 # Conversion between C and Fortran Comm handles:

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -24,7 +24,7 @@ immutable Boundary
   b::UInt8
 end
 
-MPI.type_create(Boundary)
+MPI.mpitype(Boundary)
 
 arr = Array(Boundary, 3)
 for i=1:3
@@ -55,7 +55,7 @@ immutable Boundary2
   b::Tuple{Int, UInt8}
 end
 
-MPI.type_create(Boundary2)
+MPI.mpitype(Boundary2)
 
 arr = Array(Boundary2, 3)
 arr_recv = Array(Boundary2, 3)

--- a/test/test_exscan.jl
+++ b/test/test_exscan.jl
@@ -12,7 +12,7 @@ rank = MPI.Comm_rank(comm)
 typs = setdiff([MPI.MPIDatatype.types...], [Char, Int8, UInt8])
 for typ in typs
     val = convert(typ,rank+1)
-    B = MPI.ExScan(val, MPI.PROD, comm)
+    B = MPI.Exscan(val, MPI.PROD, comm)
     if rank > 0
         @test_approx_eq B[1] factorial(rank)
     end


### PR DESCRIPTION
I propose merging `mpitype` with `type_create` this make the following much cleaner:
```
x = [(2,1,3)]
MPI.Send(x, dest, 999, comm)
```
as opposed to first having the create the type
```
x = [(2,1,3)]
MPI.type_create(x)
MPI.Send(x, dest, 999, comm)
```
since the MPI_Type is created automatically from the array type if it doesn't already exist.

Also, `MPI_Exscan` was inconsistently named, it was named `ExScan` but everything else only capitalizes the first letter, so I propose changing this to `Exscan`