### PR TITLE
fix CComm depwarn

### DIFF
--- a/deps/gen_functions.c
+++ b/deps/gen_functions.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
          STRING(MPI_TYPE_COMMIT));
   printf(")\n");
   printf("\n");
-  printf("bitstype %d CComm\n", (int)(sizeof(MPI_Comm) * 8));
+  printf("primitive type CComm %d end\n", (int)(sizeof(MPI_Comm) * 8));
 
   return 0;
 }

--- a/src/win_mpiconstants.jl
+++ b/src/win_mpiconstants.jl
@@ -90,4 +90,4 @@ const MPI_WAITANY = (:MPI_WAITANY, "msmpi.dll")
 const MPI_CANCEL = (:MPI_CANCEL, "msmpi.dll")
 const MPI_ALLREDUCE = (:MPI_ALLREDUCE, "msmpi.dll")
 
-bitstype 32 CComm
+primitive type CComm 32 end


### PR DESCRIPTION
Changes `bitstype` to `primitive type`.