### PR TITLE
[WIP] Add functions for Cartesian process topology

### DIFF
--- a/deps/gen_constants.f90
+++ b/deps/gen_constants.f90
@@ -50,6 +50,8 @@ program gen_constants
 
   call output("MPI_INFO_NULL   ", MPI_INFO_NULL)
 
+  call output("MPI_PROC_NULL   ", MPI_PROC_NULL)
+
   call output("MPI_STATUS_SIZE ", MPI_STATUS_SIZE)
   call output("MPI_ERROR       ", MPI_ERROR)
   call output("MPI_SOURCE      ", MPI_SOURCE)

--- a/deps/gen_functions.c
+++ b/deps/gen_functions.c
@@ -26,6 +26,9 @@ int main(int argc, char *argv[]) {
   printf("    :MPI_BCAST              => \"%s\",\n", STRING(MPI_BCAST));
   printf("    :MPI_BSEND              => \"%s\",\n", STRING(MPI_BSEND));
   printf("    :MPI_CANCEL             => \"%s\",\n", STRING(MPI_CANCEL));
+  printf("    :MPI_CART_CREATE        => \"%s\",\n", STRING(MPI_CART_CREATE));
+  printf("    :MPI_CART_COORDS        => \"%s\",\n", STRING(MPI_CART_COORDS));
+  printf("    :MPI_CART_SHIFT         => \"%s\",\n", STRING(MPI_CART_SHIFT));
   printf("    :MPI_COMM_DUP           => \"%s\",\n", STRING(MPI_COMM_DUP));
   printf("    :MPI_COMM_FREE          => \"%s\",\n", STRING(MPI_COMM_FREE));
   printf("    :MPI_COMM_GET_PARENT    => \"%s\",\n", STRING(MPI_COMM_GET_PARENT));
@@ -33,6 +36,7 @@ int main(int argc, char *argv[]) {
   printf("    :MPI_COMM_SIZE          => \"%s\",\n", STRING(MPI_COMM_SIZE));
   printf("    :MPI_COMM_SPLIT         => \"%s\",\n", STRING(MPI_COMM_SPLIT));
   printf("    :MPI_COMM_SPLIT_TYPE    => \"%s\",\n", STRING(MPI_COMM_SPLIT_TYPE));
+  printf("    :MPI_DIMS_CREATE        => \"%s\",\n", STRING(MPI_DIMS_CREATE));
   printf("    :MPI_EXSCAN             => \"%s\",\n", STRING(MPI_EXSCAN));
   printf("    :MPI_FETCH_AND_OP       => \"%s\",\n", STRING(MPI_FETCH_AND_OP));
   printf("    :MPI_FINALIZE           => \"%s\",\n", STRING(MPI_FINALIZE));

--- a/test/test_cart_coords.jl
+++ b/test/test_cart_coords.jl
@@ -1,0 +1,24 @@
+using Test
+using MPI
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+nnodes = MPI.Comm_size(comm)
+ndims = 3
+reorder = 1
+periods = [0,1,0]
+dims = [0,0,0]
+MPI.Dims_create!(nnodes, dims)
+comm_cart = MPI.Cart_create(comm, dims, periods, reorder)
+
+rank = MPI.Comm_rank(comm)
+ccoords = Cint[-1,-1,-1]
+MPI.Cart_coords!(comm_cart, rank, ndims, ccoords)
+@test all(ccoords .>= 0) 
+@test all(ccoords .< dims)
+
+coords = MPI.Cart_coords!(comm_cart, ndims)
+@test all(coords .>= 0)
+@test all(coords .< dims)
+
+MPI.Finalize()

--- a/test/test_cart_create.jl
+++ b/test/test_cart_create.jl
@@ -1,0 +1,21 @@
+using Test
+using MPI
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+nnodes = MPI.Comm_size(comm)
+ndims = 3
+reorder = 1
+periods = [0 1 0]
+dims = [0 0 0]
+MPI.Dims_create!(nnodes, dims)
+
+cperiods = Cint.(periods[:])
+cdims = Cint.(dims[:])
+comm_cart = MPI.Cart_create(comm, ndims, cdims, cperiods, reorder)
+@test MPI.Comm_size(comm_cart) == nnodes
+
+comm_cart2 = MPI.Cart_create(comm, dims, periods, reorder)
+@test MPI.Comm_size(comm_cart2) == nnodes
+
+MPI.Finalize()

--- a/test/test_cart_shift.jl
+++ b/test/test_cart_shift.jl
@@ -1,0 +1,23 @@
+using Test
+using MPI
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+nnodes = MPI.Comm_size(comm)
+ndims = 3
+reorder = 1
+periods = [0,1,0]
+dims = [0,0,0]
+MPI.Dims_create!(nnodes, dims)
+comm_cart = MPI.Cart_create(comm, dims, periods, reorder)
+coords = MPI.Cart_coords!(comm_cart, ndims)
+disp = 1
+
+for i in 0:2
+    neighbors = MPI.Cart_shift(comm_cart, i, disp)
+    # TODO: replace -1 with MPI.PROC_NULL
+    @test all( ((neighbors .>= 0) .& (neighbors .< nnodes)) .| 
+               (neighbors .== -1) )
+end
+
+MPI.Finalize()

--- a/test/test_dims_create.jl
+++ b/test/test_dims_create.jl
@@ -1,0 +1,24 @@
+using Test
+using MPI
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+nnodes = MPI.Comm_size(comm)
+ndims = 3
+
+cdims = Cint[0,0,0]
+MPI.Dims_create!(nnodes, ndims, cdims)
+@test prod(cdims) == nnodes
+
+cdims = Cint[1,0,1]
+MPI.Dims_create!(nnodes, ndims, cdims)
+@test cdims == Cint[1,nnodes,1]
+
+for dims in ([0,0,0], [0 0 0])
+    dims_t = typeof(dims)
+    MPI.Dims_create!(nnodes, dims)
+    @test typeof(dims) == dims_t  #Ensure the type of dims is as before
+    @test prod(dims) == nnodes
+end 
+
+MPI.Finalize()


### PR DESCRIPTION
Addition of the following functions that are fundamental to create and use a Cartesian process topology:
- [MPI_Dims_create](https://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node134.html)
- [MPI_Cart_create](https://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node133.html)
- [MPI_Cart_coords](https://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node136.html)
- [MPI_Cart_shift](https://www.mpi-forum.org/docs/mpi-1.1/mpi-11-html/node137.html)

Closes #225 