### PR TITLE
Modify Test interface

### DIFF
--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -30,8 +30,8 @@ stats = MPI.Waitall!([sreq, rreq])
 @test MPI.Get_tag(stats[2]) == src+32
 @test isapprox(norm(recv_mesg-recv_mesg_expected), 0.0)
 
-global (done, stats) = MPI.Testall!([sreq, rreq])
-@test done
+global statuses = MPI.Testall!([sreq, rreq])
+@test statuses !== nothing
 rreq = nothing
 sreq = nothing
 GC.gc()
@@ -99,8 +99,8 @@ sreq = MPI.Isend(send_mesg, dst, rank+32, comm)
 (inds, stats) = MPI.Waitsome!([sreq, rreq])
 req_arr = [sreq,rreq]
 for i in inds
-    global (done, status) = MPI.Test!( req_arr[i] )
-    @test done
+    global status = MPI.Test!(req_arr[i])
+    @test status !== nothing
 end
 
 rreq = nothing

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -22,11 +22,12 @@ rreq = MPI.Irecv!(recv_mesg, src,  src+32, comm)
 sreq = MPI.Isend(send_mesg, dst, rank+32, comm)
 
 (ind,stats) = MPI.Waitsome!([sreq, rreq])
-(done, ind, stats) = MPI.Testany!([sreq, rreq])
+testanyval = MPI.Testany!([sreq, rreq])
 arr = [sreq,rreq]
-if done
-    (onedone,stats) = MPI.Test!(arr[ind])
-    @test onedone
+if testanyval !== nothing
+    ind,stat = testanyval
+    stats = MPI.Test!(arr[ind])
+    @test stats !== nothing
 end
 
 MPI.Finalize()


### PR DESCRIPTION
This changes the return values of `Test!`/`Testany!`/`Testall!` to match those of the corresponding `Wait` functions, except that they return `nothing` if the requests have not completed. Also, add some more docs.

Note this is a breaking change. I couldn't see a clear way to deprecate this.