### PR TITLE
remove reference counting in lieu of Finalized() checks

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -4,8 +4,6 @@
 
 ```@docs
 MPI.free
-MPI.refcount_inc
-MPI.refcount_dec
 ```
 
 ## Buffers

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -37,29 +37,3 @@ with one-sided operations, but these are not often supported).
 
 If using Open MPI, the status of CUDA support can be checked via the
 [`MPI.has_cuda()`](@ref) function.
-
-## Finalizers
-
-In order to ensure MPI routines are called in the correct order at finalization time,
-MPI.jl maintains a reference count. If you define an object that needs to call an MPI
-routine during its finalization, you should call [`MPI.refcount_inc()`](@ref) when it is
-initialized, and [`MPI.refcount_dec()`](@ref) in its finalizer (after the relevant MPI
-call).
-
-For example
-```julia
-mutable struct MyObject
-    ...
-    function MyObject(args...)
-        obj = new(args...)
-        # MPI call to create object
-        refcount_inc()
-        finalizer(obj) do x
-            # MPI call to free object
-            refcount_dec()
-        end
-        return obj
-    end
-end
-```
-    

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -69,7 +69,7 @@ $(_doc_external("MPI_Init"))
 """
 function Init()
     @mpichk ccall((:MPI_Init, libmpi), Cint, (Ptr{Cint},Ptr{Cint}), C_NULL, C_NULL)
-    atexit(Finalize)
+    atexit(() -> Finalized() || Finalize())
 
     run_init_hooks()
     _warn_if_wrong_mpi()
@@ -138,8 +138,7 @@ function Init_thread(required::ThreadLevel)
         @warn "Thread level requested = $required, provided = $provided"
     end
 
-    atexit(Finalize)
-
+    atexit(() -> Finalized() || Finalize())
     run_init_hooks()
     _warn_if_wrong_mpi()
     return provided

--- a/src/info.jl
+++ b/src/info.jl
@@ -33,16 +33,14 @@ function Info(;init=false)
     info = Info(INFO_NULL.val)
     if init
         @mpichk ccall((:MPI_Info_create, libmpi), Cint, (Ptr{MPI_Info},), info)
-        refcount_inc()
         finalizer(free, info)
     end
     return info
 end
 
 function free(info::Info)
-    if info.val != INFO_NULL.val
+    if info.val != INFO_NULL.val && !Finalized()
         @mpichk ccall((:MPI_Info_free, libmpi), Cint, (Ptr{MPI_Info},), info)
-        refcount_dec()
     end
     return nothing
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -4,7 +4,7 @@ FileHandle() = FileHandle(FILE_NULL.val)
 
 module File
 
-import MPI: MPI, @mpichk, _doc_external, MPIPtr, libmpi,
+import MPI: MPI, @mpichk, _doc_external, MPIPtr, libmpi, Finalized,
     Comm, MPI_Comm, FileHandle, MPI_File, Info, MPI_Info, FILE_NULL,
     Datatype, MPI_Datatype, MPI_Offset, Status, Buffer, Buffer_send
 import Base: close

--- a/src/io.jl
+++ b/src/io.jl
@@ -4,7 +4,7 @@ FileHandle() = FileHandle(FILE_NULL.val)
 
 module File
 
-import MPI: MPI, @mpichk, _doc_external, MPIPtr, libmpi, refcount_inc, refcount_dec,
+import MPI: MPI, @mpichk, _doc_external, MPIPtr, libmpi,
     Comm, MPI_Comm, FileHandle, MPI_File, Info, MPI_Info, FILE_NULL,
     Datatype, MPI_Datatype, MPI_Offset, Status, Buffer, Buffer_send
 import Base: close
@@ -16,7 +16,6 @@ function open(comm::Comm, filename::AbstractString, amode::Cint, info::Info)
     @mpichk ccall((:MPI_File_open, libmpi), Cint,
                   (MPI_Comm, Cstring, Cint, MPI_Info, Ptr{MPI_File}),
                   comm, filename, amode, info, file)
-    refcount_inc()
     finalizer(close, file)
     file
 end
@@ -62,11 +61,10 @@ function open(comm::Comm, filename::AbstractString;
 end
 
 function close(file::FileHandle)
-    if file.val != FILE_NULL.val
+    if file.val != FILE_NULL.val && !Finalized()
         # int MPI_File_close(MPI_File *fh)
         @mpichk ccall((:MPI_File_close, libmpi), Cint,
                       (Ptr{MPI_File},), file)
-        refcount_dec()
     end
     return nothing
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -46,9 +46,8 @@ Op(::typeof(⊻), ::Type{T}; iscommutative=true) where {T<:MPIInteger} = BXOR
 
 
 function free(op::Op)
-    if op.val != OP_NULL.val
+    if op.val != OP_NULL.val && !Finalized()
         @mpichk ccall((:MPI_Op_free, libmpi), Cint, (Ptr{MPI_Op},), op)
-        refcount_dec()
     end
     return nothing
 end
@@ -82,7 +81,6 @@ function Op(f, T=Any; iscommutative=false)
                   (Ptr{Cvoid}, Cint, Ptr{MPI_Op}),
                   fptr, iscommutative, op)
 
-    refcount_inc()
     finalizer(free, op)
     return op
 end

--- a/src/topology.jl
+++ b/src/topology.jl
@@ -35,7 +35,6 @@ function Cart_create(comm_old::Comm, ndims::Integer, dims::MPIBuffertype{Cint}, 
                   (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{MPI_Comm}),
                   comm_old, ndims, dims, periods, reorder, comm_cart)
     if comm_cart.val != MPI_COMM_NULL
-        refcount_inc()
         finalizer(free, comm_cart)
     end
     comm_cart
@@ -182,7 +181,6 @@ function Cart_sub(comm::Comm, remain_dims::MPIBuffertype{Cint})
                   (MPI_Comm, Ptr{Cint}, Ptr{MPI_Comm}),
                   comm, remain_dims, comm_sub)
     if comm_sub.val != MPI_COMM_NULL
-        refcount_inc()
         finalizer(free, comm_sub)
     end
     comm_sub


### PR DESCRIPTION
This seems much simpler, and makes it easy to work with externally-initialized MPI (https://github.com/omlins/libdiffusion/pull/2).