### PR TITLE
move Info to C interface

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -11,6 +11,11 @@ end
     isfile(depfile) || error("MPI not properly installed. Please run Pkg.build(\"MPI\")")
 end
 
+macro mpichk(expr)
+    esc(expr)
+end
+
+
 include(depfile)
 
 include("mpi-base.jl")

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1731,11 +1731,11 @@ function Comm_get_parent()
 end
 
 function Comm_spawn(command::String, argv::Vector{String}, nprocs::Integer,
-                    comm::Comm, errors = Vector{Cint}(undef, nprocs))
+                    comm::Comm, errors = Vector{Cint}(undef, nprocs); kwargs...)
     c_intercomm = Ref{CComm}()
     ccall((:MPI_Comm_spawn, libmpi), Nothing,
          (Cstring, Ptr{Ptr{Cchar}}, Cint, CInfo, Cint, CComm, Ref{CComm}, Ptr{Cint}),
-         command, argv, nprocs, CInfo(INFO_NULL), 0, CComm(comm), c_intercomm, errors)
+         command, argv, nprocs, Info(kwargs...), 0, CComm(comm), c_intercomm, errors)
     return Comm(c_intercomm[])
 end
 

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -1832,10 +1832,6 @@ if HAVE_MPI_COMM_C2F
     function Comm(ccomm::CComm)
       Comm(ccall((:MPI_Comm_c2f, libmpi), Cint, (CComm,), ccomm))
     end
-    # Assume info is treated the same way
-    function CInfo(finfo::Cint)
-      ccall((:MPI_Info_f2c, libmpi), CInfo, (Cint,), finfo)
-    end
 elseif sizeof(CComm) == sizeof(Cint)
     # in MPICH, both C and Fortran use identical Cint comm handles
     # and MPI_Comm_c2f is not provided.
@@ -1844,9 +1840,6 @@ elseif sizeof(CComm) == sizeof(Cint)
     end
     function Comm(ccomm::CComm)
       Comm(reinterpret(Cint, ccomm))
-    end
-    function CInfo(finfo::Cint)
-      reinterpret(CInfo, finfo)
     end
 else
     @warn("No MPI_Comm_c2f found - conversion to/from MPI.CComm will not work")

--- a/src/mpi-base.jl
+++ b/src/mpi-base.jl
@@ -206,6 +206,9 @@ function Init()
     end
     ccall(MPI_INIT, Nothing, (Ref{Cint},), 0)
     atexit(refcount_dec)
+
+    # initialise constants
+    INFO_NULL.cinfo = CInfo(MPI_INFO_NULL)
 end
 
 """
@@ -1830,11 +1833,8 @@ if HAVE_MPI_COMM_C2F
       Comm(ccall((:MPI_Comm_c2f, libmpi), Cint, (CComm,), ccomm))
     end
     # Assume info is treated the same way
-    function CInfo(info::Info)
-      ccall((:MPI_Info_f2c, libmpi), CInfo, (Cint,), info.val)
-    end
-    function Info(cinfo::CInfo)
-      Info(ccall((:MPI_Info_c2f, libmpi), Cint, (CInfo,), cinfo))
+    function CInfo(finfo::Cint)
+      ccall((:MPI_Info_f2c, libmpi), CInfo, (Cint,), finfo)
     end
 elseif sizeof(CComm) == sizeof(Cint)
     # in MPICH, both C and Fortran use identical Cint comm handles
@@ -1845,11 +1845,8 @@ elseif sizeof(CComm) == sizeof(Cint)
     function Comm(ccomm::CComm)
       Comm(reinterpret(Cint, ccomm))
     end
-    function CInfo(info::Info)
-      reinterpret(CInfo, info.val)
-    end
-    function Info(cinfo::CInfo)
-      Info(reinterpret(Cint, cinfo))
+    function CInfo(finfo::Cint)
+      reinterpret(CInfo, finfo)
     end
 else
     @warn("No MPI_Comm_c2f found - conversion to/from MPI.CComm will not work")

--- a/test/test_info.jl
+++ b/test/test_info.jl
@@ -5,12 +5,12 @@ MPI.Init()
 
 info = MPI.Info()
 @test typeof(info) == MPI.Info
-@test info.val == MPI.MPI_INFO_NULL
+@test info.cinfo == MPI.CInfo(MPI.MPI_INFO_NULL)
 
 testinfo(;kwargs...) = MPI.Info(kwargs...)
 
 info = testinfo(foo="fast", bar=true, baz=[10, -2])
-@test info.val != MPI.MPI_INFO_NULL
+@test info.cinfo !=  MPI.CInfo(MPI.MPI_INFO_NULL)
 
 @test length(info) == 3
 @test info[:foo] == "fast"
@@ -22,6 +22,7 @@ delete!(info, :bar)
 @test_throws KeyError info[:bar]
 
 MPI.free(info)
-@test info.val == MPI.MPI_INFO_NULL
+@test info.cinfo ==  MPI.CInfo(MPI.MPI_INFO_NULL)
 
 MPI.Finalize()
+@test MPI.Finalized()


### PR DESCRIPTION
This avoids relying on the gfortran ABI for strings. Also a good test case for moving to the C API generally.