### PR TITLE
Add MPImanager option to address side effect of https://github.com/JuliaLang/julia/pull/23699

### DIFF
--- a/conf/travis-install-mpi.sh
+++ b/conf/travis-install-mpi.sh
@@ -14,7 +14,6 @@ case "$os" in
     Darwin)
         brew update
         brew upgrade cmake
-        brew cask uninstall oclint # Prevent conflict with gcc
         case "$MPI_IMPL" in
             mpich|mpich3)
                 brew install mpich

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -58,7 +58,8 @@ mutable struct MPIManager <: ClusterManager
     function MPIManager(; np::Integer = Sys.CPU_THREADS,
                           mpirun_cmd::Cmd = `mpiexec -n $np`,
                           launch_timeout::Real = 60.0,
-                          mode::TransportMode = MPI_ON_WORKERS)
+                          mode::TransportMode = MPI_ON_WORKERS,
+                          master_tcp_interface::String="" )
         mgr = new()
         mgr.np = np
         mgr.mpi2j = Dict{Int,Int}()

--- a/src/cman.jl
+++ b/src/cman.jl
@@ -3,7 +3,7 @@ export MPIManager, launch, manage, kill, procs, connect, mpiprocs, @mpi_do
 export TransportMode, MPI_ON_WORKERS, TCP_TRANSPORT_ALL, MPI_TRANSPORT_ALL
 using Compat
 using Compat.Distributed
-import Compat.Sockets: connect, listenany, accept, IPv4, getsockname
+import Compat.Sockets: connect, listenany, accept, IPv4, getsockname, getaddrinfo
 
 
 
@@ -87,7 +87,17 @@ mutable struct MPIManager <: ClusterManager
         # Listen to TCP sockets if necessary
         if mode != MPI_TRANSPORT_ALL
             # Start a listener for capturing stdout from the workers
-            port, server = listenany(11000)
+            if master_tcp_interface != ""
+               # Listen on specified server interface
+               # This allows direct connection from other hosts on same network as
+               # specified interface.
+               port, server = 
+                listenany(getaddrinfo(master_tcp_interface), 11000)
+            else
+               # Listen on default interface (localhost)
+               # This precludes direct connection from other hosts.
+               port, server = listenany(11000)
+            end
             ip = getsockname(server)[1].host
             @async begin
                 while true


### PR DESCRIPTION
Hi All - another PR. This one addresses a problem I have run into launching ```MPI.jl``` in ```mode != MPI_TRANSPORT_ALL``` style with julia 1.0.1 and 1.0.2 on a multi-node cluster. 
As described below it looks to me that a change in ```julia/stdlib/Sockets/src/Sockets.jl``` about a year ago may have impacted the ability of ```MPI.jl``` to start up in some use cases on multi-node cluster setups?

This PR addresses a side-effect of [a security/semantics issue](https://github.com/JuliaLang/julia/pull/23699) that was [fixed](https://github.com/JuliaLang/julia/commit/775f1fc42622b3a141aa242ffe04c22eb08dfdd9 ) a year ago in core library [```julia/stdlib/Sockets/src/Sockets.jl```](https://github.com/JuliaLang/julia/blob/96ce5ba22122280b67991849acdb17b36603224f/stdlib/Sockets/src/Sockets.jl#L577). That change altered the default ```listenany()``` interface that a socket listened on to be ```127.0.0.0``` where previously it looks to have been ```0.0.0.0```. 

The change was consistent with documentation. It also removed a security concern, since ```0.0.0.0``` implies accepting connections on any interface. 

For ```MPI.jl``` this change looks to have an unexpected side effect. Before the ```julia/stdlib/Sockets/src/Sockets.jl``` fix, remote node workers on a cluster could connect back to the master during the ```addprocs()``` initial handshaking. All that was required was to set the value
of ```manager.ip``` to the correct hostname e.g.

```
manager=MPIManager(np=4)
manager.ip=Int(Sockets.IPv4("10.1.7.49"))
addprocs(manager)
```

would work OK and return a list of process ranks as expected. The processes could be on multiple physical nodes on a network and things would start up and handshake OK. 

Following the [update to ```Sockets.jl```](https://github.com/JuliaLang/julia/commit/775f1fc42622b3a141aa242ffe04c22eb08dfdd9) it looks as though multi-node ```addprocs()``` would fail with

```
ERROR: IOError: connect: connection refused (ECONNREFUSED)
```

. This makes sense because the socket on the master is now configured to listen only for connections from the ```127.0.0.1``` (localhost traffic only) interface and not the ```0.0.0.0``` (any network) interface as before. 

This PR is a suggested fix to address the behavior change of ```listenany()```. The PR introduces a new optional argument ```master_tcp_interface``` to ```MPIManager()``` that is used as follows

```
manager=MPIManager(np=4,master_tcp_interface="10.1.7.49")
addprocs(manager)
```

. The option causes a specific interface (```10.1.7.49``` in the example) to be set for listening on. The value
specified can be either an IP address or a DNS name. It should correspond to the IP interface to use on the host running the julia master process. I have not tried to figure out the interface automatically, since on many clusters hosts can have multiple interfaces. In principle a cluster manager or some other system might be able to provide the value automatically. 

The PR leaves the old ```127.0.0.1``` behavior unchanged, if ```master_tcp_interface``` is not set. 

This PR does have some security implications. It opens a port on an interface. However, this is something a user can do explicitly already. In a cluster environment with a private internal network
this is something MPI libraries already do. 

I am also not familiar with how ```Pkg Distributed``` and other multi-node packages are dealing with this, so there may be a better approach. 

This approach does allow the ```mode != MPI_TRANSPORT_ALL``` style of using ```MPI.jl``` to work across a multi-node cluster. Unless I am mistaken ```MPI.jl``` in ```mode != MPI_TRANSPORT_ALL``` style will not work on multi-node clusters at the moment? Possibly some very complex external tunneling approach could be an alternate work around, but that would be quite fiddly. 