### PR TITLE
Enable override of MPI_Comm_c2f detection

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,7 +27,8 @@ flags = ["MPI_C_COMPILER",
          "MPI_Fortran_LINK_FLAGS",
          "MPI_Fortran_LIBRARIES",
          "MPI_INCLUDE_PATH",
-         "MPI_LIBRARIES"]
+         "MPI_LIBRARIES",
+         "HAVE_MPI_COMM_C2F"]
 for flag in flags
     try
         val = ENV["JULIA_$flag"]


### PR DESCRIPTION
To build using Cray compiler wrappers (`CC=cc` and `FC=ftn`) I find I have to override this check.  The problem is that the associated check doesn't work because it lacks the necessary `#include "mpi.h"` and furthermore, the Cray header defines this via macro:

    #define MPI_Comm_c2f(comm) (MPI_Fint)(comm)

Maybe there's a better check that could be used?  If so then ignore this PR but the right one has to be put in (not sure my CMake is good enough...)