### PR TITLE
Store full path of libmpi and mpiexec in deps.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -38,14 +38,17 @@ end
 const libmpi = find_library(Sys.iswindows() ? "msmpi.dll" : "libmpi",
                             MPI_LIBRARY_PATH !== nothing ? [MPI_LIBRARY_PATH] : [])
 
-libptr = dlopen_e(libmpi)
-if libmpi == "" || libptr == C_NULL
-    error("No MPI library found")
+if libmpi == ""
+    error("No MPI library found.\nEnsure an MPI implementation is loaded, or set the `JULIA_MPI_PATH` variable.")
 end
-@info "Using MPI library $libmpi"
 
-libpath = dlpath(libptr)
-libsize = filesize(libpath)
+# expand paths
+libmpi = dlpath(libmpi)
+libsize = filesize(libmpi)
+
+mpiexec = Sys.which(mpiexec)
+
+@info "Using MPI library $libmpi"
 
 function Get_version()
     major = Ref{Cint}()

--- a/deps/gen_consts.jl
+++ b/deps/gen_consts.jl
@@ -104,6 +104,7 @@ MPI_pointers = [
     :MPI_STATUSES_IGNORE,
     ]
 
+const libptr = dlopen_e(libmpi)
 
 open("gen_consts.c","w") do f
     print(f,"""


### PR DESCRIPTION
This makes it slightly easier to use on clusters since it avoids the need to "module load mpiXXX" each time it is used, and makes it more robust if the wrong MPI library is loaded.

Also improves the error message if no MPI library is found.