### PR TITLE
Spectrum MPI is called mpi_ibm

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -27,7 +27,7 @@ end
 const mpiexec_args = split(get(ENV, "JULIA_MPIEXEC_ARGS", ""))
 
 const libmpi = get(ENV, "JULIA_MPI_LIBRARY") do
-    libmpi = find_library(["libmpi", "msmpi", "libmpich"],
+    libmpi = find_library(["libmpi", "libmpi_ibm", "msmpi", "libmpich"],
                           MPI_LIBRARY_PATH !== nothing ? [MPI_LIBRARY_PATH] : [])
     if libmpi == ""
         error("No MPI library found.\nEnsure an MPI implementation is loaded, or set the `JULIA_MPI_PATH` variable.")


### PR DESCRIPTION
Apparently something that happened to PyMPI as well
https://bitbucket.org/mpi4py/mpi4py/issues/63/cant-import-mpi-with-spectrum-mpi

I suspect I didn't see this on Summit before, because we were using the cmake
infrastructure.