### PR TITLE
Add Buffer type, improve Datatype handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.11.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -12,8 +13,8 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-julia = "1"
 Requires = "~0.5"
+julia = "1"
 
 [extras]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"

--- a/deps/consts_msmpi.jl
+++ b/deps/consts_msmpi.jl
@@ -1,5 +1,9 @@
 # From https://github.com/microsoft/Microsoft-MPI/blob/v10.0/src/include/mpi.h
 
+const MPI_Aint   = Int
+const MPI_Offset = Int64
+const MPI_Count  = Int64
+
 for T in [:MPI_Comm, :MPI_Info, :MPI_Win, :MPI_Request, :MPI_Op, :MPI_Datatype]
     @eval begin
         primitive type $T 32 end

--- a/deps/gen_consts.jl
+++ b/deps/gen_consts.jl
@@ -125,6 +125,10 @@ int main(int argc, char *argv[]) {
     fprintf(fptr, "# Do not edit\\n");
 """)
 
+    println(f,"  fprintf(fptr, \"const MPI_Aint = Int%d\\n\", 8*(int)sizeof(MPI_Aint));")
+    println(f,"  fprintf(fptr, \"const MPI_Offset = Int%d\\n\", 8*(int)sizeof(MPI_Offset));")
+    println(f,"  fprintf(fptr, \"const MPI_Count = Int%d\\n\", 8*(int)sizeof(MPI_Count));")
+
     println(f,"  fprintf(fptr, \"const MPI_Status_size = %d\\n\", (int)sizeof(MPI_Status));")
     println(f,"  fprintf(fptr, \"const MPI_Status_Source_offset = %d\\n\", (int)offsetof(MPI_Status, MPI_SOURCE));")
     println(f,"  fprintf(fptr, \"const MPI_Status_Tag_offset = %d\\n\", (int)offsetof(MPI_Status, MPI_TAG));")

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -8,11 +8,25 @@ MPI.refcount_inc
 MPI.refcount_dec
 ```
 
+## Buffers
+
+```@docs
+MPI.Buffer
+MPI.Buffer_send
+MPI.MPIPtr
+```
+
 ## Datatype objects
 
 ```@docs
-MPI.mpitype
-MPI.Type_Create_Subarray
+MPI.Datatype
+MPI.Types.extent
+MPI.Types.create_contiguous
+MPI.Types.create_vector
+MPI.Types.create_subarray
+MPI.Types.create_struct
+MPI.Types.create_resized
+MPI.Types.commit!
 ```
 
 ## Operator objects

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -2,6 +2,7 @@ module MPI
 
 using Libdl, Serialization
 using Requires
+using DocStringExtensions
 
 macro mpichk(expr)
     @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
@@ -38,11 +39,13 @@ function _doc_external(fname)
 end    
 
 include(joinpath(@__DIR__, "..", "deps", "deps.jl"))
+
 include("handle.jl")
 include("info.jl")
 include("comm.jl")
 include("environment.jl")
 include("datatypes.jl")
+include("buffers.jl")
 include("operators.jl")
 include("pointtopoint.jl")
 include("collective.jl")

--- a/src/buffers.jl
+++ b/src/buffers.jl
@@ -1,0 +1,127 @@
+const MPIInteger = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64}
+const MPIFloatingPoint = Union{Float32, Float64}
+const MPIComplex = Union{ComplexF32, ComplexF64}
+
+const MPIDatatype = Union{Char,
+                            Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64,
+                            UInt64,
+                            Float32, Float64, ComplexF32, ComplexF64}
+MPIBuffertype{T} = Union{Ptr{T}, Array{T}, SubArray{T}, Ref{T}}
+
+MPIBuffertypeOrConst{T} = Union{MPIBuffertype{T}, SentinelPtr}
+
+Base.cconvert(::Type{MPIPtr}, x::Union{Ptr{T}, Array{T}, Ref{T}}) where T = Base.cconvert(Ptr{T}, x)
+function Base.cconvert(::Type{MPIPtr}, x::SubArray{T}) where T
+    Base.cconvert(Ptr{T}, x)
+end
+function Base.unsafe_convert(::Type{MPIPtr}, x::MPIBuffertype{T}) where T
+    ptr = Base.unsafe_convert(Ptr{T}, x)
+    reinterpret(MPIPtr, ptr)
+end
+function Base.cconvert(::Type{MPIPtr}, ::Nothing)
+    reinterpret(MPIPtr, C_NULL)
+end
+
+macro assert_minlength(buffer, count)
+    quote
+        if $(esc(buffer)) isa AbstractArray
+            @assert length($(esc(buffer))) >= $(esc(count))
+        end
+    end
+end
+
+"""
+    MPI.MPIPtr
+
+A pointer to an MPI buffer. This type is used only as part of the implicit conversion in
+`ccall`: a Julia object can be passed to MPI by defining methods for
+`Base.cconvert(::Type{MPIPtr}, ...)`/`Base.unsafe_convert(::Type{MPIPtr}, ...)`.
+
+Currently supported are:
+ - `Ptr`
+ - `Ref`
+ - `Array`
+ - `SubArray`
+ - `CuArray` if CuArrays.jl is loaded.
+
+Additionally, certain sentinel values can be used, e.g. `MPI_IN_PLACE` or `MPI_BOTTOM`.
+"""
+MPIPtr
+
+
+"""
+    MPI.Buffer
+
+An MPI buffer for communication operations.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+
+# Usage
+
+    Buffer(data, count::Integer, datatype::Datatype)
+
+Generic constructor.
+
+    Buffer(data)
+
+Construct a `Buffer` backed by `data`, automatically determining the appropriate `count`
+and `datatype`. Methods are provided for
+
+ - `Ref`
+ - `Array`
+ - `CuArray` if CuArrays.jl is loaded
+ - `SubArray`s of an `Array` or `CuArray` where the layout is contiguous, sequential or
+   blocked.
+
+"""
+struct Buffer{A}
+    """a Julia object referencing a region of memory to be used for communication. It is
+    required that the object can be `cconvert`ed to an [`MPIPtr`](@ref)."""
+    data::A
+
+    """the number of elements of `datatype` in the buffer. Note that this may not
+    correspond to the number of elements in the array if derived types are used."""
+    count::Cint
+
+    """the [`MPI.Datatype`](@ref) stored in the buffer."""
+    datatype::Datatype
+end
+Buffer(buf::Buffer) = buf
+Buffer(data, count::Integer, datatype::Datatype) = Buffer(data, Cint(count), datatype)
+
+function Buffer(arr::Array)
+    Buffer(arr, Cint(length(arr)), Datatype(eltype(arr)))
+end
+function Buffer(ref::Ref)
+    Buffer(ref, Cint(1), Datatype(eltype(ref)))
+end
+
+# SubArray
+function Buffer(sub::Base.FastContiguousSubArray)
+    Buffer(sub, Cint(length(sub)), Datatype(eltype(sub)))
+end
+function Buffer(sub::Base.FastSubArray)
+    datatype = Types.create_vector(length(sub), 1, sub.stride1,
+                                   Datatype(eltype(sub); commit=false))
+    Types.commit!(datatype)
+    Buffer(sub, Cint(1), datatype)
+end
+function Buffer(sub::SubArray{T,N,P,I,false}) where {T,N,P,I<:Tuple{Vararg{Union{Base.ScalarIndex, Base.Slice, AbstractUnitRange}}}}
+    datatype = Types.create_subarray(size(parent(sub)),
+                                     map(length, sub.indices),
+                                     map(i -> first(i)-1, sub.indices),
+                                     Datatype(eltype(sub), commit=false))
+    Types.commit!(datatype)
+    Buffer(parent(sub), Cint(1), datatype)
+end
+
+"""
+    Buffer_send(data)
+
+Construct a [`Buffer`](@ref) object for a send operation from `data`, allowing cases where
+`isbits(data)`.
+"""
+Buffer_send(data) = isbits(data) ? Buffer(Ref(data)) : Buffer(data)
+
+const BUFFER_NULL = Buffer(C_NULL, 0, DATATYPE_NULL)

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -33,7 +33,7 @@ function Bcast!(buffer, count::Integer,
     #               MPI_Comm comm)
     @mpichk ccall((:MPI_Bcast, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
-                  buffer, count, mpitype(eltype(buffer)), root, comm)
+                  buffer, count, Datatype(eltype(buffer)), root, comm)
     buffer
 end
 
@@ -105,7 +105,7 @@ function Scatter!(sendbuf, recvbuf, count::Integer, root::Integer, comm::Comm)
     #                 MPI_Comm comm)
     @mpichk ccall((:MPI_Scatter, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
-                  sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), root, comm)
+                  sendbuf, count, Datatype(T), recvbuf, count, Datatype(T), root, comm)
     recvbuf
 end
 
@@ -174,7 +174,7 @@ function Scatterv!(sendbuf, recvbuf, counts::Vector, root::Integer, comm::Comm)
     #                  int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
     @mpichk ccall((:MPI_Scatterv, libmpi), Cint,
                   (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
-                  sendbuf, counts, disps, mpitype(T), recvbuf, recvcnt, mpitype(T), root, comm)
+                  sendbuf, counts, disps, Datatype(T), recvbuf, recvcnt, Datatype(T), root, comm)
     recvbuf
 end
 
@@ -245,7 +245,7 @@ function Gather!(sendbuf, recvbuf, count::Integer, root::Integer, comm::Comm)
     #                MPI_Comm comm)
     @mpichk ccall((:MPI_Gather, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
-                  sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), root, comm)
+                  sendbuf, count, Datatype(T), recvbuf, count, Datatype(T), root, comm)
     isroot ? recvbuf : nothing
 end
 function Gather!(sendbuf, recvbuf, root::Integer, comm::Comm)
@@ -305,7 +305,7 @@ function Allgather!(sendbuf, recvbuf, count::Integer, comm::Comm)
     #                   MPI_Datatype recvtype, MPI_Comm comm)
     @mpichk ccall((:MPI_Allgather, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm),
-                  sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), comm)
+                  sendbuf, count, Datatype(T), recvbuf, count, Datatype(T), comm)
     recvbuf
 end
 function Allgather!(sendrecvbuf, count::Integer, comm::Comm)
@@ -381,7 +381,7 @@ function Gatherv!(sendbuf, recvbuf, counts::Vector{Cint}, root::Integer, comm::C
     #                 MPI_Datatype recvtype, int root, MPI_Comm comm)
     @mpichk ccall((:MPI_Gatherv, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Cint, MPI_Comm),
-                  sendbuf, sendcnt, mpitype(T), recvbuf, counts, displs, mpitype(T), root, comm)
+                  sendbuf, sendcnt, Datatype(T), recvbuf, counts, displs, Datatype(T), root, comm)
     isroot ? recvbuf : nothing
 end
 
@@ -436,7 +436,7 @@ function Allgatherv!(sendbuf, recvbuf, counts::Vector{Cint}, comm::Comm)
     #                    const int displs[], MPI_Datatype recvtype, MPI_Comm comm)
     @mpichk ccall((:MPI_Allgatherv, libmpi), Cint,
               (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm),
-              sendbuf, sendcnt, mpitype(T), recvbuf, counts, displs, mpitype(T), comm)
+              sendbuf, sendcnt, Datatype(T), recvbuf, counts, displs, Datatype(T), comm)
     recvbuf
 end
 function Allgatherv!(sendrecvbuf, counts::Vector{Cint}, comm::Comm)
@@ -499,7 +499,7 @@ function Alltoall!(sendbuf, recvbuf, count::Integer, comm::Comm)
     #                  MPI_Comm comm)
     @mpichk ccall((:MPI_Alltoall, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm),
-                  sendbuf, count, mpitype(T), recvbuf, count, mpitype(T), comm)
+                  sendbuf, count, Datatype(T), recvbuf, count, Datatype(T), comm)
     recvbuf
 end
 function Alltoall!(sendrecvbuf, count::Integer, comm::Comm)
@@ -558,7 +558,7 @@ function Alltoallv!(sendbuf, recvbuf, scounts::Vector{Cint}, rcounts::Vector{Cin
     #                   MPI_Datatype recvtype, MPI_Comm comm)
     @mpichk ccall((:MPI_Alltoallv, libmpi), Cint,
                   (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm),
-                  sendbuf, scounts, sdispls, mpitype(T), recvbuf, rcounts, rdispls, mpitype(T), comm)
+                  sendbuf, scounts, sdispls, Datatype(T), recvbuf, rcounts, rdispls, Datatype(T), comm)
     recvbuf
 end
 
@@ -616,7 +616,7 @@ function Reduce!(sendbuf, recvbuf, count::Integer, op::Union{Op,MPI_Op}, root::I
     #                MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
     @mpichk ccall((:MPI_Reduce, libmpi), Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, Cint, MPI_Comm),
-                  sendbuf, recvbuf, count, mpitype(T), op, root, comm)
+                  sendbuf, recvbuf, count, Datatype(T), op, root, comm)
     recvbuf
 end
 
@@ -699,7 +699,7 @@ function Allreduce!(sendbuf, recvbuf, count::Integer, op::Union{Op,MPI_Op}, comm
     #                   MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
     @mpichk ccall((:MPI_Allreduce, libmpi), Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
-                  sendbuf, recvbuf, count, mpitype(T), op, comm)
+                  sendbuf, recvbuf, count, Datatype(T), op, comm)
     recvbuf
 end
 function Allreduce!(sendbuf, recvbuf, count::Integer, opfunc, comm::Comm)
@@ -766,7 +766,7 @@ function Scan!(sendbuf, recvbuf, count::Integer,
     #              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
     @mpichk ccall((:MPI_Scan, libmpi), Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
-                  sendbuf, recvbuf, count, mpitype(T), op, comm)
+                  sendbuf, recvbuf, count, Datatype(T), op, comm)
     recvbuf
 end
 function Scan!(sendbuf, recvbuf, count::Integer, opfunc, comm::Comm)
@@ -840,7 +840,7 @@ function Exscan!(sendbuf, recvbuf, count::Integer,
     #                MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
     @mpichk ccall((:MPI_Exscan, libmpi), Cint,
           (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
-          sendbuf, recvbuf, count, mpitype(T), op, comm)
+          sendbuf, recvbuf, count, Datatype(T), op, comm)
     recvbuf
 end
 function Exscan!(sendbuf, recvbuf, count::Integer, opfunc, comm::Comm)

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -11,6 +11,17 @@ function Base.unsafe_convert(::Type{MPIPtr}, buf::DeviceBuffer)
     reinterpret(MPIPtr, buf.ptr)
 end
 # CuArrays > v1.3
-function Base.unsafe_convert(::Type{MPIPtr}, buf::CuArray{T}) where T
-    reinterpret(MPIPtr, Base.unsafe_convert(CuPtr{T}, buf))
+function Base.unsafe_convert(::Type{MPIPtr}, X::CuArray{T}) where T
+    reinterpret(MPIPtr, Base.unsafe_convert(CuPtr{T}, X))
+end
+# only need to define this for strided arrays: all others can be handled by generic machinery
+function Base.unsafe_convert(::Type{MPIPtr}, V::SubArray{T,N,P,I,true}) where {T,N,P<:CuArray,I}
+    X = parent(V)
+    pX = Base.unsafe_convert(CuPtr{T}, X)
+    pV = pX + ((V.offset1 + V.stride1) - first(LinearIndices(X)))*sizeof(T)
+    return reinterpret(MPIPtr, pV)
+end
+
+function Buffer(arr::CuArray)
+    Buffer(arr, Cint(length(arr)), Datatype(eltype(arr)))
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -38,3 +38,53 @@ end false
         Gatherv!(buf, nothing, counts, root, comm)
     end
 end false    
+
+@deprecate(mpitype(T), Datatype(T), false)
+
+@deprecate(Type_Create_Subarray(ndims::Integer, sizes::MPIBuffertype{Cint}, subsizes::MPIBuffertype{Cint},
+                                starts::MPIBuffertype{Cint}, order::Integer, oldtype),
+           Types.create_subarray(sizes, subsizes, starts, Datatype(oldtype); rowmajor = order == MPI_ORDER_C), false)
+@deprecate(Type_Create_Struct(nfields::Integer, blocklengths::MPIBuffertype{Cint},
+                              displacements::MPIBuffertype{Cptrdiff_t}, types::MPIBuffertype{MPI_Datatype}),
+           Types.create_struct(blocklengths, displacements, types), false)
+@deprecate(Type_Commit!(datatype), Types.commit!(datatype), false)
+
+
+@deprecate(Send(buf, count::Integer, datatype::Datatype, dest::Integer, tag::Integer, comm::Comm),
+           Send(Buffer(buf, count, datatype), dest, tag, comm), false)
+@deprecate(Send(buf::AbstractArray, count::Integer, dest::Integer, tag::Integer, comm::Comm),
+           Send(view(buf, 1:count), dest, tag, comm), false)
+@deprecate(Send(buf::Ref, count::Integer, dest::Integer, tag::Integer, comm::Comm),
+           Send(buf, dest, tag, comm), false)
+
+@deprecate(Isend(buf, count::Integer, datatype::Datatype, dest::Integer, tag::Integer, comm::Comm),
+           Isend(Buffer(buf,count,datatype), dest, tag, comm), false)
+@deprecate(Isend(buf::AbstractArray, count::Integer, dest::Integer, tag::Integer, comm::Comm),
+           Isend(view(buf,1:count), dest, tag, comm), false)
+@deprecate(Isend(buf::Ref, count::Integer, dest::Integer, tag::Integer, comm::Comm),
+           Isend(buf, dest, tag, comm), false)
+
+@deprecate(Recv!(buf, count::Integer, datatype::Datatype, src::Integer, tag::Integer, comm::Comm),
+           Recv!(Buffer(buf, count, datatype), src, tag, comm), false)
+@deprecate(Recv!(buf::AbstractArray, count::Integer, src::Integer, tag::Integer, comm::Comm),
+           Recv!(view(buf, 1:count), src, tag, comm), false)
+@deprecate(Recv!(buf::Ref, count::Integer, src::Integer, tag::Integer, comm::Comm),
+           Recv!(buf, src, tag, comm), false)
+
+@deprecate(Irecv!(buf, count::Integer, datatype::Datatype, src::Integer, tag::Integer, comm::Comm),           
+           Irecv!(Buffer(buf,count,datatype), src, tag, comm), false)
+@deprecate(Irecv!(buf::AbstractArray, count::Integer, src::Integer, tag::Integer, comm::Comm),           
+           Irecv!(view(buf,1:count), src, tag, comm), false)
+@deprecate(Irecv!(buf::Ref, count::Integer, src::Integer, tag::Integer, comm::Comm),           
+           Irecv!(buf, src, tag, comm), false)
+
+@deprecate(Sendrecv!(sendbuf, sendcount::Integer, sendtype,   dest::Integer, sendtag::Integer,
+                     recvbuf, recvcount::Integer, recvtype, source::Integer, recvtag::Integer,
+                     comm::Comm),
+           Sendrecv!(Buffer(sendbuf, sendcount, sendtype), dest, sendtag,
+                     Buffer(recvbuf, recvcount, recvtype), source, recvtag, comm), false)           
+@deprecate(Sendrecv!(sendbuf, sendcount::Integer,   dest::Integer, sendtag::Integer,
+                     recvbuf, recvcount::Integer, source::Integer, recvtag::Integer,
+                     comm::Comm),
+           Sendrecv!(view(sendbuf, 1:sendcount), dest, sendtag,
+                     view(recvbuf, 1:recvcount), source, recvtag, comm), false)

--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -155,7 +155,7 @@ function Get(origin_buffer, count::Integer, target_rank::Integer, target_disp::I
     #             MPI_Datatype target_datatype, MPI_Win win)
     @mpichk ccall((:MPI_Get, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Win),
-                  origin_buffer, count, mpitype(T), target_rank, Cptrdiff_t(target_disp), count, mpitype(T), win)
+                  origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), win)
 end
 function Get(origin_buffer::AbstractArray{T}, target_rank::Integer, win::Win) where T
     count = length(origin_buffer)
@@ -173,7 +173,7 @@ function Put(origin_buffer, count::Integer, target_rank::Integer, target_disp::I
     T = eltype(origin_buffer)
     @mpichk ccall((:MPI_Put, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Win),
-                  origin_buffer, count, mpitype(T), target_rank, Cptrdiff_t(target_disp), count, mpitype(T), win)
+                  origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), win)
 end
 function Put(origin_buffer::AbstractArray{T}, target_rank::Integer, win::Win) where T
     count = length(origin_buffer)
@@ -191,7 +191,7 @@ function Fetch_and_op(sourceval, returnval, target_rank::Integer, target_disp::I
     T = eltype(sourceval)
     @mpichk ccall((:MPI_Fetch_and_op, libmpi), Cint,
                   (MPIPtr, MPIPtr, MPI_Datatype, Cint, Cptrdiff_t, MPI_Op, MPI_Win),
-                  sourceval, returnval, mpitype(T), target_rank, target_disp, op, win)
+                  sourceval, returnval, Datatype(T), target_rank, target_disp, op, win)
 end
 
 function Accumulate(origin_buffer, count::Integer, target_rank::Integer, target_disp::Integer, op::Op, win::Win)
@@ -202,7 +202,7 @@ function Accumulate(origin_buffer, count::Integer, target_rank::Integer, target_
     T = eltype(origin_buffer)
     @mpichk ccall((:MPI_Accumulate, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Op, MPI_Win),
-                  origin_buffer, count, mpitype(T), target_rank, Cptrdiff_t(target_disp), count, mpitype(T), op, win)
+                  origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), op, win)
 end
 
 function Get_accumulate(origin_buffer, result_buffer, count::Integer, target_rank::Integer, target_disp::Integer, op::Op, win::Win)
@@ -215,5 +215,5 @@ function Get_accumulate(origin_buffer, result_buffer, count::Integer, target_ran
     T = eltype(origin_buffer)
     @mpichk ccall((:MPI_Get_accumulate, libmpi), Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Op, MPI_Win),
-                  origin_buffer, count, mpitype(T), result_buffer, count, mpitype(T), target_rank, Cptrdiff_t(target_disp), count, mpitype(T), op, win)
+                  origin_buffer, count, Datatype(T), result_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), op, win)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -59,13 +59,9 @@ end
 
 function (w::OpWrapper{F,T})(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t::Ptr{MPI_Datatype}) where {F,T}
     len = unsafe_load(_len)
-    if isconcretetype(T)
-        S = T
-    else
-        S = mpitype_dict_inverse[unsafe_load(t)]
-    end
-    a = Ptr{S}(_a)
-    b = Ptr{S}(_b)
+    @assert isconcretetype(T)
+    a = Ptr{T}(_a)
+    b = Ptr{T}(_b)
     for i = 1:len
         unsafe_store!(b, w.f(unsafe_load(a,i), unsafe_load(b,i)), i)
     end

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -3,113 +3,146 @@ using MPI
 
 MPI.Init()
 
-#MPI.mpitype_dict[Boundary] = MPI.mpitype_dict[Int]
 comm_size = MPI.Comm_size(MPI.COMM_WORLD)
-comm_rank = MPI.Comm_rank(MPI.COMM_WORLD) + 1
+comm_rank = MPI.Comm_rank(MPI.COMM_WORLD)
 
 # send to next higher process, with wraparound
-dest = (comm_rank % comm_size) + 1
-if comm_rank > 1
-  src = comm_rank - 1
-else
-  src = comm_size
-end
-
+dest = mod(comm_rank+1, comm_size)
+src  = mod(comm_rank-1, comm_size)
 
 # test simple type
-
 mutable struct NotABits
-  a::Any
+    a::Any
 end
 
-@test_throws ArgumentError MPI.mpitype(NotABits)
+@testset "Non bitstype" begin
+    @test_throws ArgumentError MPI.Datatype(NotABits)
+end
 
 struct Boundary
-  c::UInt16  # force some padding to be inserted
-  a::Int
-  b::UInt8
+    c::UInt16  # force some padding to be inserted
+    a::Int
+    b::UInt8
+end
+@testset "Compound type" begin
+    sz = sizeof(Boundary)
+    al = Base.datatype_alignment(Boundary)
+    @test MPI.Types.extent(MPI.Datatype(Boundary)) == (0, cld(sz,al)*al)
+
+    arr = [Boundary( (comm_rank + i) % 127, i + comm_rank, i % 64) for i = 1:3]
+    req_send = MPI.Isend(arr, dest, 1, MPI.COMM_WORLD)
+
+    # receive the message
+    arr_recv = Array{Boundary}(undef, 3)
+    req_recv = MPI.Irecv!(arr_recv, src, 1, MPI.COMM_WORLD)
+
+    MPI.Wait!(req_send)
+    MPI.Wait!(req_recv)
+
+    # check received array
+    for i=1:3
+        bndry_i = arr_recv[i]
+        @test bndry_i.a == (src + i)
+        @test bndry_i.b == i % 64
+        @test bndry_i.c == (src + i) % 127
+    end
 end
 
-MPI.mpitype(Boundary)
-
-arr = [Boundary( (comm_rank + i) % 127, i + comm_rank, i % 64) for i = 1:3]
-req_send = MPI.Isend(arr, dest - 1, 1, MPI.COMM_WORLD)
-
-# receive the message
-arr_recv = Array{Boundary}(undef, 3)
-req_recv = MPI.Irecv!(arr_recv, src - 1, 1, MPI.COMM_WORLD)
-
-MPI.Wait!(req_send)
-MPI.Wait!(req_recv)
-
-# check received array
-for i=1:3
-  bndry_i = arr_recv[i]
-  @test bndry_i.a == (src + i)
-  @test bndry_i.b == i % 64
-  @test bndry_i.c == (src + i) % 127
-end
-
-
-# test nested types
 struct Boundary2
-  a::UInt32
-  b::Tuple{Int, UInt8}
+    a::UInt32
+    b::Tuple{Int, UInt8}
+    c::Nothing
+end
+@testset "nested types" begin
+    sz = sizeof(Boundary2)
+    al = Base.datatype_alignment(Boundary2)
+    @test MPI.Types.extent(MPI.Datatype(Boundary2)) == (0, cld(sz,al)*al)
+
+    arr = [Boundary2( (comm_rank + i) % 127, ( Int(i + comm_rank), UInt8(i % 64)), nothing) for i = 1:3]
+    arr_recv = Array{Boundary2}(undef,3)
+
+    req_send = MPI.Isend(arr, dest, 1, MPI.COMM_WORLD)
+    req_recv = MPI.Irecv!(arr_recv, src, 1, MPI.COMM_WORLD)
+
+    MPI.Wait!(req_send)
+    MPI.Wait!(req_recv)
+
+    # check received array
+    for i=1:3
+        bndry_i = arr_recv[i]
+        @test bndry_i.a == (src + i) % 127
+        @test bndry_i.b[1] == (src + i)
+        @test bndry_i.b[2] == (i % 64)
+        @test bndry_i.c === nothing
+    end
 end
 
-MPI.mpitype(Boundary2)
-
-arr = Array{Boundary2}(undef,3)
-arr_recv = Array{Boundary2}(undef,3)
-
-for i=1:3
-  arr[i] = Boundary2( (comm_rank + i) % 127, ( Int(i + comm_rank), UInt8(i % 64) ) )
-end
-
-req_send = MPI.Isend(arr, dest - 1, 1, MPI.COMM_WORLD)
-req_recv = MPI.Irecv!(arr_recv, src - 1, 1, MPI.COMM_WORLD)
-
-MPI.Wait!(req_send)
-MPI.Wait!(req_recv)
-
-# check received array
-for i=1:3
-  bndry_i = arr_recv[i]
-  @test bndry_i.a == (src + i) % 127
-  @test bndry_i.b[1] == (src + i)
-  @test bndry_i.b[2] == (i % 64)
-end
-
-
-# test a primitive type
 primitive type Primitive16 16 end
 primitive type Primitive24 24 end
+primitive type Primitive80 80 end
 
-nfields, blocklengths, displacements, types = MPI.factorPrimitiveType(Primitive16)
-@test nfields == 1
-@test displacements[1] == 0
-@test types[1] == MPI.mpitype(Int16)
-@test blocklengths[1] == 1
+@testset for PrimitiveType in (Primitive16, Primitive24, Primitive80)        
+    sz = sizeof(PrimitiveType)
+    al = Base.datatype_alignment(PrimitiveType)
+    @test MPI.Types.extent(MPI.Datatype(PrimitiveType)) == (0, cld(sz,al)*al)
 
-nfields, blocklengths, displacements, types = MPI.factorPrimitiveType(Primitive24)
-@test nfields == 2
-@test displacements[1] == 0
-@test displacements[2] == 2
-@test types[1] == MPI.mpitype(Int16)
-@test types[2] == MPI.mpitype(Int8)
-@test blocklengths[1] == 1
-@test blocklengths[2] == 1
+    if VERSION < v"1.3" && PrimitiveType == Primitive80
+        # alignment is broken on earlier Julia versions
+        continue
+    end
+    
+    arr = [Core.Intrinsics.trunc_int(PrimitiveType, UInt128(comm_rank + i)) for i = 1:4]
+    arr_recv = Array{PrimitiveType}(undef,4)    
+    
+    recv_req = MPI.Irecv!(arr_recv, src, 2, MPI.COMM_WORLD)
+    send_req = MPI.Isend(arr, dest, 2, MPI.COMM_WORLD)
 
+    MPI.Wait!(recv_req)
+    MPI.Wait!(send_req)
 
-obj = [Ptr{Int}(comm_rank)]
-obj_recv = Array{Ptr{Int}}(undef, 1)
-recv_req = MPI.Irecv!(obj_recv, src - 1, 2, MPI.COMM_WORLD)
-send_req = MPI.Isend(obj, dest - 1, 2, MPI.COMM_WORLD)
+    @test arr_recv == [Core.Intrinsics.trunc_int(PrimitiveType, UInt128(src + i)) for i = 1:4]
+end
 
-MPI.Wait!(recv_req)
-MPI.Wait!(send_req)
+@testset "packed non-aligned tuples" begin
+    T = NTuple{3,UInt8}
 
-@test obj_recv[1] == Ptr{Int}(src)
+    sz = sizeof(T)
+    al = Base.datatype_alignment(T)
+    @test MPI.Types.extent(MPI.Datatype(T)) == (0, cld(sz,al)*al)
+
+    arr = [(UInt8(comm_rank),UInt8(i),UInt8(0)) for i = 1:8]
+    arr_recv = Array{T}(undef,8)
+
+    req_send = MPI.Isend(arr, dest, 1, MPI.COMM_WORLD)
+    req_recv = MPI.Irecv!(arr_recv, src, 1, MPI.COMM_WORLD)
+
+    MPI.Wait!(req_send)
+    MPI.Wait!(req_recv)
+
+    # check received array
+    @test arr_recv == [(UInt8(src),UInt8(i),UInt8(0)) for i = 1:8]
+end
+
+@testset "0-sized type" begin
+    sz = sizeof(Nothing)
+    al = Base.datatype_alignment(Nothing)
+
+    # OpenMPI gives incorrect values
+    # see https://github.com/open-mpi/ompi/issues/7266
+    # @test MPI.Types.extent(MPI.Datatype(Nothing)) == (0, cld(sz,al)*al)
+
+    arr = [nothing for i = 1:100]
+    arr_recv = Array{Nothing}(undef,100)
+
+    req_send = MPI.Isend(arr, dest, 1, MPI.COMM_WORLD)
+    req_recv = MPI.Irecv!(arr_recv, src, 1, MPI.COMM_WORLD)
+
+    MPI.Wait!(req_send)
+    MPI.Wait!(req_recv)
+
+    # check received array
+    @test arr_recv == [nothing for i = 1:100]
+end
 
 
 MPI.Barrier(MPI.COMM_WORLD)


### PR DESCRIPTION
This contains two related changes:

1. Defines a specific `Buffer` type, which contains the reference to the storage buffer, its count and datatype. This allows us to simplify the type signatures of various functions, as `count` and `datatype` no longer need to be arguments to the functions. This also adds default conversion methods for `Array`s and `Subarray`s (creating the derived datatypes where necessary, and determining the appropriate `count`s), and moves the point-to-point operations to use these conversions.

2. Improves the handling of `Datatype` handles, by making them garbage-collected objects (like other MPI handles), moves lower-level functions to a submodule, defines consistent interfaces. Also fixes #327.

I still need to move the collective calls over as well, however that will require more thought on how to handle the "chunked" operations like scatter/gather.

I also removed the inverse dictionary mappings from MPI Datatype -> Julia Type, as that is no longer so easy to determine.