### PR TITLE
fix various depwarns under 0.7 (without breaking 0.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.6
 BinDeps
 Compat 0.9.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,9 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  # The MPI tests with Julia 0.5 are currently broken. We don't quite
-  # know why; see <https://github.com/JuliaParallel/MPI.jl/issues/123>
-  # for the respective discussion.
-  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1,8 +1,8 @@
-typealias MPIDatatype Union{Char,
+const MPIDatatype = Union{Char,
                             Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64,
                             UInt64,
                             Float32, Float64, Complex64, Complex128}
-typealias MPIBuffertype{T} Union{Ptr{T}, Array{T}, Ref{T}}
+MPIBuffertype{T} = Union{Ptr{T}, Array{T}, Ref{T}}
 
 if VERSION >= v"0.5.0-"
     # TODO: Use Compat for this
@@ -67,7 +67,7 @@ function mpitype{T}(::Type{T})
 end
 
 
-type Comm
+mutable struct Comm
     val::Cint
     Comm(val::Integer) = new(val)
 end
@@ -75,7 +75,7 @@ const COMM_NULL  = Comm(MPI_COMM_NULL)
 const COMM_SELF  = Comm(MPI_COMM_SELF)
 const COMM_WORLD = Comm(MPI_COMM_WORLD)
 
-type Op
+mutable struct Op
     val::Cint
 end
 const OP_NULL = Op(MPI_OP_NULL)
@@ -90,13 +90,13 @@ const MIN     = Op(MPI_MIN)
 const PROD    = Op(MPI_PROD)
 const SUM     = Op(MPI_SUM)
 
-type Request
+mutable struct Request
     val::Cint
     buffer
 end
 const REQUEST_NULL = Request(MPI_REQUEST_NULL, nothing)
 
-type Status
+mutable struct Status
     val::Array{Cint,1}
     Status() = new(Array{Cint}(MPI_STATUS_SIZE))
 end

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -18,13 +18,13 @@ end
 
 # test simple type 
 
-type NotABits
+mutable struct NotABits
   a::Any
 end
 
 @test_throws ArgumentError MPI.type_create(NotABits)
 
-immutable Boundary
+struct Boundary
   c::UInt16  # force some padding to be inserted
   a::Int
   b::UInt8
@@ -56,7 +56,7 @@ end
 
 
 # test nested types
-immutable Boundary2
+struct Boundary2
   a::UInt32
   b::Tuple{Int, UInt8}
 end


### PR DESCRIPTION
This pull request fixes those depwarns under 0.7 that can be fixed without breaking 0.6. Best!