### PR TITLE
Add using MPI as first command in test to precompile

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using MPI
 using Base.Test
 
 # Code coverage command line options; must correspond to src/julia.h


### PR DESCRIPTION
The appveyor test right now fail because the first test starts multiple julia instances that all try to precompile MPI at the same time. This PR will trigger the precompile before any new processes are started and thus fixes that bug.