### PR TITLE
Add Wtime and Wtick

### DIFF
--- a/deps/gen_functions.c
+++ b/deps/gen_functions.c
@@ -71,6 +71,7 @@ int main(int argc, char *argv[]) {
   printf("    :MPI_WAITANY            => \"%s\",\n", STRING(MPI_WAITANY));
   printf("    :MPI_WAITSOME           => \"%s\",\n", STRING(MPI_WAITSOME));
   printf("    :MPI_WTIME              => \"%s\",\n", STRING(MPI_WTIME));
+  printf("    :MPI_WTICK              => \"%s\",\n", STRING(MPI_WTICK));
   printf("    :MPI_TYPE_CREATE_STRUCT => \"%s\",\n", 
          STRING(MPI_TYPE_CREATE_STRUCT));
   printf("    :MPI_TYPE_COMMIT        => \"%s\",\n", 

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -172,6 +172,20 @@ function Comm_size(comm::Comm)
     Int(size[])
 end
 
+function Wtime()
+
+  val = ccall(MPI_WTIME, Cdouble, () )
+  return val
+end
+
+function Wtick()
+
+  val = ccall(MPI_WTICK, Cdouble, () )
+  return val
+end
+
+
+
 function type_create(T::DataType)
     if !isbits(T)
         throw(ArgumentError("Type must be isbits()"))

--- a/test/test_time.jl
+++ b/test/test_time.jl
@@ -1,0 +1,20 @@
+# test wtime and wtick
+
+using Base.Test
+using MPI
+
+MPI.Init()
+
+sleeptime = 1
+val1 = MPI.Wtime()
+sleep(sleeptime)
+val2 = MPI.Wtime()
+
+resolution = MPI.Wtick()
+
+@test resolution > 0
+@test resolution < 1  # pretty sure all clocks are have 1 second accuracy
+@test val2 - val1 > sleeptime - resolution
+
+MPI.Finalize()
+


### PR DESCRIPTION
This PR adds the `MPI_Wtick` and `MPI_Wtick` functions.  One thing I did not add is the `MPI_WTIME_IS_GLOBAL` attribute, because 1) I don't know how to use pointers in Fortran, and 2) `MPI_Attr_get` was deprecated in favor for `MPI_Comm_Attr_get` in MPI 2.0, so we would have to add a system for dealing with that.