### PR TITLE
Add logo to docs

### DIFF
--- a/docs/src/assets/logo.svg
+++ b/docs/src/assets/logo.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   sodipodi:docname="mpi_jl.svg"
+   viewBox="0 0 275.6608 198.06421"
+   height="198.06421"
+   width="275.6608"
+   id="svg80"
+   version="1.1">
+  <metadata
+     id="metadata86">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs84" />
+  <sodipodi:namedview
+     inkscape:current-layer="g88"
+     inkscape:window-maximized="0"
+     inkscape:window-y="44"
+     inkscape:window-x="1763"
+     inkscape:cy="145.35694"
+     inkscape:cx="280.32616"
+     inkscape:zoom="1.1"
+     showgrid="false"
+     id="namedview82"
+     inkscape:window-height="853"
+     inkscape:window-width="1418"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <g
+     id="g88"
+     inkscape:label="Image"
+     inkscape:groupmode="layer">
+    <rect
+       transform="matrix(0.99981558,0.01920454,-0.32803664,0.944665,0,0)"
+       y="-2.7273855"
+       x="134.15919"
+       height="141.78041"
+       width="140.65759"
+       id="rect94-6-7"
+       style="fill:#9558b2;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.13111" />
+    <rect
+       style="fill:#389826;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.13111;stroke-opacity:1"
+       id="rect94-6"
+       width="140.65759"
+       height="141.78041"
+       x="100.75105"
+       y="30.745317"
+       transform="matrix(0.99981558,0.01920454,-0.32803664,0.944665,0,0)" />
+    <rect
+       transform="matrix(0.99981558,0.01920454,-0.32803664,0.944665,0,0)"
+       y="63.65591"
+       x="67.403069"
+       height="141.78041"
+       width="140.65759"
+       id="rect94"
+       style="fill:#cb3c33;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.13111" />
+  </g>
+</svg>


### PR DESCRIPTION
Based on the MPI logo (https://github.com/mpi-forum/mpi-forum.github.io/blob/master/images/mpi-forum-logo.jpg) but using Julia colours.