### PR TITLE
Optionally call MPI.Finalize at exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ able to run the MPI job as expected, e.g., with
 
 `mpirun -np 3 julia 01-hello.jl`
 
+### Cleanup
+In Julia code building on this package, it may happen that you want to run MPI cleanup functions in a finalizer.
+This makes it impossible to manually call `MPI.Finalize()`, since the Julia finalizers may run after this call.
+To solve this, a C `atexit` hook to run `MPI.Finalize()` can be set using `MPI.finalize_atexit()`. It is possible
+to check if this function was called by checking the global `Ref` `MPI.FINALIZE_ATEXIT`.
+
 ## Usage : MPI and Julia parallel constructs together
 
 In order for MPI calls to be made from a Julia cluster, it requires the use of

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -202,13 +202,13 @@ endif(UNIX)
 
 add_dependencies(dist version)
 
-add_library(juliampi SHARED test_mpi.f90)
+add_library(juliampi SHARED juliampi.c test_mpi.f90)
 
 if(MPI_Fortran_LINK_FLAGS)
   set_target_properties(juliampi PROPERTIES LINK_FLAGS ${MPI_Fortran_LINK_FLAGS})
 endif(MPI_Fortran_LINK_FLAGS)
 
-target_link_libraries(juliampi ${MPI_Fortran_LIBRARIES})
+target_link_libraries(juliampi ${MPI_C_LIBRARIES} ${MPI_Fortran_LIBRARIES})
 
 include(CheckFunctionExists)
 set(CMAKE_REQUIRED_LIBRARIES ${MPI_C_LIBRARIES})

--- a/deps/juliampi.c
+++ b/deps/juliampi.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <mpi.h>
+
+void finalize_atexit()
+{
+    int iflag, fflag;
+    MPI_Initialized(&iflag);
+    MPI_Finalized(&fflag);
+    if (iflag && !fflag)
+    {
+        MPI_Finalize();
+    }
+}
+
+int install_finalize_atexit_hook()
+{
+    return atexit(finalize_atexit);
+}

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -194,6 +194,25 @@ function Finalize()
     ccall(MPI_FINALIZE, Void, (Ptr{Cint},), &0)
 end
 
+const FINALIZE_ATEXIT = Ref(false)
+
+"""
+    finalize_atexit()
+
+Indicate that MPI.Finalize() should be called automatically at exit, if not called manually already.
+The global variable `FINALIZE_ATEXIT` indicates if this function was called.
+"""
+function finalize_atexit()
+    if is_windows()
+        error("finalize_atexit is not supported on Windows")
+    end
+    ret = ccall(:install_finalize_atexit_hook, Cint, ())
+    if ret != 0
+        error("Failed to set finalize_atexit")
+    end
+    FINALIZE_ATEXIT[] = true
+end
+
 function Abort(comm::Comm, errcode::Integer)
     ccall(MPI_ABORT, Void, (Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
           &comm.val, &errcode, &0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ singlefiles = ["test_spawn.jl"]
 
 excludedfiles = []
 if is_windows()
-    excludedfiles = ["test_info.jl", "test_onesided.jl"]
+    excludedfiles = ["test_info.jl", "test_onesided.jl", "test_finalize_atexit.jl"]
     if Sys.WORD_SIZE == 32
         push!(excludedfiles, "test_spawn.jl")
     end

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -7,6 +7,11 @@ MPI.Init()
 
 @test MPI.Comm(MPI.CComm(MPI.COMM_WORLD)).val == MPI.COMM_WORLD.val
 
+if !is_windows()
+    MPI.finalize_atexit()
+    @test MPI.FINALIZE_ATEXIT[]
+end
+
 @test !MPI.Finalized()
 MPI.Finalize()
 @test MPI.Finalized()

--- a/test/test_finalize_atexit.jl
+++ b/test/test_finalize_atexit.jl
@@ -1,0 +1,10 @@
+using Base.Test
+using MPI
+
+@test !MPI.Initialized()
+MPI.Init()
+MPI.finalize_atexit()
+@test MPI.FINALIZE_ATEXIT[]
+
+@test MPI.Initialized()
+@test !MPI.Finalized()


### PR DESCRIPTION
This is useful for enabling cleanup using standard Julia finalizers, which otherwise run after `MPI.Finalize()`.