### PR TITLE
Deprecate mpiexec binding

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,6 @@
 using Libdl
 
+
 MPI_PATH = get(ENV, "JULIA_MPI_PATH", nothing)
 MPI_LIBRARY_PATH = get(ENV, "JULIA_MPI_LIBRARY_PATH") do
     MPI_PATH !== nothing ? joinpath(MPI_PATH,"lib") : nothing
@@ -15,7 +16,7 @@ mpicc = get(ENV, "JULIA_MPICC") do
     end
 end
 
-const mpiexec = get(ENV, "JULIA_MPIEXEC") do
+const mpiexec_path = get(ENV, "JULIA_MPIEXEC") do
     if MPI_PATH !== nothing && Sys.isexecutable(joinpath(MPI_PATH,"bin","mpiexec"))
         joinpath(MPI_PATH,"bin","mpiexec")
     else
@@ -77,7 +78,7 @@ open("deps.jl","w") do f
     println(f, :(const libmpi = $libmpi))
     println(f, :(const libmpi_size = $libsize))
     println(f, :(const MPI_VERSION = $MPI_VERSION))
-    println(f, :(const mpiexec = $mpiexec))
+    println(f, :(const mpiexec_path = $mpiexec_path))
 
     if Sys.iswindows()
         println(f, :(include("consts_msmpi.jl")))
@@ -85,7 +86,7 @@ open("deps.jl","w") do f
         include("gen_consts.jl")
 
         run(`$mpicc gen_consts.c -o gen_consts $CFLAGS`)
-        run(`$mpiexec -n 1 ./gen_consts`)
+        run(`$mpiexec_path -n 1 ./gen_consts`)
 
         println(f, :(include("consts.jl")))
     end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ for (example_title, example_md) in EXAMPLES
         println(mdfile, "```")
         println(mdfile, "> mpiexec -n 3 julia $example_jl")
         cd(@__DIR__) do
-            write(mdfile, read(`$(MPI.mpiexec) -n 3 $(joinpath(Sys.BINDIR, Base.julia_exename())) --project $example_jl`))
+            write(mdfile, read(`$(MPI.mpiexec_path) -n 3 $(joinpath(Sys.BINDIR, Base.julia_exename())) --project $example_jl`))
         end
         println(mdfile, "```")
     end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -88,3 +88,5 @@ end false
                      comm::Comm),
            Sendrecv!(view(sendbuf, 1:sendcount), dest, sendtag,
                      view(recvbuf, 1:recvcount), source, recvtag, comm), false)
+
+Base.@deprecate_binding(mpiexec,mpiexec_path,false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using DoubleFloats
 using MPI
 using Test
 
-import MPI: mpiexec
+import MPI: mpiexec_path
 
 # Code coverage command line options; must correspond to src/julia.h
 # and src/ui/repl.c
@@ -28,7 +28,7 @@ function runtests()
     testfiles = sort(filter(istest, readdir(testdir)))
     extra_args = []
     @static if !Sys.iswindows()
-        if occursin( "OpenRTE", read(`$mpiexec --version`, String))
+        if occursin( "OpenRTE", read(`$mpiexec_path --version`, String))
             push!(extra_args,"--oversubscribe")
         end
     end
@@ -39,9 +39,9 @@ function runtests()
     for f in testfiles
         coverage_opt = coverage_opts[Base.JLOptions().code_coverage]
         if f ∈ singlefiles
-            run(`$mpiexec $extra_args -n 1 $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            run(`$mpiexec_path $extra_args -n 1 $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         else
-            run(`$mpiexec $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
+            run(`$mpiexec_path $extra_args -n $nprocs $exename --code-coverage=$coverage_opt $(joinpath(testdir, f))`)
         end
         Base.with_output_color(:green,stdout) do io
             println(io,"\tSUCCESS: $f")


### PR DESCRIPTION
To prepare for switching to use BinaryBuilder-provided binaries (#328/#339), this deprecates `mpiexec` so that we can make it consistent. I've renamed it to `mpiexec_path`.