### PR TITLE
Several fixes to `Exscan!`

### DIFF
--- a/src/collective.jl
+++ b/src/collective.jl
@@ -844,16 +844,16 @@ end
 function Exscan!(sendbuf, recvbuf, count::Integer, opfunc, comm::Comm)
     Exscan!(sendbuf, recvbuf, count, Op(opfunc, eltype(recvbuf)), comm)
 end
-function Exscan!(sendbuf::AbstractArray, recvbuf, op, comm::Comm)
+function Exscan!(sendbuf::AbstractArray, recvbuf::AbstractArray, op, comm::Comm)
     Exscan!(sendbuf, recvbuf, length(sendbuf), op, comm)
 end
 
 # inplace
 function Exscan!(buf, count::Integer, opfunc, comm::Comm)
-    Exscan!(MPI_IN_PLACE, buf, count, Op(opfunc, eltype(sendbuf)), comm)
+    Exscan!(MPI_IN_PLACE, buf, count, Op(opfunc, eltype(buf)), comm)
 end
-function Exscan!(buf, opfunc, comm::Comm)
-    Exscan!(buf, length(buf), Op(opfunc, eltype(sendbuf)), comm)
+function Exscan!(buf, op, comm::Comm)
+    Exscan!(buf, length(buf), op, comm)
 end
 
 

--- a/test/test_exscan.jl
+++ b/test/test_exscan.jl
@@ -26,8 +26,16 @@ for T in setdiff([Base.uniontypes(MPI.MPIDatatype)...], [Char, Int8, UInt8])
     
     B = MPI.Exscan(A, *, comm)
     @test B isa ArrayType{T}
+
+    MPI.Exscan!(A, length(A), *, comm)
     if rank > 0
-        @test B == ArrayType{T}(fill(T(prodrank), 4))
+        @test A == ArrayType{T}(fill(T(prodrank), 4))
+    end
+
+    A = ArrayType{T}(fill(T(rank+1), 4))
+    MPI.Exscan!(A, *, comm)
+    if rank > 0
+        @test A == ArrayType{T}(fill(T(prodrank), 4))
     end
     
     B = MPI.Exscan(T(rank+1), *, comm)


### PR DESCRIPTION
* Fixed several issues related to the Exscan! API and implementation (one ambiguity, double call to `Op(opfunc, eltype(buf))`, together with the typos described in
  https://github.com/JuliaParallel/MPI.jl/issues/394

* Added two tests to test_exscan.jl in order to stress two untested
  overloaded variants of Exscan.