### PR TITLE
rename MPI.Types module to MPI.Type

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -21,8 +21,8 @@ end
 
 primitive type MPIPtr Sys.WORD_SIZE
 end
-Base.cconvert(::Type{MPIPtr}, x::SentinelPtr) = x
-Base.unsafe_convert(::Type{MPIPtr}, x::SentinelPtr) = reinterpret(MPIPtr, x)
+Base.cconvert(::Base.Type{MPIPtr}, x::SentinelPtr) = x
+Base.unsafe_convert(::Base.Type{MPIPtr}, x::SentinelPtr) = reinterpret(MPIPtr, x)
 
 
 function _doc_external(fname)

--- a/src/buffers.jl
+++ b/src/buffers.jl
@@ -10,15 +10,15 @@ MPIBuffertype{T} = Union{Ptr{T}, Array{T}, SubArray{T}, Ref{T}}
 
 MPIBuffertypeOrConst{T} = Union{MPIBuffertype{T}, SentinelPtr}
 
-Base.cconvert(::Type{MPIPtr}, x::Union{Ptr{T}, Array{T}, Ref{T}}) where T = Base.cconvert(Ptr{T}, x)
-function Base.cconvert(::Type{MPIPtr}, x::SubArray{T}) where T
+Base.cconvert(::Base.Type{MPIPtr}, x::Union{Ptr{T}, Array{T}, Ref{T}}) where T = Base.cconvert(Ptr{T}, x)
+function Base.cconvert(::Base.Type{MPIPtr}, x::SubArray{T}) where T
     Base.cconvert(Ptr{T}, x)
 end
-function Base.unsafe_convert(::Type{MPIPtr}, x::MPIBuffertype{T}) where T
+function Base.unsafe_convert(::Base.Type{MPIPtr}, x::MPIBuffertype{T}) where T
     ptr = Base.unsafe_convert(Ptr{T}, x)
     reinterpret(MPIPtr, ptr)
 end
-function Base.cconvert(::Type{MPIPtr}, ::Nothing)
+function Base.cconvert(::Base.Type{MPIPtr}, ::Nothing)
     reinterpret(MPIPtr, C_NULL)
 end
 
@@ -102,17 +102,17 @@ function Buffer(sub::Base.FastContiguousSubArray)
     Buffer(sub, Cint(length(sub)), Datatype(eltype(sub)))
 end
 function Buffer(sub::Base.FastSubArray)
-    datatype = Types.create_vector(length(sub), 1, sub.stride1,
+    datatype = Type.create_vector(length(sub), 1, sub.stride1,
                                    Datatype(eltype(sub); commit=false))
-    Types.commit!(datatype)
+    Type.commit!(datatype)
     Buffer(sub, Cint(1), datatype)
 end
 function Buffer(sub::SubArray{T,N,P,I,false}) where {T,N,P,I<:Tuple{Vararg{Union{Base.ScalarIndex, Base.Slice, AbstractUnitRange}}}}
-    datatype = Types.create_subarray(size(parent(sub)),
+    datatype = Type.create_subarray(size(parent(sub)),
                                      map(length, sub.indices),
                                      map(i -> first(i)-1, sub.indices),
                                      Datatype(eltype(sub), commit=false))
-    Types.commit!(datatype)
+    Type.commit!(datatype)
     Buffer(parent(sub), Cint(1), datatype)
 end
 

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -2,20 +2,20 @@ import .CuArrays: CuArray
 import .CuArrays.CUDAdrv: CuPtr, synchronize
 import .CuArrays.CUDAdrv.Mem: DeviceBuffer
 
-function Base.cconvert(::Type{MPIPtr}, buf::CuArray{T}) where T
+function Base.cconvert(::Base.Type{MPIPtr}, buf::CuArray{T}) where T
     Base.cconvert(CuPtr{T}, buf) # returns DeviceBuffer
 end
 
 # CuArrays <= v1.3
-function Base.unsafe_convert(::Type{MPIPtr}, buf::DeviceBuffer)
+function Base.unsafe_convert(::Base.Type{MPIPtr}, buf::DeviceBuffer)
     reinterpret(MPIPtr, buf.ptr)
 end
 # CuArrays > v1.3
-function Base.unsafe_convert(::Type{MPIPtr}, X::CuArray{T}) where T
+function Base.unsafe_convert(::Base.Type{MPIPtr}, X::CuArray{T}) where T
     reinterpret(MPIPtr, Base.unsafe_convert(CuPtr{T}, X))
 end
 # only need to define this for strided arrays: all others can be handled by generic machinery
-function Base.unsafe_convert(::Type{MPIPtr}, V::SubArray{T,N,P,I,true}) where {T,N,P<:CuArray,I}
+function Base.unsafe_convert(::Base.Type{MPIPtr}, V::SubArray{T,N,P,I,true}) where {T,N,P<:CuArray,I}
     X = parent(V)
     pX = Base.unsafe_convert(CuPtr{T}, X)
     pV = pX + ((V.offset1 + V.stride1) - first(LinearIndices(X)))*sizeof(T)

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -53,13 +53,13 @@ for (mpiname, T) in [
 
     @eval if @isdefined($(Symbol(:MPI_,mpiname)))
         const $mpiname = _Datatype($(Symbol(:MPI_,mpiname)))
-        if !hasmethod(Datatype, Tuple{Type{$T}})
-            Datatype(::Type{$T}; commit=true) = $mpiname
+        if !hasmethod(Datatype, Tuple{Base.Type{$T}})
+            Datatype(::Base.Type{$T}; commit=true) = $mpiname
         end
     end
 end
     
-module Types
+module Type
 
 import MPI
 import MPI: @mpichk, libmpi, _doc_external,
@@ -67,7 +67,7 @@ import MPI: @mpichk, libmpi, _doc_external,
     refcount_inc, refcount_dec, free
 
 """
-    lb, extent = MPI.Types.extent(dt::MPI.Datatype)
+    lb, extent = MPI.Type.extent(dt::MPI.Datatype)
 
 Gets the lowerbound `lb` and the extent `extent` in bytes.
 
@@ -86,11 +86,11 @@ function extent(dt::Datatype)
 end
 
 """
-    MPI.Types.create_contiguous(count::Integer, oldtype::MPI.Datatype)
+    MPI.Type.create_contiguous(count::Integer, oldtype::MPI.Datatype)
 
 Create a derived [`Datatype`](@ref) that replicates `oldtype` into `count` contiguous locations.
 
-Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
+Note that [`MPI.Type.commit!`](@ref) must be used before the datatype can be used for
 communication.
 
 # External links
@@ -108,19 +108,19 @@ end
 
 
 """
-    MPI.Types.create_vector(count::Integer, blocklength::Integer, stride::Integer, oldtype::MPI.Datatype)
+    MPI.Type.create_vector(count::Integer, blocklength::Integer, stride::Integer, oldtype::MPI.Datatype)
 
 Create a derived [`Datatype`](@ref) that replicates `oldtype` into locations that
 consist of equally spaced blocks. 
 
-Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
+Note that [`MPI.Type.commit!`](@ref) must be used before the datatype can be used for
 communication.
 
 # Example
 
 ```julia
-datatype = MPI.Types.create_vector(3, 2, 5, MPI.Datatype(Int64))
-MPI.Types.commit!(datatype)
+datatype = MPI.Type.create_vector(3, 2, 5, MPI.Datatype(Int64))
+MPI.Type.commit!(datatype)
 ```
 will create a datatype with the following layout
 ```
@@ -152,7 +152,7 @@ function create_vector(count::Integer, blocklength::Integer, stride::Integer, ol
 end
 
 """
-    MPI.Types.create_subarray(sizes, subsizes, offset, oldtype::Datatype;
+    MPI.Type.create_subarray(sizes, subsizes, offset, oldtype::Datatype;
                               rowmajor=false)
     
 Creates a derived [`Datatype`](@ref) describing an `N`-dimensional subarray of size
@@ -162,7 +162,7 @@ the first element offset by `offset` (i.e. the 0-based index of the first elemen
 Column-major indexing (used by Julia and Fortran) is assumed; use the keyword
 `rowmajor=true` to specify row-major layout (used by C and numpy).
 
-Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
+Note that [`MPI.Type.commit!`](@ref) must be used before the datatype can be used for
 communication.
 
 # External links
@@ -190,11 +190,11 @@ function create_subarray(sizes,
 end
 
 """
-    MPI.Types.create_struct(blocklengths, displacements, types)
+    MPI.Type.create_struct(blocklengths, displacements, types)
 
 Creates a derived [`Datatype`](@ref) describing a struct layout.
 
-Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
+Note that [`MPI.Type.commit!`](@ref) must be used before the datatype can be used for
 communication.
 
 # External links
@@ -223,17 +223,17 @@ end
 
 
 """
-    MPI.Types.create_resized(oldtype::Datatype, lb::Integer, extent::Integer)
+    MPI.Type.create_resized(oldtype::Datatype, lb::Integer, extent::Integer)
 
 Creates a new [`Datatype`](@ref) that is identical to `oldtype`, except that the lower
 bound of this new datatype is set to be `lb`, and its upper bound is set to be `lb +
 extent`.
 
-Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
+Note that [`MPI.Type.commit!`](@ref) must be used before the datatype can be used for
 communication.
 
 # See also
-- [`MPI.Types.extent`](@ref)
+- [`MPI.Type.extent`](@ref)
 
 # External links
 $(_doc_external("MPI_Type_create_resized"))
@@ -252,7 +252,7 @@ end
 
 
 """
-    MPI.Types.commit!(newtype::Datatype)
+    MPI.Type.commit!(newtype::Datatype)
 
 Commits a [`Datatype`](@ref) so that it can be used for communication.
 
@@ -266,7 +266,7 @@ function commit!(newtype::Datatype)
 end
 
 
-function Datatype(::Type{T}; commit=true) where T
+function Datatype(::Base.Type{T}; commit=true) where T
     if !isbitstype(T)
         throw(ArgumentError("Type must be isbitstype"))
     end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -43,11 +43,11 @@ end false
 
 @deprecate(Type_Create_Subarray(ndims::Integer, sizes::MPIBuffertype{Cint}, subsizes::MPIBuffertype{Cint},
                                 starts::MPIBuffertype{Cint}, order::Integer, oldtype),
-           Types.create_subarray(sizes, subsizes, starts, Datatype(oldtype); rowmajor = order == MPI_ORDER_C), false)
+           Type.create_subarray(sizes, subsizes, starts, Datatype(oldtype); rowmajor = order == MPI_ORDER_C), false)
 @deprecate(Type_Create_Struct(nfields::Integer, blocklengths::MPIBuffertype{Cint},
                               displacements::MPIBuffertype{Cptrdiff_t}, types::MPIBuffertype{MPI_Datatype}),
-           Types.create_struct(blocklengths, displacements, types), false)
-@deprecate(Type_Commit!(datatype), Types.commit!(datatype), false)
+           Type.create_struct(blocklengths, displacements, types), false)
+@deprecate(Type_Commit!(datatype), Type.commit!(datatype), false)
 
 
 @deprecate(Send(buf, count::Integer, datatype::Datatype, dest::Integer, tag::Integer, comm::Comm),

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -26,11 +26,11 @@ macro mpi_handle(def, mpiname=nothing, extrafields...)
         end
 
         # allows us to pass XX objects directly into MPI_XX ccall signatures
-        function Base.cconvert(::Type{$mpiname}, obj::$name)
+        function Base.cconvert(::Base.Type{$mpiname}, obj::$name)
             obj.val
         end
         # allows us to pass XX objects directly into Ptr{MPI_XX} ccall signatures
-        function Base.unsafe_convert(::Type{Ptr{$mpiname}}, obj::$name)
+        function Base.unsafe_convert(::Base.Type{Ptr{$mpiname}}, obj::$name)
             convert(Ptr{$mpiname}, pointer_from_objref(obj))
         end
     end

--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -69,7 +69,7 @@ This is a collective call over `comm`.
 
 [`MPI.free`](@ref) should be called on the `Win` object once operations have been completed.
 """
-function Win_allocate_shared(::Type{T}, len::Int, comm::Comm; kwargs...) where T
+function Win_allocate_shared(::Base.Type{T}, len::Int, comm::Comm; kwargs...) where T
     win = Win()
     out_baseptr = Ref{Ptr{T}}()
     # int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info,

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -36,13 +36,13 @@ if @isdefined(MPI_NO_OP)
     const NO_OP   = _Op(MPI_NO_OP, nothing)
 end
 
-Op(::typeof(min), ::Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint}} = MIN
-Op(::typeof(max), ::Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint}} = MAX
-Op(::typeof(+), ::Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint,MPIComplex}} = SUM
-Op(::typeof(*), ::Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint,MPIComplex}} = PROD
-Op(::typeof(&), ::Type{T}; iscommutative=true) where {T<:MPIInteger} = BAND
-Op(::typeof(|), ::Type{T}; iscommutative=true) where {T<:MPIInteger} = BOR
-Op(::typeof(⊻), ::Type{T}; iscommutative=true) where {T<:MPIInteger} = BXOR
+Op(::typeof(min), ::Base.Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint}} = MIN
+Op(::typeof(max), ::Base.Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint}} = MAX
+Op(::typeof(+), ::Base.Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint,MPIComplex}} = SUM
+Op(::typeof(*), ::Base.Type{T}; iscommutative=true) where {T<:Union{MPIInteger,MPIFloatingPoint,MPIComplex}} = PROD
+Op(::typeof(&), ::Base.Type{T}; iscommutative=true) where {T<:MPIInteger} = BAND
+Op(::typeof(|), ::Base.Type{T}; iscommutative=true) where {T<:MPIInteger} = BOR
+Op(::typeof(⊻), ::Base.Type{T}; iscommutative=true) where {T<:MPIInteger} = BXOR
 
 
 function free(op::Op)

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -164,7 +164,7 @@ function Get_count(stat::Status, datatype::Datatype)
                   Ref(stat), datatype, count)
     Int(count[])
 end
-Get_count(stat::Status, ::Type{T}) where {T} = Get_count(stat, Datatype(T))
+Get_count(stat::Status, ::Base.Type{T}) where {T} = Get_count(stat, Datatype(T))
 
 
 """
@@ -295,7 +295,7 @@ Returns a tuple of the object of type `T` and the [`Status`](@ref) of the receiv
 # External links
 $(_doc_external("MPI_Recv"))
 """
-function Recv(::Type{T}, src::Integer, tag::Integer, comm::Comm) where T
+function Recv(::Base.Type{T}, src::Integer, tag::Integer, comm::Comm) where T
     buf = Ref{T}()
     stat = Recv!(buf, src, tag, comm)
     (buf[], stat)

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -27,7 +27,7 @@ end
 @testset "Compound type" begin
     sz = sizeof(Boundary)
     al = Base.datatype_alignment(Boundary)
-    @test MPI.Types.extent(MPI.Datatype(Boundary)) == (0, cld(sz,al)*al)
+    @test MPI.Type.extent(MPI.Datatype(Boundary)) == (0, cld(sz,al)*al)
 
     arr = [Boundary( (comm_rank + i) % 127, i + comm_rank, i % 64) for i = 1:3]
     req_send = MPI.Isend(arr, dest, 1, MPI.COMM_WORLD)
@@ -56,7 +56,7 @@ end
 @testset "nested types" begin
     sz = sizeof(Boundary2)
     al = Base.datatype_alignment(Boundary2)
-    @test MPI.Types.extent(MPI.Datatype(Boundary2)) == (0, cld(sz,al)*al)
+    @test MPI.Type.extent(MPI.Datatype(Boundary2)) == (0, cld(sz,al)*al)
 
     arr = [Boundary2( (comm_rank + i) % 127, ( Int(i + comm_rank), UInt8(i % 64)), nothing) for i = 1:3]
     arr_recv = Array{Boundary2}(undef,3)
@@ -84,7 +84,7 @@ primitive type Primitive80 80 end
 @testset for PrimitiveType in (Primitive16, Primitive24, Primitive80)        
     sz = sizeof(PrimitiveType)
     al = Base.datatype_alignment(PrimitiveType)
-    @test MPI.Types.extent(MPI.Datatype(PrimitiveType)) == (0, cld(sz,al)*al)
+    @test MPI.Type.extent(MPI.Datatype(PrimitiveType)) == (0, cld(sz,al)*al)
 
     if VERSION < v"1.3" && PrimitiveType == Primitive80
         # alignment is broken on earlier Julia versions
@@ -108,7 +108,7 @@ end
 
     sz = sizeof(T)
     al = Base.datatype_alignment(T)
-    @test MPI.Types.extent(MPI.Datatype(T)) == (0, cld(sz,al)*al)
+    @test MPI.Type.extent(MPI.Datatype(T)) == (0, cld(sz,al)*al)
 
     arr = [(UInt8(comm_rank),UInt8(i),UInt8(0)) for i = 1:8]
     arr_recv = Array{T}(undef,8)
@@ -129,7 +129,7 @@ end
 
     # OpenMPI gives incorrect values
     # see https://github.com/open-mpi/ompi/issues/7266
-    # @test MPI.Types.extent(MPI.Datatype(Nothing)) == (0, cld(sz,al)*al)
+    # @test MPI.Type.extent(MPI.Datatype(Nothing)) == (0, cld(sz,al)*al)
 
     arr = [nothing for i = 1:100]
     arr_recv = Array{Nothing}(undef,100)


### PR DESCRIPTION
Makes the name consistent with MPI (see #338).