### PR TITLE
Work around a type issue on Windows 32 bit

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -61,7 +61,7 @@ function __init__()
 
     # Note: older versions of OpenMPI (e.g. the version on Travis) do not
     # define MPI_CHAR and MPI_*INT*_T for Fortran, so we don't use them (yet).
-    for (T,mpiT) in (Char => MPI_INTEGER4,   # => MPI_WCHAR, (note: wchar_t is 16 bits in Windows)
+    for (T,mpiT) in (
                      Int8 => MPI_INTEGER1,   # => MPI_INT8_T,
                      UInt8 => MPI_INTEGER1,  # => MPI_UINT8_T,
                      Int16 => MPI_INTEGER2,  # => MPI_INT16_T,
@@ -73,7 +73,14 @@ function __init__()
                      Float32 => MPI_REAL4,
                      Float64 => MPI_REAL8,
                      ComplexF32 => MPI_COMPLEX8,
-                     ComplexF64 => MPI_COMPLEX16)
+                     ComplexF64 => MPI_COMPLEX16,
+                     Char => MPI_INTEGER4    # => MPI_WCHAR, (note: wchar_t is
+                                             #                16 bits in Windows)
+                                             # Place this last so this entry
+                                             # is no in the inverse map which
+                                             # seems to cause issues in 32 bit
+                                             # Windows.
+                    )
 
         recordDataType(T, mpiT)
     end


### PR DESCRIPTION
As @simonbyrne pointed out, it seems that
https://github.com/JuliaParallel/MPI.jl/blob/bc2e97949aae507414c96c4596961f0d05abc3e5/src/mpi-op.jl#L27
returns a `Char` on Windows 32 bit when it should (?) be an `Int32`.

To avoid this we make sure the inverse map doesn't contain the value `Char`.