### PR TITLE
Implement MPI_IN_PLACE for MPI Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ Julia Function (assuming `import MPI`) | Fortran Function
  `MPI.Allreduce!`                      | `MPI.Allreduce`                       | [`MPI_Allreduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allreduce.3.php)		 | ✅
  `MPI.Alltoall!`                       | `MPI.Alltoall`                        | [`MPI_Alltoall`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoall.3.php)		   | ✅
  `MPI.Alltoallv!`                      | `MPI.Alltoallv`                       | [`MPI_Alltoallv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoallv.3.php)		 | ❌
- 	                                     | `MPI.Barrier`                         | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)			   | ❌
+ --                                    | `MPI.Barrier`                         | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)			   | ❌
  `MPI.Bcast!`                          | `MPI.Bcast!`                          | [`MPI_Bcast`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Bcast.3.php)				     | ❌
- 				                               | `MPI.Exscan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)			     | ❌
+ --		                               | `MPI.Exscan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)			     | ❌
  `MPI.Gather!`                         | `MPI.Gather`                          | [`MPI_Gather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gather.3.php)			     | `Gather_in_place!`
  `MPI.Gatherv!`                        | `MPI.Gatherv`                         | [`MPI_Gatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gatherv.3.php)			   | `Gatherv_in_place!`
  `MPI.Reduce!`                         | `MPI.Reduce`                          | [`MPI_Reduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Reduce.3.php)			     | `Reduce_in_place!`

--- a/README.md
+++ b/README.md
@@ -248,22 +248,31 @@ Julia Function (assuming `import MPI`) | Fortran Function
  `MPI.Waitsome!`                       | [`MPI_Waitsome`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Waitsome.3.php)
 
 
-#### Collective communication
-Julia Function (assuming `import MPI`) | Fortran Function
----------------------------------------|--------------------------------------------------------
- `MPI.Allgather`                       | [`MPI_Allgather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgather.3.php)
- `MPI.Allgatherv`                      | [`MPI_Allgatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgatherv.3.php)
- `MPI.Alltoall`                        | [`MPI_Alltoall`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoall.3.php)
- `MPI.Alltoallv`                       | [`MPI_Alltoallv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoallv.3.php)
- `MPI.Barrier`                         | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)
- `MPI.Bcast!`                          | [`MPI_Bcast`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Bcast.3.php)
- `MPI.Exscan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)
- `MPI.Gather`                          | [`MPI_Gather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gather.3.php)
- `MPI.Gatherv`                         | [`MPI_Gatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gatherv.3.php)
- `MPI.Reduce`                          | [`MPI_Reduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Reduce.3.php)
- `MPI.Scan`                            | [`MPI_Scan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scan.3.php)
- `MPI.Scatter`                         | [`MPI_Scatter`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatter.3.php)
- `MPI.Scatterv`                        | [`MPI_Scatterv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatterv.3.php)
+ #### Collective communication (assuming `import MPI`)
+ Non-Allocating Julia Function 		  |Allocating Julia Function 			  | Fortran Function																	| Supports `MPI_IN_PLACE`
+ --------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------|-----------
+ `MPI.Allgather!`                      | `MPI.Allgather`                       | [`MPI_Allgather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgather.3.php)		 | ✅
+ `MPI.Allgatherv!`                     | `MPI.Allgatherv`                      | [`MPI_Allgatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgatherv.3.php)	 | ✅
+ `MPI.Allreduce!`                      | `MPI.Allreduce`                       | [`MPI_Allreduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allreduce.3.php)		 | ✅
+ `MPI.Alltoall!`                       | `MPI.Alltoall`                        | [`MPI_Alltoall`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoall.3.php)		   | ✅
+ `MPI.Alltoallv!`                      | `MPI.Alltoallv`                       | [`MPI_Alltoallv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoallv.3.php)		 | ❌
+ 	                                     | `MPI.Barrier`                         | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)			   | ❌
+ `MPI.Bcast!`                          | `MPI.Bcast!`                          | [`MPI_Bcast`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Bcast.3.php)				     | ❌
+ 				                               | `MPI.Exscan`                          | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)			     | ❌
+ `MPI.Gather!`                         | `MPI.Gather`                          | [`MPI_Gather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gather.3.php)			     | `Gather_in_place!`
+ `MPI.Gatherv!`                        | `MPI.Gatherv`                         | [`MPI_Gatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gatherv.3.php)			   | `Gatherv_in_place!`
+ `MPI.Reduce!`                         | `MPI.Reduce`                          | [`MPI_Reduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Reduce.3.php)			     | `Reduce_in_place!`
+ `MPI.Scan`                            | `MPI.Scan`                            | [`MPI_Scan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scan.3.php)				       | missing
+ `MPI.Scatter!`                        | `MPI.Scatter`                         | [`MPI_Scatter`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatter.3.php)			   | `Scatter_in_place!`
+ `MPI.Scatterv!`                       | `MPI.Scatterv`                        | [`MPI_Scatterv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatterv.3.php)		   | `Scatterv_in_place!`
+
+The non-allocating Julia functions map directly to the corresponding MPI operations, after asserting that the size of the output buffer is sufficient to store the result.
+
+The allocating Julia functions allocate an output buffer and then call the non-allocating method.
+
+All-to-all collective communications support in place operations by passing
+`MPI.IN_PLACE` with the same syntax documented by MPI.
+One-to-All communications support it by calling the function `*_in_place!`, calls the MPI functions with the right syntax on root and non root process.
 
 #### One-sided communication
 Julia Function (assuming `import MPI`) | Fortran Function

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 branches:
   only:
     - master
-    - /release-.*/
+    - philipvinc/in_place
 
 notifications:
   - provider: Email

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 branches:
   only:
     - master
-    - philipvinc/in_place
+    - /release-.*/
 
 notifications:
   - provider: Email

--- a/deps/gen_functions.c
+++ b/deps/gen_functions.c
@@ -112,5 +112,9 @@ int main(int argc, char *argv[]) {
   printf("primitive type CInfo %d end\n", (int)(sizeof(MPI_Info) * 8));
   printf("primitive type CWin %d end\n", (int)(sizeof(MPI_Win) * 8));
 
+  printf("\n");
+  printf("\n");
+  printf("const MPI_IN_PLACE_VAL = %d\n", ((int)MPI_IN_PLACE));
+
   return 0;
 }

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -74,6 +74,11 @@ function __init__()
 
         recordDataType(T, mpiT)
     end
+
+    # Initialize the void* MPI_IN_PLACE. As pointers are set to 0 at
+    # precompilation, this must be done in __init__
+    # MPI_IN_PLACE_VAL = (int)MPI_IN_PLACE
+    Core.eval(MPI, :(const IN_PLACE = Ptr{Cvoid}(MPI_IN_PLACE_VAL)))
 end
 
 end

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -23,6 +23,9 @@ include("cman.jl")
 const mpitype_dict = Dict{DataType, Cint}()
 const mpitype_dict_inverse = Dict{Cint, DataType}()
 
+# Initialize the void* IN_PLACE with the value extracted during the build phase. 
+const IN_PLACE = reinterpret(ConstantPtr, MPI_IN_PLACE_VAL)
+
 """
   Setter function for mpitype_dict and mpitype_dict_inverse
 """
@@ -74,11 +77,6 @@ function __init__()
 
         recordDataType(T, mpiT)
     end
-
-    # Initialize the void* MPI_IN_PLACE. As pointers are set to 0 at
-    # precompilation, this must be done in __init__
-    # MPI_IN_PLACE_VAL = (int)MPI_IN_PLACE
-    Core.eval(MPI, :(const IN_PLACE = Ptr{Cvoid}(MPI_IN_PLACE_VAL)))
 end
 
 end

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1210,7 +1210,7 @@ buffer `recvbuf`.
 function Gather!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
                 count::Integer, root::Integer, comm::Comm) where T
     isroot = Comm_rank(comm) == root
-    isroot && @assert length(recvbuf) > count
+    isroot && @assert length(recvbuf) >= count*Comm_size(comm)
     ccall(MPI_GATHER, Nothing,
           (Ptr{T}, Ref{Cint}, Ref{Cint}, Ptr{T}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint}),
           sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), root, comm.val, 0)

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -985,6 +985,11 @@ function Allreduce!(buf::MPIBuffertype{T}, op::Union{Op, Function}, comm::Comm) 
     Allreduce!(MPI.IN_PLACE, buf, op, comm)
 end
 
+function Allreduce(sendbuf::Array{T, N}, op::Union{Op, Function}, comm::Comm) where {T, N}
+    recvbuf = Array{T,N}(undef, size(sendbuf))
+    Allreduce!(sendbuf, recvbuf, op, comm)
+end
+
 function Allreduce(obj::T, op::Union{Op,Function}, comm::Comm) where T
     objref = Ref(obj)
     outref = Ref{T}()

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1014,6 +1014,7 @@ function Reduce_in_place!(buf::MPIBuffertype{T}, count::Integer,
                           op::Op, root::Integer,
                           comm::Comm) where T
     if Comm_rank(comm) == root
+        @assert length(buf) >= count
         ccall(MPI_REDUCE, Nothing,
               (Ptr{T}, Ptr{T}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint},
                Ref{Cint}, Ref{Cint}),

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -926,7 +926,7 @@ and stores the result in `recvbuf` on the process of rank `root`.
 
 On non-root processes recvbuf is ignored.
 
-To perform the reduction in place refer to Reduce_in_place!
+To perform the reduction in place refer to `Reduce_in_place!`
 """
 function Reduce!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
                  count::Integer, op::Op, root::Integer,
@@ -956,7 +956,7 @@ Performs `op` reduction on the buffer `sendbuf` and stores the result in
 
 On non-root processes recvbuf is ignored.
 
-To perform the reduction in place refer to Reduce_in_place!
+To perform the reduction in place refer to `Reduce_in_place!`
 """
 function Reduce!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
                  op::Union{Op, Function}, root::Integer, comm::Comm) where T
@@ -1132,6 +1132,8 @@ include("mpi-op.jl")
 Splits the buffer `sendbuf` in the `root` process into `Comm_size(comm)` chunks
 and sends the j-th chunk to the process of rank j into the `recvbuf` buffer,
 which must be of length at least `count`.
+
+To perform the reduction in place refer to `Scatter_in_place!`
 """
 function Scatter!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
                   count::Integer, root::Integer,
@@ -1264,6 +1266,8 @@ end
 Each process sends the first `count` elements of the buffer `sendbuf` to the
 `root` process. The `root` process stores elements in rank order in the buffer
 buffer `recvbuf`.
+
+To perform the reduction in place refer to `Gather_in_place!`
 """
 function Gather!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
                 count::Integer, root::Integer, comm::Comm) where T
@@ -1336,17 +1340,16 @@ function Gather_in_place!(buf::MPIBuffertype{T}, count::Integer, root::Integer,
     buf
 end
 
-
 """
   Allgather!(sendbuf, recvbuf, count, comm)
 
 Each process sends the first `count` elements of `sendbuf` to the
-other processes, who store the results in rank order into 
+other processes, who store the results in rank order into
 `recvbuf`.
 
-If `sendbuf==MPI.IN_PLACE` the input data is assumed to be in the 
-area of `recvbuf` where the process would receive it's own 
-contribution. 
+If `sendbuf==MPI.IN_PLACE` the input data is assumed to be in the
+area of `recvbuf` where the process would receive it's own
+contribution.
 """
 function Allgather!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
                     count::Integer, comm::Comm) where T
@@ -1368,7 +1371,7 @@ function Allgather!(buf::MPIBuffertype{T}, count::Integer,
 end
 
 """
-  Allgather!(sendbuf, recvbuf, count, comm)
+  Allgather(sendbuf, recvbuf, count, comm)
 
 Each process sends the first `count` elements of `sendbuf` to the
 other processes, who store the results in rank order allocating

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -978,9 +978,9 @@ end
 
 function Reduce(sendbuf::Array{T,N}, op::Union{Op,Function},
     root::Integer, comm::Comm) where {T,N}
-    #isroot = Comm_rank(comm) == root
-    #recvbuf = Array{T,N}(undef, isroot ? count : 0)
-    Reduce(sendbuf, length(sendbuf), op, root, comm)
+    isroot = Comm_rank(comm) == root
+    recvbuf = Array{T,N}(undef, isroot ? size(sendbuf) : Tuple(zeros(Int, ndims(sendbuf))))
+    Reduce!(sendbuf, recvbuf, length(sendbuf), op, root, comm)
 end
 
 function Reduce(sendbuf::SubArray{T}, op::Union{Op,Function}, root::Integer, comm::Comm) where T

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1076,6 +1076,13 @@ function Allreduce(obj::T, op::Union{Op,Function}, comm::Comm) where T
     outref[]
 end
 
+# Deprecation warning for lowercase allreduce that was used until v. 0.7.2
+# Should be removed at some point in the future
+function allreduce(sendbuf::MPIBuffertype{T}, op::Union{Op,Function},
+                   comm::Comm) where T
+    @warn "`allreduce` is deprecated, use `Allreduce` instead."
+    Allreduce(sendbuf, op, comm)
+end
 
 include("mpi-op.jl")
 

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1032,7 +1032,7 @@ end
 # Convert to MPI.Op
 Reduce_in_place!(buf::MPIBuffertype{T}, count::Integer, op::Function,
                  root::Integer, comm::Comm) where T =
-                    Reduce_in_place(buf, count, user_op(op), root, comm)
+                    Reduce_in_place!(buf, count, user_op(op), root, comm)
 
 """
     Allreduce!(sendbuf, recvbuf, count, op, comm)
@@ -1087,7 +1087,7 @@ the results on all the processes in the group.
 Equivalent to calling `Allreduce!(MPI.IN_PLACE, buf, op, comm)`
 """
 function Allreduce!(buf::MPIBuffertype{T}, op::Union{Op, Function}, comm::Comm) where T
-    Allreduce!(MPI.IN_PLACE, buf, op, comm)
+    Allreduce!(MPI.IN_PLACE, buf, length(buf), op, comm)
 end
 
 """
@@ -1104,7 +1104,7 @@ end
 
 function Allreduce(sendbuf::Array{T, N}, op::Union{Op, Function}, comm::Comm) where {T, N}
     recvbuf = Array{T,N}(undef, size(sendbuf))
-    Allreduce!(sendbuf, recvbuf, op, comm)
+    Allreduce!(sendbuf, recvbuf, length(sendbuf), op, comm)
 end
 
 function Allreduce(obj::T, op::Union{Op,Function}, comm::Comm) where T
@@ -1177,7 +1177,7 @@ function Scatter_in_place!(buf::MPIBuffertype{T},
 end
 
 """
-    Scatter!(sendbuf, recvbuf, count, root, comm)
+    Scatter(sendbuf, recvbuf, count, root, comm)
 
 Splits the buffer `sendbuf` in the `root` process into `Comm_size(comm)` chunks
 and sends the j-th chunk to the process of rank j, allocating the output buffer.

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -947,13 +947,17 @@ function Reduce(object::T, op::Union{Op,Function}, root::Integer, comm::Comm) wh
 end
 
 """
-  Allreduce!(sendbuf, recvbuf, count, op, comm)
+    Allreduce!(sendbuf, recvbuf, count, op, comm)
 
-Performs `op` reduction on the first `count` elements of the buffer 
-`sendbuf` storing the result in `recvbuf`. 
+Performs `op` reduction on the first `count` elements of the buffer
+`sendbuf` storing the result in the `recvbuf` of all processes in the
+group.
+
+All-reduce is equivalent to a Reduce operation followed by a Broadcast, but
+can lead to better performance.
 
 If `sendbuf==MPI.IN_PLACE` the data is read from `recvbuf` and then overwritten
-with the results. 
+with the results.
 """
 function Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
                    count::Integer, op::Op, comm::Comm) where T
@@ -970,13 +974,16 @@ Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
     Allreduce!(sendbuf, recvbuf, count, user_op(opfunc), comm)
 
 """
-  Allreduce!(sendbuf, recvbuf, op, comm)
+    Allreduce!(sendbuf, recvbuf, op, comm)
 
-Performs `op` reduction on the buffer `sendbuf`, storing the 
-result in `recvbuf`. 
+Performs `op` reduction on the buffer `sendbuf` storing the result in the
+`recvbuf` of all processes in the group.
+
+All-reduce is equivalent to a Reduce operation followed by a Broadcast, but
+can lead to better performance.
 
 If `sendbuf==MPI.IN_PLACE` the data is read from `recvbuf` and then overwritten
-with the results. 
+with the results.
 """
 function Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
                    op::Union{Op,Function}, comm::Comm) where T
@@ -984,10 +991,10 @@ function Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
 end
 
 """
-  Allreduce!(buf, op, comm)
+    Allreduce!(buf, op, comm)
 
-Performs `op` reduction in place on the buffer `sendbuf`, overwriting it with the 
-results.
+Performs `op` reduction in place on the buffer `sendbuf`, overwriting it with
+the results on all the processes in the group.
 
 Equivalent to calling `Allreduce!(MPI.IN_PLACE, buf, op, comm)`
 """
@@ -995,6 +1002,12 @@ function Allreduce!(buf::MPIBuffertype{T}, op::Union{Op, Function}, comm::Comm) 
     Allreduce!(MPI.IN_PLACE, buf, op, comm)
 end
 
+"""
+    Allreduce(sendbuf, op, comm)
+
+Performs `op` reduction on the buffer `sendbuf`, allocating and returning the
+output buffer in all processes of the group.
+"""
 function Allreduce(sendbuf::MPIBuffertype{T}, op::Union{Op,Function}, comm::Comm) where T
 
   recvbuf = similar(sendbuf)

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -972,7 +972,7 @@ an output buffer allocated on the process of rank `root`.
 function Reduce(sendbuf::MPIBuffertype{T}, count::Integer,
                 op::Union{Op, Function}, root::Integer, comm::Comm) where T
     isroot = Comm_rank(comm) == root
-    recvbuf = typeof(sendbuf)(undef, isroot ? count : 0) #Array{T}(undef, isroot ? count : 0)
+    recvbuf = Array{T}(undef, isroot ? count : 0)
     Reduce!(sendbuf, recvbuf, count, op, root, comm)
 end
 

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1260,8 +1260,7 @@ contribution.
 """
 function Allgather!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
                     count::Integer, comm::Comm) where T
-    #FIXME enable the assert
-    #@assert length(recvbuf) == Comm_size(comm)*count
+    @assert length(recvbuf) >= Comm_size(comm)*count
     ccall(MPI_ALLGATHER, Nothing,
           (Ptr{T}, Ref{Cint}, Ref{Cint}, Ptr{T}, Ref{Cint}, Ref{Cint}, Ref{Cint}, Ref{Cint}),
           sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), comm.val, 0)

--- a/src/mpi-op.jl
+++ b/src/mpi-op.jl
@@ -61,7 +61,7 @@ for (f,op) in ((+,SUM), (*,PROD),
     @eval user_op(::$(typeof(f))) = $op
 end
 
-Allreduce!(sendbuf::MPIBuffertype{T}, recvbuf::MPIBuffertype{T},
+Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
            count::Integer, opfunc::Function, comm::Comm) where {T} =
     Allreduce!(sendbuf, recvbuf, count, user_op(opfunc), comm)
 

--- a/src/mpi-op.jl
+++ b/src/mpi-op.jl
@@ -61,10 +61,6 @@ for (f,op) in ((+,SUM), (*,PROD),
     @eval user_op(::$(typeof(f))) = $op
 end
 
-Allreduce!(sendbuf::MPIBuffertypeOrConst{T}, recvbuf::MPIBuffertype{T},
-           count::Integer, opfunc::Function, comm::Comm) where {T} =
-    Allreduce!(sendbuf, recvbuf, count, user_op(opfunc), comm)
-
 Reduce(sendbuf::MPIBuffertype{T}, count::Integer,
        opfunc::Function, root::Integer, comm::Comm) where {T} =
     Reduce(sendbuf, count, user_op(opfunc), root, comm)

--- a/src/mpi-op.jl
+++ b/src/mpi-op.jl
@@ -60,7 +60,3 @@ for (f,op) in ((+,SUM), (*,PROD),
                (&, BAND), (|, BOR), (⊻, BXOR))
     @eval user_op(::$(typeof(f))) = $op
 end
-
-Reduce(sendbuf::MPIBuffertype{T}, count::Integer,
-       opfunc::Function, root::Integer, comm::Comm) where {T} =
-    Reduce(sendbuf, count, user_op(opfunc), root, comm)

--- a/src/win_mpiconstants.jl
+++ b/src/win_mpiconstants.jl
@@ -53,6 +53,8 @@ const MPI_TAG_UB = Int32(1681915906)
 const MPI_UNDEFINED = Int32(-32766)
 const HAVE_MPI_COMM_C2F = false
 
+const MPI_IN_PLACE_VAL = -1
+
 const libmpi = "msmpi.dll"
 
 const MPI_ABORT = (:MPI_ABORT, libmpi)

--- a/test/test_allgather.jl
+++ b/test/test_allgather.jl
@@ -28,6 +28,10 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
 	MPI.Allgather!(A, C, length(A), comm)
 	@test C == map(typ, collect(1:MPI.Comm_size(comm)))
 
+	# Test assertion error
+	C = fill(val, MPI.Comm_size(comm)-1)
+	@test_throws AssertionError MPI.Allgather!(A, C, length(A), comm)
+
 	# Test explicit IN_PLACE
 	A = typ[val]
 	C = fill(val, MPI.Comm_size(comm))

--- a/test/test_allgather.jl
+++ b/test/test_allgather.jl
@@ -19,6 +19,31 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
     C = allgather(A)
     @test typeof(C) === Vector{typ}
     @test C == map(typ, collect(1:MPI.Comm_size(comm)))
+
+    val = typ(MPI.Comm_rank(comm) + 1)
+
+	# Test passing output buffer with set size
+	A = typ[val]
+	C = fill(val, MPI.Comm_size(comm))
+	MPI.Allgather!(A, C, length(A), comm)
+	@test C == map(typ, collect(1:MPI.Comm_size(comm)))
+
+	# Test explicit IN_PLACE
+	A = typ[val]
+	C = fill(val, MPI.Comm_size(comm))
+	C[MPI.Comm_rank(comm)+1] = MPI.Comm_rank(comm) + 1
+	MPI.Allgather!(MPI.IN_PLACE, C, 1, comm)
+	@test typeof(C) === Vector{typ}
+	@test C == map(typ, collect(1:MPI.Comm_size(comm)))
+
+	# Test IN_PLACE
+	A = typ[val]
+	C = fill(val, MPI.Comm_size(comm))
+	C[MPI.Comm_rank(comm)+1] = MPI.Comm_rank(comm) + 1
+	MPI.Allgather!(C, 1, comm)
+	@test typeof(C) === Vector{typ}
+	@test C == map(typ, collect(1:MPI.Comm_size(comm)))
+
 end
 
 MPI.Finalize()

--- a/test/test_allgatherv.jl
+++ b/test/test_allgatherv.jl
@@ -21,6 +21,29 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
     counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
     B = allgatherv_array(A, counts)
     @test B == ones(typ, 3 * div(size,2) + mod(size,2))
+
+    # Test passing the output buffer
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts)-1)
+    @test_throws AssertionError MPI.Allgatherv!(A, B, counts, comm)
+
+    # Test assertion when output size is too small
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts))
+    MPI.Allgatherv!(A, B, counts, comm)
+    @test B == ones(typ, 3 * div(size,2) + mod(size,2))
+
+    # Test explicit MPI_IN_PLACE
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts))
+    start = (cumsum(counts)-counts.+1)[MPI.Comm_rank(comm)+1]
+    len   = counts[MPI.Comm_rank(comm)+1]
+    B[start:(start+len-1)] .= A
+    MPI.Allgatherv!(MPI.IN_PLACE, B, counts, comm)
+    @test B == ones(typ, 3 * div(size,2) + mod(size,2))
 end
 
 MPI.Finalize()

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -8,15 +8,34 @@ comm_size = MPI.Comm_size(MPI.COMM_WORLD)
 send_arr = Int[1, 2, 3]
 
 for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
+
+  # Non allocating version
   recv_arr = zeros(Int, 3)
-
   MPI.Allreduce!(send_arr, recv_arr, op, MPI.COMM_WORLD)
-
   for i=1:3
     @test recv_arr[i] == comm_size*send_arr[i]
   end
 
+  # Assertions when output buffer too small
+  recv_arr = zeros(Int, 2)
+  @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr, op, MPI.COMM_WORLD)
 
+
+  # IN_PLACE 
+  recv_arr = deepcopy(send_arr)
+  MPI.Allreduce!(MPI.IN_PLACE, recv_arr, op, MPI.COMM_WORLD)
+  for i=1:3
+    @test recv_arr[i] == comm_size*send_arr[i]
+  end
+
+  # IN_PLACE 
+  recv_arr = deepcopy(send_arr)
+  MPI.Allreduce!(recv_arr, op, MPI.COMM_WORLD)
+  for i=1:3
+    @test recv_arr[i] == comm_size*send_arr[i]
+  end
+
+  # Allocating version
   val = MPI.Allreduce(2, op, MPI.COMM_WORLD)
   @test val == comm_size*2
 
@@ -26,6 +45,8 @@ for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
     @test length(vals) == 3
     @test eltype(vals) == Int
   end
+
+
 end
 
 MPI.Barrier( MPI.COMM_WORLD )

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -18,7 +18,7 @@ for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
 
   # Assertions when output buffer too small
   recv_arr = zeros(Int, 2)
-  @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr, op, MPI.COMM_WORLD)
+  @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr, 3, op, MPI.COMM_WORLD)
 
 
   # IN_PLACE 

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -39,7 +39,7 @@ for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
   val = MPI.Allreduce(2, op, MPI.COMM_WORLD)
   @test val == comm_size*2
 
-  vals = MPI.allreduce(send_arr, op, MPI.COMM_WORLD)
+  vals = MPI.Allreduce(send_arr, op, MPI.COMM_WORLD)
   for i=1:3
     @test vals[i] == comm_size*send_arr[i]
     @test length(vals) == 3

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -5,48 +5,51 @@ MPI.Init()
 
 comm_size = MPI.Comm_size(MPI.COMM_WORLD)
 
-send_arr = Int[1, 2, 3]
+for typ=[Int]
+    for dims = [1, 2, 3]
+        send_arr = zeros(typ, Tuple(3 for i in 1:dims))
+        send_arr[:] .= 1:length(send_arr)
 
-for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
+        for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
 
-  # Non allocating version
-  recv_arr = zeros(Int, 3)
-  MPI.Allreduce!(send_arr, recv_arr, op, MPI.COMM_WORLD)
-  for i=1:3
-    @test recv_arr[i] == comm_size*send_arr[i]
-  end
+            # Non allocating version
+            recv_arr = zeros(typ, size(send_arr))
+            MPI.Allreduce!(send_arr, recv_arr, op, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test recv_arr[i] == comm_size*send_arr[i]
+            end
 
-  # Assertions when output buffer too small
-  recv_arr = zeros(Int, 2)
-  @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr, 3, op, MPI.COMM_WORLD)
+            # Assertions when output buffer too small
+            recv_arr = zeros(typ, size(send_arr).-1)
+            @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr,
+                                                       length(send_arr),
+                                                        op, MPI.COMM_WORLD)
 
+            recv_arr = deepcopy(send_arr)
+            MPI.Allreduce!(MPI.IN_PLACE, recv_arr, op, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test recv_arr[i] == comm_size*send_arr[i]
+            end
 
-  # IN_PLACE 
-  recv_arr = deepcopy(send_arr)
-  MPI.Allreduce!(MPI.IN_PLACE, recv_arr, op, MPI.COMM_WORLD)
-  for i=1:3
-    @test recv_arr[i] == comm_size*send_arr[i]
-  end
+            # IN_PLACE
+            recv_arr = deepcopy(send_arr)
+            MPI.Allreduce!(recv_arr, op, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test recv_arr[i] == comm_size*send_arr[i]
+            end
 
-  # IN_PLACE 
-  recv_arr = deepcopy(send_arr)
-  MPI.Allreduce!(recv_arr, op, MPI.COMM_WORLD)
-  for i=1:3
-    @test recv_arr[i] == comm_size*send_arr[i]
-  end
+            # Allocating version
+            val = MPI.Allreduce(2, op, MPI.COMM_WORLD)
+            @test val == comm_size*2
 
-  # Allocating version
-  val = MPI.Allreduce(2, op, MPI.COMM_WORLD)
-  @test val == comm_size*2
-
-  vals = MPI.Allreduce(send_arr, op, MPI.COMM_WORLD)
-  for i=1:3
-    @test vals[i] == comm_size*send_arr[i]
-    @test length(vals) == 3
-    @test eltype(vals) == Int
-  end
-
-
+            vals = MPI.Allreduce(send_arr, op, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test vals[i] == comm_size*send_arr[i]
+                @test length(vals) == length(send_arr)
+                @test eltype(vals) == typ
+            end
+        end
+    end
 end
 
 MPI.Barrier( MPI.COMM_WORLD )

--- a/test/test_alltoall.jl
+++ b/test/test_alltoall.jl
@@ -7,6 +7,24 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-a = fill(rank,size)
-@test MPI.Alltoall(a, 1, comm) == collect(0:(size-1))
+for typ in Base.uniontypes(MPI.MPIDatatype)
+
+    # Allocating version
+    a = fill(convert(typ, rank),size)
+    b = MPI.Alltoall(a, 1, comm)
+    @test b == convert.(typ, collect(0:(size-1)))
+
+    # Non Allocating version
+    a = fill(convert(typ, rank),size)
+    b = Array{typ}(undef, size*1)
+    MPI.Alltoall!(a, b, 1, comm)
+    @test b == convert.(typ, collect(0:(size-1)))
+
+    # IN_PLACE version
+    a = fill(convert(typ, rank),size)
+    MPI.Alltoall!(MPI.IN_PLACE, a, 1, comm)
+    @test a == convert.(typ, collect(0:(size-1)))
+
+end
+
 MPI.Finalize()

--- a/test/test_alltoallv.jl
+++ b/test/test_alltoallv.jl
@@ -21,8 +21,19 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
     end
     scounts = convert(Vector{Cint}, collect(1:size))
     rcounts = fill(convert(Cint,rank + 1),size)
+
+    # Allocating version
     C = alltoallv_array(A, scounts, rcounts)
     @test B == C
+
+    # Non Allocating version
+    C = Array{typ}(undef, sum(rcounts))
+    MPI.Alltoallv!(A, C, scounts, rcounts, comm)
+    @test B == C
+
+    # Test assertion on wrong output buffer length
+    C = Array{typ}(undef, sum(rcounts)-1)
+    @test_throws AssertionError MPI.Alltoallv!(A, C, scounts, rcounts, comm)
 end
 
 MPI.Finalize()

--- a/test/test_gather.jl
+++ b/test/test_gather.jl
@@ -3,25 +3,51 @@ using MPI
 
 MPI.Init()
 
-function gather(A, root)
-    comm = MPI.COMM_WORLD
-    C = MPI.Gather(A, root, comm)
-end
-
 comm = MPI.COMM_WORLD
 root = 0
+rank = MPI.Comm_rank(comm)
+sz   = MPI.Comm_size(comm)
+isroot = MPI.Comm_rank(comm) == root
 
 for typ in Base.uniontypes(MPI.MPIDatatype)
+
+    # Allocating
     A = typ[MPI.Comm_rank(comm) + 1]
-    C = gather(A, root)
+    C = MPI.Gather(A, root, comm)
     if MPI.Comm_rank(comm) == root
         @test typeof(C) === Vector{typ}
         @test C == map(typ, collect(1:MPI.Comm_size(comm)))
     end
+
+    # Allocating, object
     A = convert(typ,MPI.Comm_rank(comm) + 1)
-    C = gather(A, root)
+    C = MPI.Gather(A, root, comm)
     if MPI.Comm_rank(comm) == root
         @test typeof(C) === Vector{typ}
+        @test C == map(typ, collect(1:MPI.Comm_size(comm)))
+    end
+
+    # Allocating, explicit length
+    A = typ[MPI.Comm_rank(comm) + 1, 0]
+    C = MPI.Gather(A, 1, root, comm)
+    if MPI.Comm_rank(comm) == root
+        @test typeof(C) === Vector{typ}
+        @test C == map(typ, collect(1:MPI.Comm_size(comm)))
+    end
+
+    # Allocating, view
+    A = typ[MPI.Comm_rank(comm) + 1, 0]
+    C = MPI.Gather(view(A, 1:1), root, comm)
+    if MPI.Comm_rank(comm) == root
+        @test typeof(C) === Vector{typ}
+        @test C == map(typ, collect(1:MPI.Comm_size(comm)))
+    end
+
+    # Non Allocating
+    A = typ[MPI.Comm_rank(comm) + 1]
+    C = Array{typ}(undef, sz)
+    MPI.Gather!(A, C, length(A), root, comm)
+    if MPI.Comm_rank(comm) == root
         @test C == map(typ, collect(1:MPI.Comm_size(comm)))
     end
 end

--- a/test/test_gather.jl
+++ b/test/test_gather.jl
@@ -50,6 +50,17 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
     if MPI.Comm_rank(comm) == root
         @test C == map(typ, collect(1:MPI.Comm_size(comm)))
     end
+
+    # In_place
+    A = typ[rank + 1]
+    B = Array{typ}(undef, sz);
+    B[rank+1] = rank+1
+    C = isroot ? B : A
+    MPI.Gather_in_place!(C, 1, root, comm)
+    if MPI.Comm_rank(comm) == root
+        @test C == map(typ, collect(1:MPI.Comm_size(comm)))
+    end
+
 end
 
 MPI.Finalize()

--- a/test/test_gatherv.jl
+++ b/test/test_gatherv.jl
@@ -44,10 +44,10 @@ for typ in Base.uniontypes(MPI.MPIDatatype)
     start = (cumsum(counts)-counts.+1)[MPI.Comm_rank(comm)+1]
     len   = counts[MPI.Comm_rank(comm)+1]
     B[start:(start+len-1)] .= A
-    #MPI.Gatherv!(MPI.IN_PLACE, B, counts, root, comm)
-    #if rank == root
-    #    @test B == ones(typ, 3 * div(size,2) + mod(size,2))
-    #end
+    MPI.Gatherv_in_place!(B, counts, root, comm)
+    if rank == root
+        @test B == ones(typ, 3 * div(size,2) + mod(size,2))
+    end
 end
 
 

--- a/test/test_gatherv.jl
+++ b/test/test_gatherv.jl
@@ -3,11 +3,6 @@ using MPI
 
 MPI.Init()
 
-function gatherv_array(A, counts::Vector{Cint}, root)
-    comm = MPI.COMM_WORLD
-    B = MPI.Gatherv(A, counts, root, comm)
-end
-
 comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
@@ -19,11 +14,41 @@ Base.one(::Type{Char}) = '\01'
 for typ in Base.uniontypes(MPI.MPIDatatype)
 
     A = ones(typ, mod(rank,2) + 1)
-    counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]
-    B = gatherv_array(A, counts, root)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = MPI.Gatherv(A, counts, root, comm)
     if rank == root
         @test B == ones(typ, 3 * div(size,2) + mod(size,2))
     end
+
+    # Test passing the output buffer
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts)-1)
+    if rank == root
+        @test_throws AssertionError MPI.Gatherv!(A, B, counts, root, comm)
+    end
+
+    # Test assertion when output size is too small
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts))
+    MPI.Gatherv!(A, B, counts, root, comm)
+    if rank == root
+        @test B == ones(typ, 3 * div(size,2) + mod(size,2))
+    end
+
+    # Test explicit MPI_IN_PLACE
+    A = ones(typ, mod(rank,2) + 1)
+    counts = Cint[mod(i,2) + 1 for i in 0:(size-1)]
+    B = ones(typ, sum(counts))
+    start = (cumsum(counts)-counts.+1)[MPI.Comm_rank(comm)+1]
+    len   = counts[MPI.Comm_rank(comm)+1]
+    B[start:(start+len-1)] .= A
+    #MPI.Gatherv!(MPI.IN_PLACE, B, counts, root, comm)
+    #if rank == root
+    #    @test B == ones(typ, 3 * div(size,2) + mod(size,2))
+    #end
 end
+
 
 MPI.Finalize()

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -65,6 +65,11 @@ for typ=[Int]
             val = MPI.Reduce(2, op, root, MPI.COMM_WORLD)
             @test rank == root ? val == comm_size*2 : true
 
+            # Allocating, Subarray
+            A = typ[1,2]
+            val = MPI.Reduce(view(A, 2:2), op, root, MPI.COMM_WORLD)
+            @test rank == root ? val[1] == comm_size*2 : true
+
             vals = MPI.Reduce(send_arr, op, root, MPI.COMM_WORLD)
             for i=1:length(recv_arr)
                 @test rank == root ? vals[i] == comm_size*send_arr[i] : true

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -54,6 +54,13 @@ for typ=[Int]
                                                                 op, root,
                                                                 MPI.COMM_WORLD)
 
+            # IN_PLACE
+            recv_arr = deepcopy(send_arr)
+            MPI.Reduce_in_place!(recv_arr, length(recv_arr), op, root, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test rank == root ? recv_arr[i] == comm_size*send_arr[i] : true
+            end
+
             # Allocating version
             val = MPI.Reduce(2, op, root, MPI.COMM_WORLD)
             @test rank == root ? val == comm_size*2 : true

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -6,25 +6,68 @@ using Compat.LinearAlgebra
 MPI.Init()
 
 comm = MPI.COMM_WORLD
-size = MPI.Comm_size(comm)
+sz = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 
-root = size-1
-val = rank == root ? sum(0:size-1) : nothing
+root = sz-1
+val = rank == root ? sum(0:sz-1) : nothing
 @test MPI.Reduce(rank, MPI.SUM, root, comm) == val
 
-val = rank == root ? size-1 : nothing
+val = rank == root ? sz-1 : nothing
 @test MPI.Reduce(rank, MPI.MAX, root, comm) == val
 
 val = rank == root ? 0 : nothing
 @test MPI.Reduce(rank, MPI.MIN, root, comm) == val
 
-val = rank == root ? size : nothing
+val = rank == root ? sz : nothing
 @test MPI.Reduce(1, +, root, comm) == val
 
 mesg = collect(1.0:5.0)
 sum_mesg = MPI.Reduce(mesg, MPI.SUM, root, comm)
-sum_mesg = rank == root ? sum_mesg : size*mesg
-@test isapprox(norm(sum_mesg-size*mesg), 0.0)
+sum_mesg = rank == root ? sum_mesg : sz*mesg
+@test isapprox(norm(sum_mesg-sz*mesg), 0.0)
 
+
+comm_size = MPI.Comm_size(MPI.COMM_WORLD)
+
+send_arr = Int[1, 2, 3]
+
+for typ=[Int]
+    for dims = [1, 2, 3]
+        send_arr = zeros(typ, Tuple(3 for i in 1:dims))
+        send_arr[:] .= 1:length(send_arr)
+
+        for op in (MPI.SUM, +, (x,y) -> 2x+y-x)
+
+            # Non allocating version
+            recv_arr = zeros(typ, size(send_arr))
+            MPI.Reduce!(send_arr, recv_arr, op, root, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test rank == root ? recv_arr[i] == comm_size*send_arr[i] : true
+            end
+
+            # Assertions when output buffer too small
+            recv_arr = zeros(typ, size(send_arr).-1)
+            rank == root && @test_throws AssertionError MPI.Reduce!(send_arr,
+                                                                recv_arr,
+                                                                length(send_arr),
+                                                                op, root,
+                                                                MPI.COMM_WORLD)
+
+            # Allocating version
+            val = MPI.Reduce(2, op, root, MPI.COMM_WORLD)
+            @test rank == root ? val == comm_size*2 : true
+
+            vals = MPI.Reduce(send_arr, op, root, MPI.COMM_WORLD)
+            for i=1:length(recv_arr)
+                @test rank == root ? vals[i] == comm_size*send_arr[i] : true
+                @test rank == root ? length(vals) == length(send_arr) : true
+                @test rank == root ? eltype(vals) == typ : true
+            end
+        end
+    end
+end
+
+
+MPI.Barrier( MPI.COMM_WORLD )
 MPI.Finalize()

--- a/test/test_scatter.jl
+++ b/test/test_scatter.jl
@@ -22,9 +22,35 @@ A = collect(1:MPI.Comm_size(comm))
 B = scatter_array(A, root)
 @test B[1] == MPI.Comm_rank(comm) + 1
 for typ in Base.uniontypes(MPI.MPIDatatype)
+
+    # Allocating version
     global A = convert(Vector{typ},collect(1:MPI.Comm_size(comm)))
     global B = scatter_array(A, root)
     @test B[1] == convert(typ,MPI.Comm_rank(comm) + 1)
+
+    # Non Allocating version
+    A = convert(Vector{typ},collect(1:MPI.Comm_size(comm)))
+    if MPI.Comm_rank(comm) == root
+        B = copy(A)
+    else
+        B = Array{typ}(undef, 1)
+    end
+    MPI.Scatter!(A, B, 1, root, comm)
+    @test B[1] == convert(typ,MPI.Comm_rank(comm) + 1)
+
+    # In place version
+    A = convert(Vector{typ},collect(1:MPI.Comm_size(comm)))
+    if MPI.Comm_rank(comm) == root
+        B = copy(A)
+    else
+        B = Array{typ}(undef, 1)
+    end
+    MPI.Scatter_in_place!(B, 1, root, comm)
+    @test B[1] == convert(typ,MPI.Comm_rank(comm) + 1)
+
+    # Test throwing
+    B = Array{typ}(undef, 0)
+    @test_throws AssertionError MPI.Scatter!(A, B, 1, root, comm)
 end
 
 MPI.Finalize()

--- a/test/test_scatterv.jl
+++ b/test/test_scatterv.jl
@@ -19,16 +19,36 @@ comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)
 root = 0
-
+isroot = (MPI.Comm_rank(comm) == root)
 # Defining this to make ones work for Char
 Base.one(::Type{Char}) = '\01'
 
 for typ in Base.uniontypes(MPI.MPIDatatype)
 
+    # Allocating
     A = ones(typ, 3 * div(size,2) + mod(size,2))
     counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]
     B = scatterv_array(A, counts, root)
     @test B == ones(typ, mod(rank,2) + 1)
+
+    # Non Allocating
+    A = ones(typ, 3 * div(size,2) + mod(size,2))
+    counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]
+    B = Array{typ}(undef, counts[MPI.Comm_rank(comm) + 1])
+    MPI.Scatterv!(A, B, counts, root, comm)
+    @test B == ones(typ, mod(rank,2) + 1)
+
+    # IN_PLACE
+    counts = Cint[ mod(i,2) + 1 for i in 0:(size-1)]
+    A = ones(typ, 3 * div(size,2) + mod(size,2))
+    if isroot
+        B = deepcopy(A)
+    else
+        B = Array{typ}(undef, counts[MPI.Comm_rank(comm) + 1])
+    end
+    MPI.Scatterv_in_place!(B, counts, root, comm)
+    isroot  && @test B == A
+    !isroot && @test B == ones(typ, mod(rank,2) + 1)
 end
 
 MPI.Finalize()


### PR DESCRIPTION
(This is a fixed [#230](https://github.com/JuliaParallel/MPI.jl/pull/230).)

Hi, 

I would like to implement non allocating versions for several MPI operations, as well as support for  MPI_IN_PLACE.

This PR defines a new variable, MPI.IN_PLACE of type `Ptr{Cvoid}`, and refactors the code of the following functions to implement a non-allocating version which accepts `MPI.IN_PLACE` if supported by MPI.

- [x] Allreduce
- [x] Allgather
- [x] Allgatherv
- [x] Alltoall
- [x] Alltoallv

For the following functions, calling `MPI_IN_PLACE` is slightly less straightforward, so I felt that the best way to support it would be to create a new method called `XXX_in_place!`. 
If you think this is not a good idea, feel free to propose a better solution.
- [x] Scatter
- [x] Reduce
- [x] Gather
- [x] Gatherv

The last three functions listed above are still missing, and if you are interested I'll be glad to include them in the PR.

I believe all CI test failures on OpenMPI-MacOS and 32bit-Windows to be unrelated to the PR. 

--
Filippo