### PR TITLE
Pass opfunc correctly to Reduce

### DIFF
--- a/src/mpi-op.jl
+++ b/src/mpi-op.jl
@@ -66,5 +66,5 @@ Allreduce!{T}(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
     Allreduce!(sendbuf, recvbuf, count, user_op(opfunc), comm)
 
 Reduce{T}(sendbuf::MPIBuffertype{T}, count::Integer,
-          op::Function, root::Integer, comm::Comm) =
+          opfunc::Function, root::Integer, comm::Comm) =
     Reduce(sendbuf, count, user_op(opfunc), root, comm)

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -18,6 +18,9 @@ val = rank == root ? size-1 : nothing
 val = rank == root ? 0 : nothing
 @test MPI.Reduce(rank, MPI.MIN, root, comm) == val
 
+val = rank == root ? size : nothing
+@test MPI.Reduce(1, +, root, comm) == val
+
 mesg = collect(1.0:5.0)
 sum_mesg = MPI.Reduce(mesg, MPI.SUM, root, comm)
 sum_mesg = rank == root ? sum_mesg : size*mesg


### PR DESCRIPTION
This fixes a bug where `opfunc` is incorrectly passed to `Reduce`.