### PR TITLE
Christophernhill/fix mpiprocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ The following lines will be typically required on the julia master process to su
 # to import MPIManager
 using MPI
 
+# need to also import Distributed to use addprocs()
+using Distributed
+
 # specify, number of mpi workers, launch cmd, etc.
 manager=MPIManager(np=4)
 

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -506,7 +506,7 @@ macro mpi_do(mgr, expr)
 end
 
 # All managed Julia processes
-Distributed.procs(mgr::MPIManager) = sort(keys(mgr.j2mpi))
+Distributed.procs(mgr::MPIManager) = sort(collect(keys(mgr.j2mpi)))
 
 # All managed MPI ranks
-mpiprocs(mgr::MPIManager) = sort(keys(mgr.mpi2j))
+mpiprocs(mgr::MPIManager) = sort(collect(keys(mgr.mpi2j)))


### PR DESCRIPTION
MPI.jl team this PR is a fixes two errors I get following the 

```manager==MPIManager(np=4)```

in the main README.md



The first error I get is

```
julia> addprocs(manager)
ERROR: UndefVarError: addprocs not defined
Stacktrace:
 [1] top-level scope at none:0
```
I get this when following the current README.md command sequence. 
I have fixed this by adding 
```
using Distributed
```
to the README.md instructions.

The second error I get is from trying
```
mpiprocs(manager)
```
the error I get is
```
julia> mpiprocs(manager)
ERROR: MethodError: no method matching sort(::Base.KeySet{Int64,Dict{Int64,Int64}})
Closest candidates are:
  sort(::AbstractUnitRange) at range.jl:936
  sort(::AbstractRange) at range.jl:939
  sort(::SparseArrays.SparseVector{Tv,Ti}; kws...) where {Tv, Ti} at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.0/SparseArrays/src/sparsevector.jl:1859
  ...
```
I have fixed this by converting the keys() passed to sort at the end of ```src/cman.jl``` to a collect(). Not sure if this has unintended side-effects, but it does fix the dispatch problem I am seeing for sort and Julia 1.0.1 with current MPI.jl (on Linux). 