### PR TITLE
Test with a non-broken OpenMPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ env:
   - MPI_IMPL=openmpi
 before_install:
   - sh ./conf/travis-install-mpi.sh $MPI_IMPL
+  - export PATH=$HOME/OpenMPI/bin:$PATH
 after_success:
   - if [ "$TRAVIS_JULIA_VERSION" = nightly ]; then julia -e 'cd(Pkg.dir("MPI")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Coveralls.process_folder())'; fi

--- a/conf/travis-install-mpi.sh
+++ b/conf/travis-install-mpi.sh
@@ -43,7 +43,13 @@ case "$os" in
                 # rm -f ./mpich_3.1-1ubuntu_amd64.deb
                 ;;
             openmpi)
-                sudo apt-get install -y gfortran openmpi-bin openmpi-common libopenmpi-dev
+                sudo apt-get install -y gfortran
+                wget --no-check-certificate https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.2.tar.gz
+                tar -zxvf openmpi-1.10.2.tar.gz
+                cd openmpi-1.10.2
+                sh ./configure --prefix=$HOME/OpenMPI
+                make -j
+                sudo make install
                 ;;
             *)
                 echo "Unknown MPI implementation: $MPI_IMPL"


### PR DESCRIPTION
I had to do the same thing in https://github.com/JuliaParallel/Elemental.jl/blob/master/mpi.sh. OpenMPI 1.6.x is old and broken but only the development version of Ubuntu seems to have a more recent version so we'll have download and build OpenMPI.