### PR TITLE
Wrap some MPI I/O operations

### DIFF
--- a/deps/consts_msmpi.jl
+++ b/deps/consts_msmpi.jl
@@ -4,7 +4,7 @@ const MPI_Aint   = Int
 const MPI_Offset = Int64
 const MPI_Count  = Int64
 
-for T in [:MPI_Comm, :MPI_Info, :MPI_Win, :MPI_Request, :MPI_Op, :MPI_Datatype]
+for T in [:MPI_Comm, :MPI_Info, :MPI_Win, :MPI_Request, :MPI_Op, :MPI_Datatype, :MPI_File]
     @eval begin
         primitive type $T 32 end
         $T(c::Cint) = reinterpret($T, c)
@@ -64,7 +64,7 @@ const MPI_UINT64_T              = reinterpret(Cint, 0x4c00083a)
 const MPI_C_FLOAT_COMPLEX       = reinterpret(Cint, 0x4c000813)
 const MPI_C_DOUBLE_COMPLEX      = reinterpret(Cint, 0x4c001014)
 
-
+const MPI_FILE_NULL = Cint(0)
 
 const MPI_PROC_NULL = Cint(-1)
 const MPI_ANY_SOURCE = Cint(-2)
@@ -80,6 +80,17 @@ const MPI_COMM_TYPE_SHARED = Cint(1)
 const MPI_ORDER_C = Cint(56)
 const MPI_ORDER_FORTRAN = Cint(57)
 const MPI_UNIVERSE_SIZE = reinterpret(Cint, 0x64400009)
+const MPI_MAX_ERROR_STRING = Cint(512)
+const MPI_SUCCESS = Cint(0)
+const MPI_MODE_RDONLY = reinterpret(Cint, 0x00000002)
+const MPI_MODE_RDWR = reinterpret(Cint, 0x00000008)
+const MPI_MODE_WRONLY = reinterpret(Cint, 0x00000004)
+const MPI_MODE_CREATE = reinterpret(Cint, 0x00000001)
+const MPI_MODE_EXCL = reinterpret(Cint, 0x00000040)
+const MPI_MODE_DELETE_ON_CLOSE = reinterpret(Cint, 0x00000010)
+const MPI_MODE_UNIQUE_OPEN = reinterpret(Cint, 0x00000020)
+const MPI_MODE_SEQUENTIAL = reinterpret(Cint, 0x00000100)
+const MPI_MODE_APPEND = reinterpret(Cint, 0x00000080)
 
 const MPI_BOTTOM = reinterpret(SentinelPtr, 0)
 const MPI_IN_PLACE = reinterpret(SentinelPtr, -1)

--- a/deps/gen_consts.jl
+++ b/deps/gen_consts.jl
@@ -78,6 +78,9 @@ MPI_handle = [
     :MPI_Request => [
         :MPI_REQUEST_NULL,
     ],
+    :MPI_File => [
+        :MPI_FILE_NULL,
+    ],
     :MPI_Op => MPI_op_consts,
     :MPI_Datatype => MPI_datatype_consts
 ]
@@ -96,7 +99,18 @@ MPI_Cints = [
     :MPI_COMM_TYPE_SHARED,
     :MPI_ORDER_C,
     :MPI_ORDER_FORTRAN,
-    :MPI_UNIVERSE_SIZE
+    :MPI_UNIVERSE_SIZE,
+    :MPI_MAX_ERROR_STRING,
+    :MPI_SUCCESS,
+    :MPI_MODE_RDONLY,
+    :MPI_MODE_RDWR,
+    :MPI_MODE_WRONLY,
+    :MPI_MODE_CREATE,
+    :MPI_MODE_EXCL,
+    :MPI_MODE_DELETE_ON_CLOSE,
+    :MPI_MODE_UNIQUE_OPEN,
+    :MPI_MODE_SEQUENTIAL,
+    :MPI_MODE_APPEND,
 ]
 
 MPI_pointers = [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -52,6 +52,7 @@ makedocs(
             "collective.md",
             "onesided.md",
             "topology.md",
+            "io.md",
             "advanced.md",
         ],
         "refindex.md",

--- a/docs/src/io.md
+++ b/docs/src/io.md
@@ -1,0 +1,24 @@
+# I/O
+
+## File manipulation
+
+```@docs
+MPI.File.open
+```
+
+## Views
+
+```@docs
+MPI.File.set_view!
+```
+
+## Data access
+
+### Explicit offsets
+
+```@docs
+MPI.File.read_at!
+MPI.File.read_at_all!
+MPI.File.write_at
+MPI.File.write_at_all
+```

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -4,13 +4,6 @@ using Libdl, Serialization
 using Requires
 using DocStringExtensions
 
-macro mpichk(expr)
-    @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
-    if Sys.iswindows()
-        insert!(expr.args, 3, :stdcall)
-    end
-    esc(expr)
-end
 
 function serialize(x)
     s = IOBuffer()
@@ -39,7 +32,7 @@ function _doc_external(fname)
 end    
 
 include(joinpath(@__DIR__, "..", "deps", "deps.jl"))
-
+include("error.jl")
 include("handle.jl")
 include("info.jl")
 include("comm.jl")
@@ -51,6 +44,7 @@ include("pointtopoint.jl")
 include("collective.jl")
 include("topology.jl")
 include("onesided.jl")
+include("io.jl")
 
 include("deprecated.jl")
 

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -41,17 +41,16 @@ function Bcast!(buffer::Union{Ref, AbstractArray}, root::Integer, comm::Comm)
     Bcast!(buffer, length(buffer), root, comm)
 end
 
-
 function bcast(obj, root::Integer, comm::Comm)
     isroot = Comm_rank(comm) == root
-    count = Array{Cint}(undef, 1)
+    count = Ref{Cint}()
     if isroot
         buf = MPI.serialize(obj)
-        count[1] = length(buf)
+        count[] = length(buf)
     end
     Bcast!(count, root, comm)
     if !isroot
-        buf = Array{UInt8}(undef, count[1])
+        buf = Array{UInt8}(undef, count[])
     end
     Bcast!(buf, root, comm)
     if !isroot
@@ -59,7 +58,6 @@ function bcast(obj, root::Integer, comm::Comm)
     end
     obj
 end
-
 
 """
     Scatter!(sendbuf, recvbuf[, count=length(recvbuf)], root::Integer, comm::Comm)

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -3,7 +3,7 @@
 
 An MPI Communicator object.
 """
-@mpi_handle Comm
+@mpi_handle Comm MPI_Comm
 
 const COMM_NULL = _Comm(MPI_COMM_NULL)
 

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -13,7 +13,7 @@ that it can be used for communication operations.
 
 Note that this can only be called on types for which `isbitstype(T)` is `true`.
 """
-@mpi_handle Datatype
+@mpi_handle Datatype MPI_Datatype
 
 const DATATYPE_NULL = _Datatype(MPI_DATATYPE_NULL)
 Datatype() = Datatype(DATATYPE_NULL.val)

--- a/src/error.jl
+++ b/src/error.jl
@@ -1,0 +1,26 @@
+struct MPIError <: Exception
+    code::Cint
+end
+
+macro mpichk(expr)
+    @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
+    if Sys.iswindows()
+        insert!(expr.args, 3, :stdcall)
+    end
+    :((errcode = $(esc(expr))) == MPI_SUCCESS || throw(MPIError(errcode)))
+end
+
+
+function error_string(err::MPIError)
+    len_ref = Ref{Cint}()
+    str_buf = Vector{UInt8}(undef, MPI_MAX_ERROR_STRING)
+    # int MPI_Error_string(int errorcode, char *string, int *resultlen)
+    @mpichk ccall((:MPI_Error_string, libmpi), Cint,
+                  (Cint, Ptr{UInt8}, Ref{Cint}), err.code, str_buf, len_ref)
+    resize!(str_buf, len_ref[])
+    return String(str_buf)
+end
+
+function Base.show(io::IO, err::MPIError)
+    print(io, "MPIError(", err.code, "): ", error_string(err))
+end

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -1,9 +1,11 @@
 const mpi_init_hooks = Any[]
 
-macro mpi_handle(def, extrafields...)
+macro mpi_handle(def, mpiname=nothing, extrafields...)
     name = def isa Expr ? def.args[1] : def
     _name = Symbol(:_, name)
-    mpiname = Symbol(:MPI_, name)
+    if mpiname == nothing
+        mpiname = Symbol(:MPI_, name)
+    end
     quote
         Base.@__doc__ mutable struct $(esc(def))
             val::$mpiname

--- a/src/info.jl
+++ b/src/info.jl
@@ -25,7 +25,7 @@ delete!(info, key)
 If `init=false` is used in the costructor (the default), a "null" `Info` object will be
 returned: no keys can be added to such an object.
 """
-@mpi_handle Info <: AbstractDict{Symbol,String}
+@mpi_handle Info <: AbstractDict{Symbol,String} MPI_Info
 
 const INFO_NULL = _Info(MPI_INFO_NULL)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,202 @@
+@mpi_handle FileHandle MPI_File
+const FILE_NULL = _FileHandle(MPI_FILE_NULL)
+FileHandle() = FileHandle(FILE_NULL.val)
+
+module File
+
+import MPI: MPI, @mpichk, _doc_external, MPIPtr, libmpi, refcount_inc, refcount_dec,
+    Comm, MPI_Comm, FileHandle, MPI_File, Info, MPI_Info, FILE_NULL,
+    Datatype, MPI_Datatype, MPI_Offset, Status, Buffer, Buffer_send
+import Base: close
+
+function open(comm::Comm, filename::AbstractString, amode::Cint, info::Info)
+    file = FileHandle()
+    # int MPI_File_open(MPI_Comm comm, const char *filename, int amode,
+    #                   MPI_Info info, MPI_File *fh)
+    @mpichk ccall((:MPI_File_open, libmpi), Cint,
+                  (MPI_Comm, Cstring, Cint, MPI_Info, Ptr{MPI_File}),
+                  comm, filename, amode, info, file)
+    refcount_inc()
+    finalizer(close, file)
+    file
+end
+
+"""
+    MPI.File.open(comm::Comm, filename::AbstractString; keywords...)
+
+Open the file identified by `filename`. This is a collective operation on `comm`.
+
+Supported keywords are as follows:
+ - `read`, `write`, `create`, `append` have the same behaviour and defaults as `Base.open`.
+ - `sequential`: file will only be accessed sequentially (default: `false`)
+ - `uniqueopen`: file will not be concurrently opened elsewhere (default: `false`)
+ - `deleteonclose`: delete file on close (default: `false`)
+
+Any additional keywords are passed via an [`Info`](@ref) object, and are implementation dependent.
+
+# External links
+$(_doc_external("MPI_File_open"))
+"""
+function open(comm::Comm, filename::AbstractString;
+              read=nothing, write=nothing, create=nothing, append=nothing,
+              sequential=false, uniqueopen=false, deleteonclose=false,
+              infokws...)
+    flags = Base.open_flags(read=read, write=write, create=create, truncate=nothing, append=append)
+    amode = flags.read ? (flags.write ? MPI.MPI_MODE_RDWR : MPI.MPI_MODE_RDONLY) : (flags.write ? MPI.MPI_MODE_WRONLY : zero(Cint))
+    if flags.write
+        amode |= flags.create ? MPI.MPI_MODE_CREATE : MPI.MPI_MODE_EXCL
+    end
+    if flags.append
+        amode |= MPI.MPI_MODE_APPEND
+    end
+    if sequential
+        amode |= MPI.MPI_MODE_SEQUENTIAL
+    end
+    if uniqueopen
+        amode |= MPI.MPI_MODE_UNIQUE_OPEN
+    end
+    if deleteonclose
+        amode |= MPI.MPI_MODE_DELETE_ON_CLOSE
+    end
+    open(comm, filename, amode, Info(infokws...))
+end
+
+function close(file::FileHandle)
+    if file.val != FILE_NULL.val
+        # int MPI_File_close(MPI_File *fh)
+        @mpichk ccall((:MPI_File_close, libmpi), Cint,
+                      (Ptr{MPI_File},), file)
+        refcount_dec()
+    end
+    return nothing
+end
+
+# View
+"""
+    MPI.File.set_view!(file::FileHandle, disp::Integer, etype::Datatype, filetype::Datatype, datarep::AbstractString; kwargs...)
+
+Set the current process's view of `file`.
+
+The start of the view is set to `disp`; the type of data is set to `etype`; the
+distribution of data to processes is set to `filetype`; and the representation of data in
+the file is set to `datarep`: one of `"native"` (default), `"internal"`, or `"external32"`.
+
+# External links
+$(_doc_external("MPI_File_set_view"))
+"""
+function set_view!(file::FileHandle, disp::Integer, etype::Datatype, filetype::Datatype, datarep::AbstractString, info::Info)
+    # int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
+    #                       MPI_Datatype filetype, const char *datarep, MPI_Info info)
+    @mpichk ccall((:MPI_File_set_view, libmpi), Cint,
+                  (MPI_File, MPI_Offset,  MPI_Datatype, MPI_Datatype, Cstring, MPI_Info),
+                  file, disp, etype, filetype, datarep, info)
+    return file
+end
+
+function set_view!(file::FileHandle, disp::Integer, etype::Datatype, filetype::Datatype, datarep="native"; infokwargs...)
+    set_view!(file, disp, etype, filetype, datarep, Info(infokwargs...))
+end
+
+
+
+
+# Explicit offsets
+"""
+    MPI.File.read_at!(file::FileHandle, offset::Integer, data)
+
+Reads from `file` at position `offset` into `data`. `data` can be a [`Buffer`](@ref), or
+any object for which `Buffer(data)` is defined.
+
+# See also
+- [`MPI.File.read_at_all!`](@ref) for the collective operation
+
+# External links
+$(_doc_external("MPI_File_read_at"))
+"""
+function read_at!(file::FileHandle, offset::Integer, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count,
+    #                      MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_read_at, libmpi), Cint,
+                  (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, offset, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+read_at!(file::FileHandle, offset::Integer, data) = read_at!(file, offset, Buffer(data))
+
+"""
+    MPI.File.read_at_all!(file::FileHandle, offset::Integer, data)
+
+Reads from `file` at position `offset` into `data`. `data` can be a [`Buffer`](@ref), or
+any object for which `Buffer(data)` is defined. This is a collective operation, so must be
+called on all ranks in the communicator on which `file` was opened.
+
+# See also
+- [`MPI.File.read_at!`](@ref) for the noncollective operation
+
+# External links
+$(_doc_external("MPI_File_read_at_all"))
+"""
+function read_at_all!(file::FileHandle, offset::Integer, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+
+    # int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
+    #                          int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_read_at_all, libmpi), Cint,
+                  (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, offset, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+read_at_all!(file::FileHandle, offset::Integer, data) = read_at_all!(file, offset, Buffer(data))
+
+"""
+    MPI.File.write_at(file::FileHandle, offset::Integer, data)
+
+Writes `data` to `file` at position `offset`. `data` can be a [`Buffer`](@ref), or any
+object for which [`Buffer_send(data)`](@ref) is defined.
+
+# See also
+- [`MPI.File.write_at_all`](@ref) for the collective operation
+
+# External links
+$(_doc_external("MPI_File_write_at"))
+"""
+function write_at(file::FileHandle, offset::Integer, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf,
+    #                       int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_write_at, libmpi), Cint,
+                  (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, offset, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+write_at(file::FileHandle, offset::Integer, data) = write_at(file, offset, Buffer_send(data))
+
+"""
+    MPI.File.write_at_all(file::FileHandle, offset::Integer, data)
+
+Writes from `data` to `file` at position `offset`. `data` can be a [`Buffer`](@ref), or
+any object for which [`Buffer_send(data)`](@ref) is defined. This is a collective
+operation, so must be called on all ranks in the communicator on which `file` was opened.
+
+# See also
+- [`MPI.File.write_at`](@ref) for the noncollective operation
+
+# External links
+$(_doc_external("MPI_File_write_at_all"))
+"""
+function write_at_all(file::FileHandle, offset::Integer, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
+    #                           int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_write_at_all, libmpi), Cint,
+                  (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, offset, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+write_at_all(file::FileHandle, offset::Integer, data) = write_at_all(file, offset, Buffer_send(data))
+
+
+
+
+end # module

--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -1,4 +1,4 @@
-@mpi_handle Win
+@mpi_handle Win MPI_Win
 
 const WIN_NULL = _Win(MPI_WIN_NULL)
 Win() = Win(WIN_NULL.val)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -17,7 +17,7 @@ associative, and if `iscommutative` is true, assumed to be commutative as well.
 - [`Scan!`](@ref)/[`Scan`](@ref)
 - [`Exscan!`](@ref)/[`Exscan`](@ref)
 """
-@mpi_handle Op fptr
+@mpi_handle Op MPI_Op fptr
 
 const OP_NULL = _Op(MPI_OP_NULL, nothing)
 const BAND    = _Op(MPI_BAND, nothing)

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -93,7 +93,7 @@ checked by other means.
 
 See also [`Cancel!`](@ref).
 """
-@mpi_handle Request buffer
+@mpi_handle Request MPI_Request buffer
 
 const REQUEST_NULL = _Request(MPI_REQUEST_NULL, nothing)
 Request() = Request(REQUEST_NULL.val, nothing)

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,66 @@
+using Test, Pkg
+using MPI
+using Random
+
+if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "CuArray"
+    using CuArrays
+    ArrayType = CuArray
+else
+    ArrayType = Array
+end
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+rank = MPI.Comm_rank(comm)
+sz = MPI.Comm_size(comm)
+filename = MPI.bcast(tempname(), 0, comm)
+
+# Write
+MPI.Barrier(comm)
+
+f = MPI.File.open(comm, filename, write=true)
+MPI.File.set_view!(f, 0, MPI.Datatype(Int64), MPI.Datatype(Int64))
+MPI.File.write_at(f, rank*2, ArrayType([Int64(rank+1) for i = 1:2]))
+close(f)
+
+MPI.Barrier(comm)
+
+if rank == 0
+    @test read!(filename, zeros(Int64, (2,sz))) == [j for i = 1:2, j=1:sz]
+end
+
+MPI.Barrier(comm)
+
+f = MPI.File.open(comm, filename, write=true)
+MPI.File.set_view!(f, 0, MPI.Datatype(Int64), MPI.Datatype(Int64))
+MPI.File.write_at_all(f, rank*2, ArrayType([Int64(rank+1) for i = 1:2]))
+close(f)
+
+MPI.Barrier(comm)
+
+if rank == 0
+    @test read!(filename, zeros(Int64, (2,sz))) == [j for i = 1:2, j=1:sz]
+end
+
+MPI.Barrier(comm)
+
+# Read
+if rank == 0
+    write(filename, [Float64(j) for i = 1:3, j = 1:sz])
+end
+
+MPI.Barrier(comm)
+
+
+f = MPI.File.open(comm, filename, read=true)
+MPI.File.set_view!(f, 0, MPI.Datatype(Float64), MPI.Datatype(Float64))
+
+data = ArrayType(zeros(Float64, 3))
+MPI.File.read_at!(f, rank*3, data)
+@test data == Float64[rank+1 for i = 1:3]
+
+MPI.Barrier(comm)
+
+data = ArrayType(zeros(Float64, 3))
+MPI.File.read_at_all!(f, rank*3, data)
+@test data == Float64[rank+1 for i = 1:3]


### PR DESCRIPTION
This exposes some of the MPI I/O operations, at the moment only the explicit offset ones.

Also adds an MPIError type to print informative error messages.