### PR TITLE
I/O: add wrappers for reading and writing to views

### DIFF
--- a/docs/src/io.md
+++ b/docs/src/io.md
@@ -21,6 +21,15 @@ MPI.File.sync
 
 ## Data access
 
+### Views
+
+```@docs
+MPI.File.read!
+MPI.File.read_all!
+MPI.File.write
+MPI.File.write_all
+```
+
 ### Explicit offsets
 
 ```@docs

--- a/docs/src/io.md
+++ b/docs/src/io.md
@@ -21,7 +21,7 @@ MPI.File.sync
 
 ## Data access
 
-### Views
+### Individual pointer
 
 ```@docs
 MPI.File.read!

--- a/src/io.jl
+++ b/src/io.jl
@@ -135,7 +135,7 @@ function sync(file::FileHandle)
 end
 
 
-# I/O using views
+# I/O using individual file pointers
 """
     MPI.File.read!(file::FileHandle, data)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -135,6 +135,106 @@ function sync(file::FileHandle)
 end
 
 
+# I/O using views
+"""
+    MPI.File.read!(file::FileHandle, data)
+
+Reads current view of `file` into `data`. `data` can be a [`Buffer`](@ref), or
+any object for which `Buffer(data)` is defined.
+
+# See also
+- [`MPI.File.set_view!`](@ref) to set the current view of the file
+- [`MPI.File.read_all!`](@ref) for the collective operation
+
+# External links
+$(_doc_external("MPI_File_read"))
+"""
+function read!(file::FileHandle, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_read(MPI_File fh, void *buf,
+    #                   int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_read, libmpi), Cint,
+                  (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+read!(file::FileHandle, data) = read!(file, Buffer(data))
+
+"""
+    MPI.File.read_all!(file::FileHandle, data)
+
+Reads current view of `file` into `data`. `data` can be a [`Buffer`](@ref), or
+any object for which `Buffer(data)` is defined. This is a collective operation, so must be
+called on all ranks in the communicator on which `file` was opened.
+
+# See also
+- [`MPI.File.set_view!`](@ref) to set the current view of the file
+- [`MPI.File.read!`](@ref) for the noncollective operation
+
+# External links
+$(_doc_external("MPI_File_read_all"))
+"""
+function read_all!(file::FileHandle, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_read_all(MPI_File fh, void *buf,
+    #                       int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_read_all, libmpi), Cint,
+                  (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+read_all!(file::FileHandle, data) = read_all!(file, Buffer(data))
+
+"""
+    MPI.File.write(file::FileHandle, data)
+
+Writes `data` to the current view of `file`. `data` can be a [`Buffer`](@ref),
+or any object for which `Buffer_send(data)` is defined.
+
+# See also
+- [`MPI.File.set_view!`](@ref) to set the current view of the file
+- [`MPI.File.write_all`](@ref) for the collective operation
+
+# External links
+$(_doc_external("MPI_File_write"))
+"""
+function write(file::FileHandle, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_write(MPI_File fh, const void *buf,
+    #                    int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_write, libmpi), Cint,
+                  (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+write(file::FileHandle, data) = write(file, Buffer_send(data))
+
+"""
+    MPI.File.write_all(file::FileHandle, data)
+
+Writes `data` to the current view of `file`. `data` can be a [`Buffer`](@ref),
+or any object for which `Buffer_send(data)` is defined. This is a collective
+operation, so must be called on all ranks in the communicator on which `file` was opened.
+
+# See also
+- [`MPI.File.set_view!`](@ref) to set the current view of the file
+- [`MPI.File.write`](@ref) for the noncollective operation
+
+# External links
+$(_doc_external("MPI_File_write_all"))
+"""
+function write_all(file::FileHandle, buf::Buffer)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    # int MPI_File_write_all(MPI_File fh, const void *buf,
+    #                    int count, MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall((:MPI_File_write_all, libmpi), Cint,
+                  (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
+                  file, buf.data, buf.count, buf.datatype, stat_ref)
+    return stat_ref[]
+end
+write_all(file::FileHandle, data) = write_all(file, Buffer_send(data))
+
+
 # Explicit offsets
 """
     MPI.File.read_at!(file::FileHandle, offset::Integer, data)

--- a/test/test_io_subarray.jl
+++ b/test/test_io_subarray.jl
@@ -1,0 +1,57 @@
+using Test
+using MPI
+using Random
+
+if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "CuArray"
+    import CUDA
+    ArrayType = CUDA.CuArray
+else
+    ArrayType = Array
+end
+
+MPI.Init()
+comm = MPI.COMM_WORLD
+rank = MPI.Comm_rank(comm)
+sz = MPI.Comm_size(comm)
+filename = MPI.bcast(tempname(), 0, comm)
+
+MPI.Barrier(comm)
+
+# Assume `data` is a subarray of a (3sz, 2sz, 5) global array that should be
+# written as a contiguous block to a single file. Note that `data` is a
+# discontiguous view of the global array.
+data = ArrayType(rand(Float64, 3, 2, 5))
+offset = (3rank, 2rank, 0)
+etype = MPI.Datatype(eltype(data))
+filetype = MPI.Types.create_subarray((3sz, 2sz, 5), size(data), offset, etype)
+MPI.Types.commit!(filetype)
+
+fh = MPI.File.open(comm, filename, read=true, write=true, create=true)
+
+# Collective write
+disp = 0
+MPI.File.set_view!(fh, disp, etype, filetype)
+MPI.File.write_all(fh, data)
+
+# Noncollective write
+disp = sizeof(data) * sz
+MPI.File.set_view!(fh, disp, etype, filetype)
+MPI.File.write(fh, data)
+
+MPI.File.sync(fh)
+
+# Noncollective read
+data_read = similar(data)
+disp = 0
+MPI.File.set_view!(fh, disp, etype, filetype)
+MPI.File.read!(fh, data_read)
+@test data_read == data
+
+# Collective read
+disp = sizeof(data) * sz
+fill!(data_read, 0)
+MPI.File.set_view!(fh, disp, etype, filetype)
+MPI.File.read_all!(fh, data_read)
+@test data_read == data
+
+close(fh)


### PR DESCRIPTION
This PR adds wrappers to MPI functions for reading and writing to views using independent and collective communication.

In particular, these functions allow to read and write subarrays representing discontiguous views of a distributed array.

Wrapped functions:

- `MPI_File_read`: read from file view (non-collective)
- `MPI_File_read_all`: read from file view (collective)
- `MPI_File_write`: write to file view (non-collective)
- `MPI_File_write_all`: write to file view (collective)