### PR TITLE
Add Universe_size

### DIFF
--- a/deps/consts_msmpi.jl
+++ b/deps/consts_msmpi.jl
@@ -82,6 +82,7 @@ const MPI_TAG_UB = reinterpret(Cint, 0x64400001)
 const MPI_COMM_TYPE_SHARED = Cint(1)
 const MPI_ORDER_C = Cint(56)
 const MPI_ORDER_FORTRAN = Cint(57)
+const MPI_UNIVERSE_SIZE = reinterpret(Cint, 0x64400009)
 
 const MPI_BOTTOM = reinterpret(SentinelPtr, 0)
 const MPI_IN_PLACE = reinterpret(SentinelPtr, -1)

--- a/deps/gen_consts.jl
+++ b/deps/gen_consts.jl
@@ -95,6 +95,7 @@ MPI_Cints = [
     :MPI_COMM_TYPE_SHARED,
     :MPI_ORDER_C,
     :MPI_ORDER_FORTRAN,
+    :MPI_UNIVERSE_SIZE
 ]
 
 MPI_pointers = [

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -101,5 +101,8 @@ function Universe_size(comm::Comm)
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
     @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
         (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, flag)
+    if flag[] == 0
+        error("Attribute MPI_UNIVERSE_SIZE is not attached")
+    end
     unsafe_load(reinterpret(Ptr{Cint}, result[]))
 end

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -100,6 +100,6 @@ function Universe_size(comm::Comm)
     result = Ref(Ptr{Cvoid}(C_NULL))
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
     @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
-        (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, rank)
+        (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, flag)
     unsafe_load(reinterpret(Ptr{Cint}, result[]))
 end

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -95,3 +95,10 @@ function Intercomm_merge(intercomm::Comm, flag::Bool)
     return newcomm
 end
 
+function Universe_size(comm::Comm)
+    rank = Ref{Cint}()
+    result = Ref(Ptr{Cvoid}(C_NULL))
+    @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
+        (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, rank)
+    unsafe_load(reinterpret(Ptr{Cint}, result[]))
+end

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -96,7 +96,7 @@ function Intercomm_merge(intercomm::Comm, flag::Bool)
 end
 
 function Universe_size(comm::Comm)
-    rank = Ref{Cint}()
+    flag = Ref{Cint}()
     result = Ref(Ptr{Cvoid}(C_NULL))
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
     @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -95,14 +95,21 @@ function Intercomm_merge(intercomm::Comm, flag::Bool)
     return newcomm
 end
 
-function universe_size(comm::Comm)
+"""
+    universe_size()
+
+The total number of available slots, or `nothing` if it is not defined. This is determined by the `MPI_UNIVERSE_SIZE` attribute of `COMM_WORLD`.
+
+This is typically dependent on the MPI implementation: for MPICH-based implementations, this is specified by the `-usize` argument. OpenMPI defines a default value based on the number of processes available.
+"""
+function universe_size()
     flag = Ref{Cint}()
-    result = Ref(Ptr{Cvoid}(C_NULL))
+    result = Ref(Ptr{Cint}(C_NULL))
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
     @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
-        (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, flag)
+        (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), MPI.COMM_WORLD, MPI_UNIVERSE_SIZE, result, flag)
     if flag[] == 0
-        error("Attribute MPI_UNIVERSE_SIZE is not attached")
+        return nothing
     end
-    unsafe_load(reinterpret(Ptr{Cint}, result[]))
+    Int(unsafe_load(result[]))
 end

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -95,7 +95,7 @@ function Intercomm_merge(intercomm::Comm, flag::Bool)
     return newcomm
 end
 
-function Universe_size(comm::Comm)
+function universe_size(comm::Comm)
     flag = Ref{Cint}()
     result = Ref(Ptr{Cvoid}(C_NULL))
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -98,6 +98,7 @@ end
 function Universe_size(comm::Comm)
     rank = Ref{Cint}()
     result = Ref(Ptr{Cvoid}(C_NULL))
+    # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
     @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
         (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), comm, MPI_UNIVERSE_SIZE, result, rank)
     unsafe_load(reinterpret(Ptr{Cint}, result[]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,11 @@ function runtests()
 
     nfail = 0
     printstyled("Running MPI.jl tests\n"; color=:white)
+
+    # MPICH doesn't define a MPI_UNIVERSE_SIZE by default
+    env = copy(ENV)
+    env["MPI_UNIVERSE_SIZE"]="4"
+    
     for f in testfiles
         coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
         if f ∈ singlefiles
@@ -41,8 +46,7 @@ function runtests()
         elseif f ∈ juliafiles
             run(`$exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         else
-            run(Cmd(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`,
-                    env=Dict("MPI_UNIVERSE_SIZE"=>"4")))
+            run(Cmd(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`, env=env))
         end
         Base.with_output_color(:green,stdout) do io
             println(io,"\tSUCCESS: $f")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,8 @@ function runtests()
         elseif f ∈ juliafiles
             run(`$exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         else
-            run(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            run(Cmd(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`,
+                    env=Dict("MPI_UNIVERSE_SIZE"=>"4")))
         end
         Base.with_output_color(:green,stdout) do io
             println(io,"\tSUCCESS: $f")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,6 @@ function runtests()
     testdir = dirname(@__FILE__)
     istest(f) = endswith(f, ".jl") && startswith(f, "test_")
     testfiles = sort(filter(istest, readdir(testdir)))
-
     extra_args = []
     @static if !Sys.iswindows()
         if occursin( "OpenRTE", read(`$mpiexec --version`, String))
@@ -34,10 +33,6 @@ function runtests()
 
     nfail = 0
     printstyled("Running MPI.jl tests\n"; color=:white)
-
-    # MPICH doesn't define a MPI_UNIVERSE_SIZE by default
-    env = copy(ENV)
-    env["MPI_UNIVERSE_SIZE"]="4"
     
     for f in testfiles
         coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
@@ -46,7 +41,7 @@ function runtests()
         elseif f ∈ juliafiles
             run(`$exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         else
-            run(Cmd(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`, env=env))
+            run(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         end
         Base.with_output_color(:green,stdout) do io
             println(io,"\tSUCCESS: $f")

--- a/test/test_universe_size.jl
+++ b/test/test_universe_size.jl
@@ -1,0 +1,10 @@
+using Test
+using MPI
+
+MPI.Init()
+
+universe_size = MPI.universe_size(MPI.COMM_WORLD)
+
+@test universe_size >= 1
+
+MPI.Finalize()

--- a/test/test_universe_size.jl
+++ b/test/test_universe_size.jl
@@ -3,8 +3,7 @@ using MPI
 
 MPI.Init()
 
-universe_size = MPI.universe_size(MPI.COMM_WORLD)
-
-@test universe_size >= 1
+usize = MPI.universe_size()
+@test usize === nothing || usize >= 1
 
 MPI.Finalize()


### PR DESCRIPTION
As part of development of MPIExecutor.jl, a package inspired by mpi4py that I'm working on, I need to be able to get the universe size to provide sane defaults.