### PR TITLE
Fix `get` call in worker-to-worker establishment MPI Transport

### DIFF
--- a/src/cman.jl
+++ b/src/cman.jl
@@ -282,7 +282,7 @@ function connect(mgr::MPIManager, pid::Int, config::WorkerConfig)
         config.connect_at = to_rank
         return start_send_event_loop(mgr, to_rank)
     else
-        return start_send_event_loop(mgr, get(config.connect_at))
+        return start_send_event_loop(mgr, config.connect_at)
     end
 end
 

--- a/test/test_cman_mpi.jl
+++ b/test/test_cman_mpi.jl
@@ -30,4 +30,12 @@ s = @distributed (+) for i in 1:10
 end
 @test s == 385
 
+# Communication between workers
+@fetchfrom 2 begin
+    @fetchfrom workers()[end] begin
+        # This call should be allowed to occur
+        @test true
+    end
+end
+
 MPI.stop_main_loop(mgr)


### PR DESCRIPTION
Remotecalls over MPI Transport between workers will call `get` on an integer that represents the target's id. This change removes the `get` and provides a simple test for worker-worker communication. 