### PR TITLE
add `sendrecv` wrapper

### DIFF
--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -421,6 +421,39 @@ function Sendrecv(sendbuf, sendcount::Integer, sendtype::Union{Datatype, MPI_Dat
 end
 
 """
+    Sendrecv(sendbuf::MPIBuffertype{T}, sendcount::Integer,   dest::Integer, sendtag::Integer,
+             recvbuf::MPIBuffertype{T}, recvcount::Integer, source::Integer, recvtag::Integer,
+             comm::Comm) where {T}
+
+Complete a blocking send-receive operation over the MPI communicator `comm`, sending 
+`sendcount` elements of type `T` from `sendbuf` to the MPI rank `dest` using message 
+tag `tag`, and receiving `recvcount` elements of the same type from MPI rank `source` into 
+the buffer `recvbuf` using message tag `tag`. Return an MPI.Status object.
+"""
+function Sendrecv(sendbuf::MPIBuffertype{T}, sendcount::Integer,   dest::Integer, sendtag::Integer,
+                  recvbuf::MPIBuffertype{T}, recvcount::Integer, source::Integer, recvtag::Integer,
+                  comm::Comm) where {T}
+    return Sendrecv(sendbuf, sendcount, mpitype(eltype(sendbuf)), dest,   sendtag,
+                    recvbuf, recvcount, mpitype(eltype(recvbuf)), source, recvtag, comm)
+end
+
+"""
+    Sendrecv(sendbuf::AbstractArray{T},   dest::Integer, sendtag::Integer,
+             recvbuf::AbstractArray{T}, source::Integer, recvtag::Integer,
+             comm::Comm) where {T}
+
+Complete a blocking send-receive operation over the MPI communicator `comm`, sending 
+`sendbuf` to the MPI rank `dest` using message tag `tag`, and receiving the buffer 
+`recvbuf` using message tag `tag`. Return an MPI.Status object.
+"""
+function Sendrecv(sendbuf::AbstractArray{T},   dest::Integer, sendtag::Integer,
+                  recvbuf::AbstractArray{T}, source::Integer, recvtag::Integer,
+                  comm::Comm) where {T}
+    return Sendrecv(sendbuf, length(sendbuf), dest,   sendtag,
+                    recvbuf, length(recvbuf), source, recvtag, comm)
+end
+
+"""
     Wait!(req::Request)
 
 Wait on the request `req` to be complete. Returns the `Status` of the request.

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -395,8 +395,8 @@ function irecv(src::Integer, tag::Integer, comm::Comm)
 end
 
 """
-    Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Int, sendtag::Int,
-             recvbuf, recvcount::Integer, recvtype::Datatype, source::Int, recvtag::Int,
+    Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Integer, sendtag::Integer,
+             recvbuf, recvcount::Integer, recvtype::Datatype, source::Integer, recvtag::Integer,
              comm::Comm)
 
 Complete a blocking send-receive operation over the MPI communicator `comm`. Send 
@@ -404,10 +404,10 @@ Complete a blocking send-receive operation over the MPI communicator `comm`. Sen
 tag `tag`, and receive `recvcount` elements of type `recvtype` from MPI rank `source` into 
 the buffer `recvbuf` using message tag `tag`. Return an MPI.Status object.
 """
-function Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Int, sendtag::Int,
-                  recvbuf, recvcount::Integer, recvtype::Datatype, source::Int, recvtag::Int,
+function Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Integer, sendtag::Integer,
+                  recvbuf, recvcount::Integer, recvtype::Datatype, source::Integer, recvtag::Integer,
                   comm::Comm)
-    # int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest,  int sendtag,
+    # int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest,   int sendtag,
     #                        void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag,
     #                    MPI_Comm comm, MPI_Status *status)
     stat_ref = Ref{Status}()

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -394,6 +394,16 @@ function irecv(src::Integer, tag::Integer, comm::Comm)
     (true, MPI.deserialize(buf), stat)
 end
 
+"""
+    Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Int, sendtag::Int,
+             recvbuf, recvcount::Integer, recvtype::Datatype, source::Int, recvtag::Int,
+             comm::Comm)
+
+Complete a blocking send-receive operation over the MPI communicator `comm`. Send 
+`sendcount` elements of type `sendtype` from `sendbuf` to the MPI rank `dest` using message 
+tag `tag`, and receive `recvcount` elements of type `recvtype` from MPI rank `source` into 
+the buffer `recvbuf` using message tag `tag`. Return an MPI.Status object.
+"""
 function Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Int, sendtag::Int,
                   recvbuf, recvcount::Integer, recvtype::Datatype, source::Int, recvtag::Int,
                   comm::Comm)

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -394,6 +394,22 @@ function irecv(src::Integer, tag::Integer, comm::Comm)
     (true, MPI.deserialize(buf), stat)
 end
 
+function Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Int, sendtag::Int,
+                  recvbuf, recvcount::Integer, recvtype::Datatype, source::Int, recvtag::Int,
+                  comm::Comm)
+    # int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest,  int sendtag,
+    #                        void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag,
+    #                    MPI_Comm comm, MPI_Status *status)
+    stat_ref = Ref{Status}()
+    @mpichk ccall((:MPI_Sendrecv, libmpi), Cint,
+                  (MPIPtr, Cint, Datatype, Cint, Cint,
+                   MPIPtr, Cint, Datatype, Cint, Cint,
+                 MPI_Comm, Ptr{Status}),
+                   sendbuf, sendcount, sendtype, dest,   sendtag,
+                   recvbuf, recvcount, recvtype, source, recvtag, comm, stat_ref)
+    return stat_ref[]
+end
+
 """
     Wait!(req::Request)
 

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -395,8 +395,8 @@ function irecv(src::Integer, tag::Integer, comm::Comm)
 end
 
 """
-    Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Integer, sendtag::Integer,
-             recvbuf, recvcount::Integer, recvtype::Datatype, source::Integer, recvtag::Integer,
+    Sendrecv(sendbuf, sendcount::Integer, sendtype::Union{Datatype, MPI_Datatype},   dest::Integer, sendtag::Integer,
+             recvbuf, recvcount::Integer, recvtype::Union{Datatype, MPI_Datatype}, source::Integer, recvtag::Integer,
              comm::Comm)
 
 Complete a blocking send-receive operation over the MPI communicator `comm`. Send 
@@ -404,16 +404,16 @@ Complete a blocking send-receive operation over the MPI communicator `comm`. Sen
 tag `tag`, and receive `recvcount` elements of type `recvtype` from MPI rank `source` into 
 the buffer `recvbuf` using message tag `tag`. Return an MPI.Status object.
 """
-function Sendrecv(sendbuf, sendcount::Integer, sendtype::Datatype,   dest::Integer, sendtag::Integer,
-                  recvbuf, recvcount::Integer, recvtype::Datatype, source::Integer, recvtag::Integer,
+function Sendrecv(sendbuf, sendcount::Integer, sendtype::Union{Datatype, MPI_Datatype},   dest::Integer, sendtag::Integer,
+                  recvbuf, recvcount::Integer, recvtype::Union{Datatype, MPI_Datatype}, source::Integer, recvtag::Integer,
                   comm::Comm)
     # int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest,   int sendtag,
     #                        void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag,
     #                    MPI_Comm comm, MPI_Status *status)
     stat_ref = Ref{Status}()
     @mpichk ccall((:MPI_Sendrecv, libmpi), Cint,
-                  (MPIPtr, Cint, Datatype, Cint, Cint,
-                   MPIPtr, Cint, Datatype, Cint, Cint,
+                  (MPIPtr, Cint, MPI_Datatype, Cint, Cint,
+                   MPIPtr, Cint, MPI_Datatype, Cint, Cint,
                  MPI_Comm, Ptr{Status}),
                    sendbuf, sendcount, sendtype, dest,   sendtag,
                    recvbuf, recvcount, recvtype, source, recvtag, comm, stat_ref)

--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -113,7 +113,12 @@ MPI.Cancel!(sreq)
 @test sreq.buffer == nothing
 GC.gc()
 
+# ---------------------
 # MPI_Sendrecv function
+# ---------------------
+# 
+# send datatype
+# ---------------------
 # We test this function by executing a left shift of the leftmost element in a 1D 
 # cartesian topology with periodic boundary conditions.
 #
@@ -147,6 +152,24 @@ MPI.Sendrecv(a, 1, subarr_send, dest_rank, 0,
              a, 1, subarr_recv,  src_rank, 0, comm_cart)
 
 @test a == [comm_rank, comm_rank, (comm_rank+1) % comm_size]
+
+# send elements from a buffer
+# ---------------------------
+a = Float64[comm_rank, comm_rank, comm_rank]
+b = Float64[       -1,        -1,        -1]
+MPI.Sendrecv(a, 2, dest_rank, 1,
+             b, 2,  src_rank, 1, comm_cart)
+
+@test b == [(comm_rank+1) % comm_size, (comm_rank+1) % comm_size, -1]
+
+# send entire buffer
+# ---------------------------
+a = Float64[comm_rank, comm_rank, comm_rank]
+b = Float64[       -1,        -1,        -1]
+MPI.Sendrecv(a, dest_rank, 2,
+             b,  src_rank, 2, comm_cart)
+
+@test b == [(comm_rank+1) % comm_size, (comm_rank+1) % comm_size, (comm_rank+1) % comm_size]
 
 MPI.Finalize()
 # @test MPI.Finalized()


### PR DESCRIPTION
Tests included. Addresses comments in #234. Docs coming. One question is how to properly type the `sendtype` and `recvtype` argument.