### PR TITLE
Update collective operations

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -49,6 +49,7 @@ makedocs(
             "environment.md",
             "comm.md",
             "pointtopoint.md",
+            "collective.md",
             ],
         "functions.md",
         ]

--- a/docs/src/collective.md
+++ b/docs/src/collective.md
@@ -1,0 +1,59 @@
+# Collective communication
+
+## Synchronization
+
+```@docs
+MPI.Barrier
+```
+
+## Broadcast
+
+```@docs
+MPI.Bcast!
+```
+
+## Gather/Scatter
+
+### Gather
+
+```@docs
+MPI.Allgather!
+MPI.Allgather
+MPI.Allgatherv!
+MPI.Allgatherv
+MPI.Gather!
+MPI.Gather
+MPI.Gatherv!
+MPI.Gatherv
+```
+
+### Scatter
+
+```@docs
+MPI.Scatter!
+MPI.Scatter
+MPI.Scatterv!
+MPI.Scatterv
+```
+
+### All-to-all
+
+```@docs
+MPI.Alltoall!
+MPI.Alltoall
+MPI.Alltoallv!
+MPI.Alltoallv
+```
+
+## Reduce/Scan
+
+```@docs
+MPI.Reduce!
+MPI.Reduce
+MPI.Allreduce!
+MPI.Allreduce
+MPI.Scan!
+MPI.Scan
+MPI.Exscan!
+MPI.Exscan
+```

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -24,69 +24,6 @@ MPI.Get_address
 MPI.mpitype
 ```
 
-
-## Collective communication
-
- Non-Allocating Julia Function         |Allocating Julia Function              | C Function                                                                  | Supports `MPI_IN_PLACE`
- --------------------------------------|---------------------------------------|-----------------------------------------------------------------------------------|-----------
- [`MPI.Allgather!`](@ref)              | [`MPI.Allgather`](@ref)               | [`MPI_Allgather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgather.3.php)    | ✅
- [`MPI.Allgatherv!`](@ref)             | [`MPI.Allgatherv`](@ref)              | [`MPI_Allgatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allgatherv.3.php)  | ✅
- [`MPI.Allreduce!`](@ref)              | [`MPI.Allreduce`](@ref)               | [`MPI_Allreduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Allreduce.3.php)    | ✅
- [`MPI.Alltoall!`](@ref)               | [`MPI.Alltoall`](@ref)                | [`MPI_Alltoall`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoall.3.php)      | ✅
- [`MPI.Alltoallv!`](@ref)              | [`MPI.Alltoallv`](@ref)               | [`MPI_Alltoallv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Alltoallv.3.php)    | ❌
- --                                    | [`MPI.Barrier`](@ref)                 | [`MPI_Barrier`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Barrier.3.php)        | ❌
- [`MPI.Bcast!`](@ref)                  | [`MPI.Bcast!`](@ref)                  | [`MPI_Bcast`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Bcast.3.php)            | ❌
- --                                    | [`MPI.Exscan`](@ref)                  | [`MPI_Exscan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Exscan.3.php)          | ❌
- [`MPI.Gather!`](@ref)                 | [`MPI.Gather`](@ref)                  | [`MPI_Gather`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gather.3.php)          | [`Gather_in_place!`](@ref)
- [`MPI.Gatherv!`](@ref)                | [`MPI.Gatherv`](@ref)                 | [`MPI_Gatherv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Gatherv.3.php)        | [`Gatherv_in_place!`](@ref)
- [`MPI.Reduce!`](@ref)                 | [`MPI.Reduce`](@ref)                  | [`MPI_Reduce`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Reduce.3.php)          | [`Reduce_in_place!`](@ref)
- [`MPI.Scan`](@ref)                    | [`MPI.Scan`](@ref)                    | [`MPI_Scan`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scan.3.php)              | missing
- [`MPI.Scatter!`](@ref)                | [`MPI.Scatter`](@ref)                 | [`MPI_Scatter`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatter.3.php)        | [`Scatter_in_place!`](@ref)
- [`MPI.Scatterv!`](@ref)               | [`MPI.Scatterv`](@ref)                | [`MPI_Scatterv`](https://www.open-mpi.org/doc/v1.10/man3/MPI_Scatterv.3.php)      | [`Scatterv_in_place!`](@ref)
-
-The non-allocating Julia functions map directly to the corresponding MPI operations, after asserting that the size of the output buffer is sufficient to store the result.
-
-The allocating Julia functions allocate an output buffer and then call the non-allocating method.
-
-All-to-all collective communications support in place operations by passing
-`MPI.IN_PLACE` with the same syntax documented by MPI.
-One-to-All communications support it by calling the function `*_in_place!`, calls the MPI functions with the right syntax on root and non root process.
-
-
-```@docs
-MPI.Allgather!
-MPI.Allgather
-MPI.Allgatherv!
-MPI.Allgatherv
-MPI.Allreduce!
-MPI.Allreduce
-MPI.Alltoall!
-MPI.Alltoall
-MPI.Alltoallv!
-MPI.Alltoallv
-MPI.Barrier
-MPI.Bcast!
-MPI.Bcast!
-MPI.Exscan
-MPI.Gather!
-MPI.Gather
-MPI.Gather_in_place!
-MPI.Gatherv!
-MPI.Gatherv
-MPI.Gatherv_in_place!
-MPI.Reduce!
-MPI.Reduce
-MPI.Reduce_in_place!
-MPI.Scan
-MPI.Scan
-MPI.Scatter!
-MPI.Scatter
-MPI.Scatter_in_place!
-MPI.Scatterv!
-MPI.Scatterv
-MPI.Scatterv_in_place!
-```
-
 ## One-sided communication
 
 Julia Function (assuming `import MPI`) | C Function

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -3,6 +3,14 @@
 const DATATYPE_NULL = _Datatype(MPI_DATATYPE_NULL)
 Datatype() = Datatype(DATATYPE_NULL.val)
 
+macro assert_minlength(buffer, count)
+    quote
+        if $(esc(buffer)) isa AbstractArray
+            @assert length($(esc(buffer))) >= $(esc(count))
+        end
+    end
+end
+
 const MPIInteger = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64}
 const MPIFloatingPoint = Union{Float32, Float64}
 const MPIComplex = Union{ComplexF32, ComplexF64}
@@ -24,6 +32,11 @@ function Base.unsafe_convert(::Type{MPIPtr}, x::MPIBuffertype{T}) where T
     ptr = Base.unsafe_convert(Ptr{T}, x)
     reinterpret(MPIPtr, ptr)
 end
+function Base.cconvert(::Type{MPIPtr}, ::Nothing)
+    reinterpret(MPIPtr, C_NULL)
+end
+
+
 
 fieldoffsets(::Type{T}) where {T} = Int[fieldoffset(T, i) for i in 1:length(fieldnames(T))]
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,40 @@
 import Base: @deprecate
 
 ## deprecated in v0.11
+
+@deprecate Reduce_in_place!(buf, count::Integer, op, root::Integer, comm::Comm) begin
+    @assert count == length(buf)
+    Reduce!(buf, op, root, comm)
+end false
+
+@deprecate Scatter_in_place!(buf, count::Integer, root::Integer, comm::Comm) begin
+    if root == MPI.Comm_rank(comm)
+        Scatter!(buf, nothing, count, root, comm)
+    else
+        Scatter!(nothing, buf, count, root, comm)        
+    end
+end false
+
+@deprecate Scatterv_in_place!(buf, counts::Vector, root::Integer, comm::Comm) begin
+    if root == MPI.Comm_rank(comm)
+        Scatterv!(buf, nothing, counts, root, comm)
+    else
+        Scatterv!(nothing, buf, counts, root, comm)
+    end
+end false
+
+@deprecate Gather_in_place!(buf, count::Integer, root::Integer, comm::Comm) begin
+    if root == MPI.Comm_rank(comm)
+        Gather!(nothing, buf, count, root, comm)
+    else
+        Gather!(buf, nothing, count, root, comm)
+    end
+end false    
+
+@deprecate Gatherv_in_place!(buf, counts::Vector{Cint}, root::Integer, comm::Comm) begin
+    if root == MPI.Comm_rank(comm)
+        Gatherv!(nothing, buf, counts, root, comm)
+    else
+        Gatherv!(buf, nothing, counts, root, comm)
+    end
+end false    

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -34,12 +34,7 @@ for T = [Int]
             recv_arr = ArrayType{T}(undef, size(send_arr).-1)
             @test_throws AssertionError MPI.Allreduce!(send_arr, recv_arr,
                                                        length(send_arr),
-                                                        op, MPI.COMM_WORLD)
-
-            recv_arr = copy(send_arr)
-            MPI.Allreduce!(MPI.IN_PLACE, recv_arr, op, MPI.COMM_WORLD)
-            @test recv_arr == comm_size .* send_arr
-
+                                                       op, MPI.COMM_WORLD)
             # IN_PLACE
             recv_arr = copy(send_arr)
             MPI.Allreduce!(recv_arr, op, MPI.COMM_WORLD)

--- a/test/test_gather.jl
+++ b/test/test_gather.jl
@@ -62,7 +62,11 @@ for T in Base.uniontypes(MPI.MPIDatatype)
     if isroot
         A = ArrayType{T}(fill(T(rank+1), 4*sz))
     end
-    MPI.Gather_in_place!(A, 4, root, comm)
+    if root == MPI.Comm_rank(comm)
+        MPI.Gather!(nothing, A, 4, root, comm)
+    else
+        MPI.Gather!(A, nothing, 4, root, comm)
+    end
     if isroot
         @test A == ArrayType{T}(repeat(1:sz, inner=4))
     end

--- a/test/test_gatherv.jl
+++ b/test/test_gatherv.jl
@@ -42,7 +42,11 @@ for T in Base.uniontypes(MPI.MPIDatatype)
 
     # Test explicit MPI_IN_PLACE
     B = ArrayType(fill(T(rank), sum(counts)))
-    MPI.Gatherv_in_place!(B, counts, root, comm)
+    if root == MPI.Comm_rank(comm)
+        MPI.Gatherv!(nothing, B, counts, root, comm)
+    else
+        MPI.Gatherv!(B, nothing, counts, root, comm)
+    end
     if isroot
         @test B == ArrayType{T}(check)
     end

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -20,12 +20,15 @@ isroot = rank == root
 
 val = isroot ? sum(0:sz-1) : nothing
 @test MPI.Reduce(rank, MPI.SUM, root, comm) == val
+@test MPI.Reduce(rank, +, root, comm) == val
 
 val = isroot ? sz-1 : nothing
 @test MPI.Reduce(rank, MPI.MAX, root, comm) == val
+@test MPI.Reduce(rank, max, root, comm) == val
 
 val = isroot ? 0 : nothing
 @test MPI.Reduce(rank, MPI.MIN, root, comm) == val
+@test MPI.Reduce(rank, min, root, comm) == val
 
 val = isroot ? sz : nothing
 @test MPI.Reduce(1, +, root, comm) == val
@@ -68,7 +71,7 @@ for T = [Int]
             
             # IN_PLACE
             recv_arr = copy(send_arr)
-            MPI.Reduce_in_place!(recv_arr, length(recv_arr), op, root, MPI.COMM_WORLD)
+            MPI.Reduce!(recv_arr, op, root, MPI.COMM_WORLD)
             if isroot
                 @test recv_arr == sz .* send_arr
             end

--- a/test/test_scatter.jl
+++ b/test/test_scatter.jl
@@ -31,7 +31,11 @@ for T in Base.uniontypes(MPI.MPIDatatype)
 
     # In place version
     B = isroot ? copy(A) : ArrayType{T}(undef, 1)
-    MPI.Scatter_in_place!(B, 1, root, comm)
+    if root == MPI.Comm_rank(comm)
+        MPI.Scatter!(B, nothing, 1, root, comm)
+    else
+        MPI.Scatter!(nothing, B, 1, root, comm)
+    end
     @test Array(B)[1] == T(rank+1)
 
     # Test throwing

--- a/test/test_scatterv.jl
+++ b/test/test_scatterv.jl
@@ -34,7 +34,11 @@ for T in Base.uniontypes(MPI.MPIDatatype)
 
     # IN_PLACE
     B = isroot ? copy(A) : ArrayType{T}(undef, counts[rank+1])
-    MPI.Scatterv_in_place!(B, counts, root, comm)
+    if root == MPI.Comm_rank(comm)
+        MPI.Scatterv!(B, nothing, counts, root, comm)
+    else
+        MPI.Scatterv!(nothing, B, counts, root, comm)
+    end
     if isroot
         @test B == A
     else


### PR DESCRIPTION
- Remove explicit `XXX_in_place!` functions, in favour of adding methods to existing mutating functions where behaviour is consistent across all ranks (e.g. `Reduce!`) or requiring branches where root behaviour is special (e.g. `Gather!`/`Scatter!`).
- Make checks and functions more consistent
- Improve docs, move to their own page