### PR TITLE
clarify docs

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -126,10 +126,10 @@ end
 
 Creates a data type describing an `ndims`-dimensional subarray of size `array_of_subsizes`
 of an `ndims-dimensional` array of size `array_of_sizes` and element type `oldtype`,
-starting at the top-left location `array_of_starts`. The parameter `order` refers to
-the memory layout of the parent array, and can be either `MPI_ORDER_C` or
-`MPI_ORDER_FORTRAN`. Note that, like other MPI data types, the type returned by this
-function should be committed with `MPI_Type_commit`.
+starting at the top-left location `array_of_starts`. Zero-based indexing is assumed. The 
+parameter `order` refers to the memory layout of the parent array, and can be either 
+`MPI_ORDER_C` or `MPI_ORDER_FORTRAN`. Note that, like other MPI data types, the type 
+returned by this function should be committed with `MPI_Type_commit`.
 """
 function Type_Create_Subarray(ndims::Integer,
                               array_of_sizes::MPIBuffertype{Cint},


### PR DESCRIPTION
The MPI function `Type_Create_Subarray` assumes zero-based indexing, but this was not specified in the original docs  I wrote for this function a while ago. This PR simply clarifies the documentation.