### PR TITLE
only finalize in the case that jl_current_exception is unset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ function runtests()
 
     nfail = 0
     printstyled("Running MPI.jl tests\n"; color=:white)
-    
+
     for f in testfiles
         mpiexec() do cmd
             cmd = `$cmd $args`
@@ -32,6 +32,9 @@ function runtests()
                 withenv("JULIA_NUM_THREAD" => "4") do
                     run(`$cmd -n $nprocs $(Base.julia_cmd()) $(joinpath(testdir, f))`)
                 end
+            elseif f == "test_error.jl"
+                r = run(ignorestatus(`$cmd -n $nprocs $(Base.julia_cmd()) $(joinpath(testdir, f))`))
+                @test !success(r)
             else
                 run(`$cmd -n $nprocs $(Base.julia_cmd()) $(joinpath(testdir, f))`)
             end

--- a/test/test_error.jl
+++ b/test/test_error.jl
@@ -1,0 +1,11 @@
+using MPI
+function main()
+    MPI.Init()
+    comm = MPI.COMM_WORLD
+    rank = MPI.Comm_rank(comm)
+    if rank == 1
+        error("Goodbye")
+    end
+    MPI.Barrier(comm)
+end
+main()


### PR DESCRIPTION
For my simple test-case this seems to work, of course if any more complicated finalizer clobbers
the current exception we are back at a deadlock. 

x-ref: https://github.com/JuliaLang/julia/issues/35981

```
➜  ~ mpirun -np 2 julia mpi.jl
rank = 0
rank = 1
ERROR: LoadError: Goodbye
Stacktrace:
 [1] main() at /home/vchuravy/mpi.jl:11
 [2] top-level scope at /home/vchuravy/mpi.jl:16
in expression starting at /home/vchuravy/mpi.jl:16
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------

signal (15): Terminated
in expression starting at /home/vchuravy/mpi.jl:16
unknown function (ip: 0x7fbedea02bc8)
opal_progress at /usr/lib/openmpi/libopen-pal.so.40 (unknown line)
ompi_request_default_wait at /usr/lib/openmpi/libmpi.so (unknown line)
ompi_coll_base_barrier_intra_two_procs at /usr/lib/openmpi/libmpi.so (unknown line)
PMPI_Barrier at /usr/lib/openmpi/libmpi.so (unknown line)
Barrier at /home/vchuravy/src/MPI/src/collective.jl:17 [inlined]
main at /home/vchuravy/mpi.jl:13
unknown function (ip: 0x7fbee955598c)
unknown function (ip: 0x7fbefbc3e855)
unknown function (ip: 0x7fbefbc3e4fa)
unknown function (ip: 0x7fbefbc3fd84)
unknown function (ip: 0x7fbefbc40832)
unknown function (ip: 0x7fbefbc5e371)
unknown function (ip: 0x7fbefbc32d9e)
jl_load at /usr/bin/../lib/libjulia.so.1 (unknown line)
unknown function (ip: 0x7fbeeec3a4bb)
unknown function (ip: 0x7fbeeec4611f)
unknown function (ip: 0x7fbeeec467e2)
unknown function (ip: 0x7fbeeec46925)
unknown function (ip: 0x5577cc4f94fe)
unknown function (ip: 0x5577cc4f90a7)
__libc_start_main at /usr/bin/../lib/libc.so.6 (unknown line)
unknown function (ip: 0x5577cc4f915d)
unknown function (ip: (nil))
Allocations: 841723 (Pool: 841418; Big: 305); GC: 1
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[28818,1],1]
  Exit code:    1
--------------------------------------------------------------------------
```