### PR TITLE
JULIA_MPI_Fortran_INCLUDE_PATH doesn't need -I

### DIFF
--- a/docs/src/installing.md
+++ b/docs/src/installing.md
@@ -43,7 +43,7 @@ You can set these variables either in your shell startup file, or e.g. via your
 `~/.juliarc` file. Here is an example:
 ```Julia
 ENV["JULIA_MPI_C_LIBRARIES"] = "-L/opt/local/lib/openmpi-gcc5 -lmpi"
-ENV["JULIA_MPI_Fortran_INCLUDE_PATH"] = "-I/opt/local/include"
+ENV["JULIA_MPI_Fortran_INCLUDE_PATH"] = "/opt/local/include"
 ENV["JULIA_MPI_Fortran_LIBRARIES"] = "-L/opt/local/lib/openmpi-gcc5 -lmpi_usempif08 -lmpi_mpifh -lmpi"
 ```
 


### PR DESCRIPTION
JULIA_MPI_Fortran_INCLUDE_PATH is a path to the include directory for mpif90 (not a flag passed to the compiler), so it doesn't need the "-I" at the start