### PR TITLE
Make MPI.jl compatible with profilers that use LD_PRELOAD

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -50,7 +50,7 @@ if haskey(ENV, "JULIA_MPIEXEC")
     end
     update_config = true
 end
-    
+
 
 if update_config
     open(config_toml, write=true) do f
@@ -75,10 +75,13 @@ if binary == "system"
     if libmpi == ""
         error("libmpi could not be found")
     end
-    
+
     const mpiexec_cmd = Cmd(mpiexec isa String ? [mpiexec] : mpiexec)
-    
+
     _doc_external(fname) = ""
+
+    # Load the library
+    dlmpi = Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
     include(joinpath("..","src","implementations.jl"))
 
     @info "Using implementation" libmpi mpiexec_cmd MPI_LIBRARY_VERSION_STRING

--- a/deps/consts_mpich.jl
+++ b/deps/consts_mpich.jl
@@ -24,7 +24,7 @@ const MPI_Request = Cint
 const MPI_REQUEST_NULL = Cint(738197504)
 
 const MPI_File = Ptr{Cvoid}
-MPI_File_f2c(c::Cint) = ccall((:MPI_File_f2c,libmpi),MPI_File,(Cint,),c)
+MPI_File_f2c(c::Cint) = ccall(:MPI_File_f2c,MPI_File,(Cint,),c)
 const MPI_FILE_NULL = Cint(0)
 
 const MPI_Op = Cint

--- a/deps/consts_openmpi.jl
+++ b/deps/consts_openmpi.jl
@@ -10,29 +10,29 @@ const MPI_Status_Tag_offset = 4
 const MPI_Status_Error_offset = 8
 
 const MPI_Info = Ptr{Cvoid}
-MPI_Info_f2c(c::Cint) = ccall((:MPI_Info_f2c,libmpi),MPI_Info,(Cint,),c)
+MPI_Info_f2c(c::Cint) = ccall(:MPI_Info_f2c,MPI_Info,(Cint,),c)
 const MPI_INFO_NULL = Cint(0)
 
 const MPI_Win = Ptr{Cvoid}
-MPI_Win_f2c(c::Cint) = ccall((:MPI_Win_f2c,libmpi),MPI_Win,(Cint,),c)
+MPI_Win_f2c(c::Cint) = ccall(:MPI_Win_f2c,MPI_Win,(Cint,),c)
 const MPI_WIN_NULL = Cint(0)
 
 const MPI_Comm = Ptr{Cvoid}
-MPI_Comm_f2c(c::Cint) = ccall((:MPI_Comm_f2c,libmpi),MPI_Comm,(Cint,),c)
+MPI_Comm_f2c(c::Cint) = ccall(:MPI_Comm_f2c,MPI_Comm,(Cint,),c)
 const MPI_COMM_NULL = Cint(2)
 const MPI_COMM_SELF = Cint(1)
 const MPI_COMM_WORLD = Cint(0)
 
 const MPI_Request = Ptr{Cvoid}
-MPI_Request_f2c(c::Cint) = ccall((:MPI_Request_f2c,libmpi),MPI_Request,(Cint,),c)
+MPI_Request_f2c(c::Cint) = ccall(:MPI_Request_f2c,MPI_Request,(Cint,),c)
 const MPI_REQUEST_NULL = Cint(0)
 
 const MPI_File = Ptr{Cvoid}
-MPI_File_f2c(c::Cint) = ccall((:MPI_File_f2c,libmpi),MPI_File,(Cint,),c)
+MPI_File_f2c(c::Cint) = ccall(:MPI_File_f2c,MPI_File,(Cint,),c)
 const MPI_FILE_NULL = Cint(0)
 
 const MPI_Op = Ptr{Cvoid}
-MPI_Op_f2c(c::Cint) = ccall((:MPI_Op_f2c,libmpi),MPI_Op,(Cint,),c)
+MPI_Op_f2c(c::Cint) = ccall(:MPI_Op_f2c,MPI_Op,(Cint,),c)
 const MPI_OP_NULL = Cint(0)
 const MPI_BAND = Cint(6)
 const MPI_BOR = Cint(8)
@@ -50,7 +50,7 @@ const MPI_REPLACE = Cint(13)
 const MPI_NO_OP = Cint(14)
 
 const MPI_Datatype = Ptr{Cvoid}
-MPI_Datatype_f2c(c::Cint) = ccall((:MPI_Type_f2c,libmpi),MPI_Datatype,(Cint,),c)
+MPI_Datatype_f2c(c::Cint) = ccall(:MPI_Type_f2c,MPI_Datatype,(Cint,),c)
 const MPI_DATATYPE_NULL = Cint(0)
 const MPI_PACKED = Cint(2)
 const MPI_CHAR = Cint(34)

--- a/deps/gen_consts.jl
+++ b/deps/gen_consts.jl
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
             end
         else
             println(f,"  fprintf(fptr, \"const $T = Ptr{Cvoid}\\n\");")
-            println(f,"  fprintf(fptr, \"$(Symbol(T,:_f2c))(c::Cint) = ccall((:$T_f2c,libmpi),$T,(Cint,),c)\\n\");")
+            println(f,"  fprintf(fptr, \"$(Symbol(T,:_f2c))(c::Cint) = ccall(:$T_f2c,$T,(Cint,),c)\\n\");")
             for constant in constants
                 println(f,"  fprintf(fptr, \"const $constant = Cint(%i)\\n\", $T_c2f($constant));")
             end

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -12,7 +12,7 @@ $(_doc_external("MPI_Barrier"))
 """
 function Barrier(comm::Comm)
     # int MPI_Barrier(MPI_Comm comm)
-    @mpichk ccall((:MPI_Barrier, libmpi), Cint, (MPI_Comm,), comm)
+    @mpichk ccall(:MPI_Barrier, Cint, (MPI_Comm,), comm)
     return nothing
 end
 
@@ -30,7 +30,7 @@ $(_doc_external("MPI_Bcast"))
 function Bcast!(buf::Buffer, root::Integer, comm::Comm)
     # int MPI_Bcast(void* buffer, int count, MPI_Datatype datatype, int root,
     #               MPI_Comm comm)
-    @mpichk ccall((:MPI_Bcast, libmpi), Cint,
+    @mpichk ccall(:MPI_Bcast, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
                   buf.data, buf.count, buf.datatype, root, comm)
     return buf.data
@@ -83,7 +83,7 @@ unmodified. For example:
 if root == MPI.Comm_rank(comm)
     MPI.Scatter!(UBuffer(buf, count), MPI.IN_PLACE, root, comm)
 else
-    MPI.Scatter!(nothing, buf, root, comm)        
+    MPI.Scatter!(nothing, buf, root, comm)
 end
 ```
 
@@ -100,7 +100,7 @@ function Scatter!(sendbuf::UBuffer, recvbuf::Buffer, root::Integer, comm::Comm)
     # int MPI_Scatter(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
     #                 void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
     #                 MPI_Comm comm)
-    @mpichk ccall((:MPI_Scatter, libmpi), Cint,
+    @mpichk ccall(:MPI_Scatter, Cint,
                   (MPIPtr, Cint, MPI_Datatype,
                    MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
@@ -114,7 +114,7 @@ Scatter!(sendbuf::Nothing, recvbuf, root::Integer, comm::Comm) =
 
 # determine UBuffer count from recvbuf
 Scatter!(sendbuf::AbstractArray, recvbuf::Union{Ref,AbstractArray}, root::Integer, comm::Comm) =
-    Scatter!(UBuffer(sendbuf,length(recvbuf)), recvbuf, root, comm)    
+    Scatter!(UBuffer(sendbuf,length(recvbuf)), recvbuf, root, comm)
 
 """
     Scatterv!(sendbuf::Union{VBuffer,Nothing}, recvbuf, root, comm)
@@ -149,7 +149,7 @@ function Scatterv!(sendbuf::VBuffer, recvbuf::Buffer, root::Integer, comm::Comm)
     # int MPI_Scatterv(const void* sendbuf, const int sendcounts[],
     #                  const int displs[], MPI_Datatype sendtype, void* recvbuf,
     #                  int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm)
-    @mpichk ccall((:MPI_Scatterv, libmpi), Cint,
+    @mpichk ccall(:MPI_Scatterv, Cint,
                   (MPIPtr, Ptr{Cint}, Ptr{Cint},  MPI_Datatype,
                    MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
                   sendbuf.data, sendbuf.counts, sendbuf.displs, sendbuf.datatype,
@@ -203,7 +203,7 @@ function Gather!(sendbuf::Buffer, recvbuf::UBuffer, root::Integer, comm::Comm)
     # int MPI_Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
     #                void* recvbuf, int recvcount, MPI_Datatype recvtype, int root,
     #                MPI_Comm comm)
-    @mpichk ccall((:MPI_Gather, libmpi), Cint,
+    @mpichk ccall(:MPI_Gather, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
                   recvbuf.data, recvbuf.count, recvbuf.datatype, root, comm)
@@ -280,7 +280,7 @@ function Gatherv!(sendbuf::Buffer, recvbuf::VBuffer, root::Integer, comm::Comm)
     # int MPI_Gatherv(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
     #                 void* recvbuf, const int recvcounts[], const int displs[],
     #                 MPI_Datatype recvtype, int root, MPI_Comm comm)
-    @mpichk ccall((:MPI_Gatherv, libmpi), Cint,
+    @mpichk ccall(:MPI_Gatherv, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Cint, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
                   recvbuf.data, recvbuf.counts, recvbuf.displs, recvbuf.datatype, root, comm)
@@ -325,7 +325,7 @@ function Allgather!(sendbuf::Buffer, recvbuf::UBuffer, comm::Comm)
     # int MPI_Allgather(const void* sendbuf, int sendcount,
     #                   MPI_Datatype sendtype, void* recvbuf, int recvcount,
     #                   MPI_Datatype recvtype, MPI_Comm comm)
-    @mpichk ccall((:MPI_Allgather, libmpi), Cint,
+    @mpichk ccall(:MPI_Allgather, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
                   recvbuf.data, recvbuf.count, recvbuf.datatype, comm)
@@ -393,7 +393,7 @@ function Allgatherv!(sendbuf::Buffer, recvbuf::VBuffer, comm::Comm)
     # int MPI_Allgatherv(const void* sendbuf, int sendcount,
     #                    MPI_Datatype sendtype, void* recvbuf, const int recvcounts[],
     #                    const int displs[], MPI_Datatype recvtype, MPI_Comm comm)
-    @mpichk ccall((:MPI_Allgatherv, libmpi), Cint,
+    @mpichk ccall(:MPI_Allgatherv, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
                   recvbuf.data, recvbuf.counts, recvbuf.displs, recvbuf.datatype,
@@ -443,7 +443,7 @@ function Alltoall!(sendbuf::UBuffer, recvbuf::UBuffer, comm::Comm)
     # int MPI_Alltoall(const void* sendbuf, int sendcount, MPI_Datatype sendtype,
     #                  void* recvbuf, int recvcount, MPI_Datatype recvtype,
     #                  MPI_Comm comm)
-    @mpichk ccall((:MPI_Alltoall, libmpi), Cint,
+    @mpichk ccall(:MPI_Alltoall, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm),
                   sendbuf.data, sendbuf.count, sendbuf.datatype,
                   recvbuf.data, recvbuf.count, recvbuf.datatype,
@@ -484,7 +484,7 @@ Alltoall(sendbuf::UBuffer,  comm::Comm) =
 """
     Alltoallv!(sendbuf::VBuffer, recvbuf::VBuffer, comm::Comm)
 
-Similar to [`Alltoall!`](@ref), except with different size chunks per process. 
+Similar to [`Alltoall!`](@ref), except with different size chunks per process.
 
 # See also
 - [`VBuffer`](@ref)
@@ -501,14 +501,14 @@ function Alltoallv!(sendbuf::VBuffer, recvbuf::VBuffer, comm::Comm)
     #                   const int sdispls[], MPI_Datatype sendtype, void* recvbuf,
     #                   const int recvcounts[], const int rdispls[],
     #                   MPI_Datatype recvtype, MPI_Comm comm)
-    @mpichk ccall((:MPI_Alltoallv, libmpi), Cint,
+    @mpichk ccall(:MPI_Alltoallv, Cint,
                   (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype,
                    MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype,
                    MPI_Comm),
                   sendbuf.data, sendbuf.counts, sendbuf.displs, sendbuf.datatype,
                   recvbuf.data, recvbuf.counts, recvbuf.displs, recvbuf.datatype,
                   comm)
-    
+
     return recvbuf.data
 end
 
@@ -525,7 +525,7 @@ end
 Performs elementwise reduction using the operator `op` on the buffer `sendbuf` and stores
 the result in `recvbuf` on the process of rank `root`.
 
-On non-root processes `recvbuf` is ignored, and can be `nothing`. 
+On non-root processes `recvbuf` is ignored, and can be `nothing`.
 
 To perform the reduction in place, provide a single buffer `sendrecvbuf`.
 
@@ -540,7 +540,7 @@ $(_doc_external("MPI_Reduce"))
 function Reduce!(rbuf::RBuffer, op::Union{Op,MPI_Op}, root::Integer, comm::Comm)
     # int MPI_Reduce(const void* sendbuf, void* recvbuf, int count,
     #                MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm)
-    @mpichk ccall((:MPI_Reduce, libmpi), Cint,
+    @mpichk ccall(:MPI_Reduce, Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, Cint, MPI_Comm),
                   rbuf.senddata, rbuf.recvdata, rbuf.count, rbuf.datatype, op, root, comm)
     return rbuf.recvdata
@@ -579,7 +579,7 @@ the result `recvbuf` on the process of rank `root`, and `nothing` on non-root pr
 $(_doc_external("MPI_Reduce"))
 """
 function Reduce(sendbuf::AbstractArray, op, root::Integer, comm::Comm)
-    if Comm_rank(comm) == root 
+    if Comm_rank(comm) == root
         Reduce!(sendbuf, similar(sendbuf), op, root, comm)
     else
         Reduce!(sendbuf, nothing, op, root, comm)
@@ -619,7 +619,7 @@ $(_doc_external("MPI_Allreduce"))
 function Allreduce!(rbuf::RBuffer, op::Union{Op,MPI_Op}, comm::Comm)
     # int MPI_Allreduce(const void* sendbuf, void* recvbuf, int count,
     #                   MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-    @mpichk ccall((:MPI_Allreduce, libmpi), Cint,
+    @mpichk ccall(:MPI_Allreduce, Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
                   rbuf.senddata, rbuf.recvdata, rbuf.count, rbuf.datatype, op, comm)
     rbuf.recvdata
@@ -679,7 +679,7 @@ $(_doc_external("MPI_Scan"))
 function Scan!(rbuf::RBuffer, op::Union{Op,MPI_Op}, comm::Comm)
     # int MPI_Scan(const void* sendbuf, void* recvbuf, int count,
     #              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-    @mpichk ccall((:MPI_Scan, libmpi), Cint,
+    @mpichk ccall(:MPI_Scan, Cint,
                   (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
                   rbuf.senddata, rbuf.recvdata, rbuf.count, rbuf.datatype, op, comm)
     rbuf.recvdata
@@ -741,7 +741,7 @@ $(_doc_external("MPI_Exscan"))
 function Exscan!(rbuf::RBuffer, op::Union{Op,MPI_Op}, comm::Comm)
     # int MPI_Exscan(const void* sendbuf, void* recvbuf, int count,
     #                MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
-    @mpichk ccall((:MPI_Exscan, libmpi), Cint,
+    @mpichk ccall(:MPI_Exscan, Cint,
           (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm),
           rbuf.senddata, rbuf.recvdata, rbuf.count, rbuf.datatype, op, comm)
     rbuf.recvdata

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -26,7 +26,7 @@ Comm() = Comm(COMM_NULL.val)
 
 function free(comm::Comm)
     if comm.val != COMM_NULL.val && !Finalized()
-        @mpichk ccall((:MPI_Comm_free, libmpi), Cint, (Ptr{MPI_Comm},), comm)
+        @mpichk ccall(:MPI_Comm_free, Cint, (Ptr{MPI_Comm},), comm)
     end
     return nothing
 end
@@ -39,7 +39,7 @@ The rank of the process in the particular communicator's group.
 
 Returns an integer in the range `0:MPI.Comm_size()-1`.
 
-# See also 
+# See also
 - [`MPI.Comm_size`](@ref).
 
 # External links
@@ -47,7 +47,7 @@ $(_doc_external("MPI_Comm_rank"))
 """
 function Comm_rank(comm::Comm)
     rank = Ref{Cint}()
-    @mpichk ccall((:MPI_Comm_rank, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, rank)
+    @mpichk ccall(:MPI_Comm_rank, Cint, (MPI_Comm, Ptr{Cint}), comm, rank)
     Int(rank[])
 end
 
@@ -64,7 +64,7 @@ $(_doc_external("MPI_Comm_size"))
 """
 function Comm_size(comm::Comm)
     size = Ref{Cint}()
-    @mpichk ccall((:MPI_Comm_size, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, size)
+    @mpichk ccall(:MPI_Comm_size, Cint, (MPI_Comm, Ptr{Cint}), comm, size)
     Int(size[])
 end
 
@@ -76,7 +76,7 @@ $(_doc_external("MPI_Comm_dup"))
 """
 function Comm_dup(comm::Comm)
     newcomm = Comm()
-    @mpichk ccall((:MPI_Comm_dup, libmpi), Cint, (MPI_Comm, Ptr{MPI_Comm}), comm, newcomm)
+    @mpichk ccall(:MPI_Comm_dup, Cint, (MPI_Comm, Ptr{MPI_Comm}), comm, newcomm)
     finalizer(free, newcomm)
     newcomm
 end
@@ -89,7 +89,7 @@ $(_doc_external("MPI_Comm_split"))
 """
 function Comm_split(comm::Comm, color::Integer, key::Integer)
     newcomm = Comm()
-    @mpichk ccall((:MPI_Comm_split, libmpi), Cint,
+    @mpichk ccall(:MPI_Comm_split, Cint,
         (MPI_Comm, Cint, Cint, Ptr{MPI_Comm}), comm, color, key, newcomm)
     finalizer(free, newcomm)
     newcomm
@@ -103,7 +103,7 @@ $(_doc_external("MPI_Comm_split_type"))
 """
 function Comm_split_type(comm::Comm,split_type::Integer,key::Integer; kwargs...)
     newcomm = Comm()
-    @mpichk ccall((:MPI_Comm_split_type, libmpi), Cint,
+    @mpichk ccall(:MPI_Comm_split_type, Cint,
           (MPI_Comm, Cint, Cint, MPI_Info, Ptr{MPI_Comm}),
           comm, split_type, key, Info(kwargs...), newcomm)
     finalizer(free, newcomm)
@@ -118,7 +118,7 @@ $(_doc_external("MPI_Comm_get_parent"))
 """
 function Comm_get_parent()
     comm = Comm()
-    @mpichk ccall((:MPI_Comm_get_parent, libmpi), Cint, (Ptr{MPI_Comm},), comm)
+    @mpichk ccall(:MPI_Comm_get_parent, Cint, (Ptr{MPI_Comm},), comm)
     comm
 end
 
@@ -134,7 +134,7 @@ function Comm_spawn(command::String, argv::Vector{String}, nprocs::Integer,
     # int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs,
     #                    MPI_Info info, int root, MPI_Comm comm, MPI_Comm *intercomm,
     #                    int array_of_errcodes[])
-    @mpichk ccall((:MPI_Comm_spawn, libmpi), Cint,
+    @mpichk ccall(:MPI_Comm_spawn, Cint,
          (Cstring, Ptr{Ptr{Cchar}}, Cint, MPI_Info, Cint, MPI_Comm, Ptr{MPI_Comm}, Ptr{Cint}),
           command, argv, nprocs, Info(kwargs...), 0, comm, intercomm, errors)
     finalizer(free, intercomm)
@@ -149,7 +149,7 @@ $(_doc_external("MPI_Intercomm_merge"))
 """
 function Intercomm_merge(intercomm::Comm, flag::Bool)
     newcomm = Comm()
-    @mpichk ccall((:MPI_Intercomm_merge, libmpi), Cint,
+    @mpichk ccall(:MPI_Intercomm_merge, Cint,
         (MPI_Comm, Cint, Ptr{MPI_Comm}), intercomm, Cint(flag), newcomm)
     finalizer(free, newcomm)
     return newcomm
@@ -166,7 +166,7 @@ function universe_size()
     flag = Ref{Cint}()
     result = Ref(Ptr{Cint}(C_NULL))
     # int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag)
-    @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint,
+    @mpichk ccall(:MPI_Comm_get_attr, Cint,
         (MPI_Comm, Cint, Ptr{Cvoid}, Ptr{Cint}), MPI.COMM_WORLD, MPI_UNIVERSE_SIZE, result, flag)
     if flag[] == 0
         return nothing
@@ -206,7 +206,7 @@ $(_doc_external("MPI_Comm_compare"))
 """
 function Comm_compare(comm1::Comm, comm2::Comm)
     result = Ref{Comparison}()
-    @mpichk ccall((:MPI_Comm_compare, libmpi), Cint,
+    @mpichk ccall(:MPI_Comm_compare, Cint,
                   (MPI_Comm, MPI_Comm, Ptr{Comparison}), comm1, comm2, result)
     result[]
 end

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -20,7 +20,7 @@ Datatype() = Datatype(DATATYPE_NULL.val)
 
 function free(dt::Datatype)
     if dt.val != DATATYPE_NULL.val && !Finalized()
-        @mpichk ccall((:MPI_Type_free, libmpi), Cint, (Ptr{MPI_Datatype},), dt)
+        @mpichk ccall(:MPI_Type_free, Cint, (Ptr{MPI_Datatype},), dt)
     end
     return nothing
 end
@@ -57,7 +57,7 @@ for (mpiname, T) in [
         end
     end
 end
-    
+
 module Types
 
 import MPI
@@ -78,7 +78,7 @@ function extent(dt::Datatype)
     extent = Ref{MPI_Aint}()
     # int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb,
     #          MPI_Aint *extent)
-    @mpichk ccall((:MPI_Type_get_extent, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_get_extent, Cint,
                   (MPI_Datatype, Ptr{MPI_Aint}, Ptr{MPI_Aint}),
                   dt, lb, extent)
     return lb[], extent[]
@@ -97,7 +97,7 @@ $(_doc_external("MPI_Type_contiguous"))
 """
 function create_contiguous(count::Integer, oldtype::Datatype)
     newtype = Datatype()
-    @mpichk ccall((:MPI_Type_contiguous, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_contiguous, Cint,
                   (Cint, MPI_Datatype, Ptr{MPI_Datatype}),
                   count, oldtype, newtype)
     finalizer(free, newtype)
@@ -109,7 +109,7 @@ end
     MPI.Types.create_vector(count::Integer, blocklength::Integer, stride::Integer, oldtype::MPI.Datatype)
 
 Create a derived [`Datatype`](@ref) that replicates `oldtype` into locations that
-consist of equally spaced blocks. 
+consist of equally spaced blocks.
 
 Note that [`MPI.Types.commit!`](@ref) must be used before the datatype can be used for
 communication.
@@ -141,7 +141,7 @@ function create_vector(count::Integer, blocklength::Integer, stride::Integer, ol
     newtype = Datatype()
     # int MPI_Type_vector(int count, int blocklength, int stride,
     #          MPI_Datatype oldtype, MPI_Datatype *newtype)
-    @mpichk ccall((:MPI_Type_vector, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_vector, Cint,
                   (Cint, Cint, Cint, MPI_Datatype, Ptr{MPI_Datatype}),
                   count, blocklength, stride, oldtype, newtype)
     finalizer(free, newtype)
@@ -151,7 +151,7 @@ end
 """
     MPI.Types.create_subarray(sizes, subsizes, offset, oldtype::Datatype;
                               rowmajor=false)
-    
+
 Creates a derived [`Datatype`](@ref) describing an `N`-dimensional subarray of size
 `subsizes` of an `N`-dimensional array of size `sizes` and element type `oldtype`, with
 the first element offset by `offset` (i.e. the 0-based index of the first element).
@@ -174,9 +174,9 @@ function create_subarray(sizes,
     sizes = sizes isa Vector{Cint} ? sizes : Cint[s for s in sizes]
     subsizes = subsizes isa Vector{Cint} ? subsizes : Cint[s for s in subsizes]
     offset = offset isa Vector{Cint} ? offset : Cint[s for s in offset]
-    
+
     newtype = Datatype()
-    @mpichk ccall((:MPI_Type_create_subarray, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_create_subarray, Cint,
                   (Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint, MPI_Datatype, Ptr{MPI_Datatype}),
                   N, sizes, subsizes, offset,
                   rowmajor ? MPI.MPI_ORDER_C : MPI.MPI_ORDER_FORTRAN,
@@ -209,7 +209,7 @@ function create_struct(blocklengths, displacements, types)
     #                            MPI_Datatype *newtype)
     GC.@preserve types begin
         mpi_types = [t.val for t in types]
-        @mpichk ccall((:MPI_Type_create_struct, libmpi), Cint,
+        @mpichk ccall(:MPI_Type_create_struct, Cint,
                       (Cint, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}),
                       N, blocklengths, displacements, mpi_types, newtype)
     end
@@ -238,7 +238,7 @@ function create_resized(oldtype::Datatype, lb::Integer, extent::Integer)
     newtype = Datatype()
     # int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb,
     #              MPI_Aint extent, MPI_Datatype *newtype)
-    @mpichk ccall((:MPI_Type_create_resized, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_create_resized, Cint,
                   (MPI_Datatype, Cptrdiff_t, Cptrdiff_t, Ptr{MPI_Datatype}),
                   oldtype, lb, extent, newtype)
     finalizer(free, newtype)
@@ -256,7 +256,7 @@ $(_doc_external("MPI_Type_commit"))
 """
 function commit!(newtype::Datatype)
     # int MPI_Type_commit(MPI_Datatype *datatype)
-    @mpichk ccall((:MPI_Type_commit, libmpi), Cint,
+    @mpichk ccall(:MPI_Type_commit, Cint,
                   (Ptr{MPI_Datatype},), newtype)
 end
 
@@ -315,6 +315,6 @@ end # module
 
 function Get_address(location)
     addr = Ref{Cptrdiff_t}(0)
-    @mpichk ccall((:MPI_Get_address, libmpi), Cint, (Ptr{Cvoid}, Ref{MPI_Aint}), location, addr)
+    @mpichk ccall(:MPI_Get_address, Cint, (Ptr{Cvoid}, Ref{MPI_Aint}), location, addr)
     return addr[]
 end

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -81,7 +81,7 @@ The only MPI functions that may be called before `MPI.Init`/`MPI.Init_thread` ar
 $(_doc_external("MPI_Init"))
 """
 function Init(;finalize_atexit=true)
-    @mpichk ccall((:MPI_Init, libmpi), Cint, (Ptr{Cint},Ptr{Cint}), C_NULL, C_NULL)
+    @mpichk ccall(:MPI_Init, Cint, (Ptr{Cint},Ptr{Cint}), C_NULL, C_NULL)
     if finalize_atexit
         atexit(_finalize)
     end
@@ -147,7 +147,7 @@ $(_doc_external("MPI_Init_thread"))
 function Init_thread(required::ThreadLevel; finalize_atexit=true)
     r_provided = Ref{ThreadLevel}()
     # int MPI_Init_thread(int *argc, char ***argv, int required, int *provided)
-    @mpichk ccall((:MPI_Init_thread, libmpi), Cint,
+    @mpichk ccall(:MPI_Init_thread, Cint,
                   (Ptr{Cint},Ptr{Cvoid}, ThreadLevel, Ref{ThreadLevel}),
                   C_NULL, C_NULL, required, r_provided)
     provided = r_provided[]
@@ -176,7 +176,7 @@ function Query_thread()
     r_provided = Ref{ThreadLevel}()
 
     # int MPI_Query_thread(int *provided)
-    @mpichk ccall((:MPI_Query_thread, libmpi), Cint,
+    @mpichk ccall(:MPI_Query_thread, Cint,
                   (Ref{ThreadLevel},), r_provided)
     return r_provided[]
 end
@@ -193,7 +193,7 @@ $(_doc_external("MPI_Is_thread_main"))
 function Is_thread_main()
     r_flag = Ref{Cint}()
     # int MPI_Is_thread_main(int *flag)
-    @mpichk ccall((:MPI_Is_thread_main, libmpi), Cint,
+    @mpichk ccall(:MPI_Is_thread_main, Cint,
                   (Ref{Cint},), r_flag)
     return r_flag[] != 0
 end
@@ -214,7 +214,7 @@ call this function when Julia exits, if it hasn't already been called.
 $(_doc_external("MPI_Finalize"))
 """
 function Finalize()
-    @mpichk ccall((:MPI_Finalize, libmpi), Cint, ())
+    @mpichk ccall(:MPI_Finalize, Cint, ())
     return nothing
 end
 
@@ -230,7 +230,7 @@ or POSIX environment should handle this as a return errorcode from the main prog
 $(_doc_external("MPI_Abort"))
 """
 function Abort(comm::Comm, errcode::Integer)
-    @mpichk ccall((:MPI_Abort, libmpi), Cint, (MPI_Comm, Cint), comm, errcode)
+    @mpichk ccall(:MPI_Abort, Cint, (MPI_Comm, Cint), comm, errcode)
 end
 
 """
@@ -246,7 +246,7 @@ $(_doc_external("MPI_Intialized"))
 """
 function Initialized()
     flag = Ref{Cint}()
-    @mpichk ccall((:MPI_Initialized, libmpi), Cint, (Ptr{Cint},), flag)
+    @mpichk ccall(:MPI_Initialized, Cint, (Ptr{Cint},), flag)
     flag[] != 0
 end
 
@@ -262,16 +262,16 @@ $(_doc_external("MPI_Finalized"))
 """
 function Finalized()
     flag = Ref{Cint}()
-    @mpichk ccall((:MPI_Finalized, libmpi), Cint, (Ptr{Cint},), flag)
+    @mpichk ccall(:MPI_Finalized, Cint, (Ptr{Cint},), flag)
     flag[] != 0
 end
 
 function Wtick()
-    @mpicall ccall((:MPI_Wtick, libmpi), Cdouble, ())
+    @mpicall ccall(:MPI_Wtick, Cdouble, ())
 end
 
 function Wtime()
-    @mpicall ccall((:MPI_Wtime, libmpi), Cdouble, ())
+    @mpicall ccall(:MPI_Wtime, Cdouble, ())
 end
 
 
@@ -291,7 +291,7 @@ function has_cuda()
         # Only Open MPI provides a function to check CUDA support
         @static if MPI_LIBRARY == OpenMPI
             # int MPIX_Query_cuda_support(void)
-            return 0 != ccall((:MPIX_Query_cuda_support, libmpi), Cint, ())
+            return 0 != ccall(:MPIX_Query_cuda_support, Cint, ())
         elseif MPI_LIBRARY == IBMSpectrumMPI
             return true
         else

--- a/src/error.jl
+++ b/src/error.jl
@@ -12,7 +12,7 @@ function error_string(err::MPIError)
     len_ref = Ref{Cint}()
     str_buf = Vector{UInt8}(undef, MPI_MAX_ERROR_STRING)
     # int MPI_Error_string(int errorcode, char *string, int *resultlen)
-    @mpichk ccall((:MPI_Error_string, libmpi), Cint,
+    @mpichk ccall(:MPI_Error_string, Cint,
                   (Cint, Ptr{UInt8}, Ref{Cint}), err.code, str_buf, len_ref)
     resize!(str_buf, len_ref[])
     return String(str_buf)

--- a/src/io.jl
+++ b/src/io.jl
@@ -13,7 +13,7 @@ function open(comm::Comm, filename::AbstractString, amode::Cint, info::Info)
     file = FileHandle()
     # int MPI_File_open(MPI_Comm comm, const char *filename, int amode,
     #                   MPI_Info info, MPI_File *fh)
-    @mpichk ccall((:MPI_File_open, libmpi), Cint,
+    @mpichk ccall(:MPI_File_open, Cint,
                   (MPI_Comm, Cstring, Cint, MPI_Info, Ptr{MPI_File}),
                   comm, filename, amode, info, file)
     finalizer(close, file)
@@ -63,7 +63,7 @@ end
 function close(file::FileHandle)
     if file.val != FILE_NULL.val && !Finalized()
         # int MPI_File_close(MPI_File *fh)
-        @mpichk ccall((:MPI_File_close, libmpi), Cint,
+        @mpichk ccall(:MPI_File_close, Cint,
                       (Ptr{MPI_File},), file)
     end
     return nothing
@@ -85,7 +85,7 @@ $(_doc_external("MPI_File_set_view"))
 function set_view!(file::FileHandle, disp::Integer, etype::Datatype, filetype::Datatype, datarep::AbstractString, info::Info)
     # int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
     #                       MPI_Datatype filetype, const char *datarep, MPI_Info info)
-    @mpichk ccall((:MPI_File_set_view, libmpi), Cint,
+    @mpichk ccall(:MPI_File_set_view, Cint,
                   (MPI_File, MPI_Offset,  MPI_Datatype, MPI_Datatype, Cstring, MPI_Info),
                   file, disp, etype, filetype, datarep, info)
     return file
@@ -109,7 +109,7 @@ function get_byte_offset(file::FileHandle, offset::Integer)
     r_displ = Ref{MPI_Offset}()
     # int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset,
     #              MPI_Offset *disp)
-    @mpichk ccall((:MPI_File_get_byte_offset, libmpi), Cint,
+    @mpichk ccall(:MPI_File_get_byte_offset, Cint,
                   (MPI_File, MPI_Offset,  Ptr{MPI_Offset}),
                   file, offset, r_displ)
     r_displ[]
@@ -128,7 +128,7 @@ $(_doc_external("MPI_File_sync"))
 """
 function sync(file::FileHandle)
     # int MPI_File_sync(MPI_File fh)
-    @mpichk ccall((:MPI_File_sync, libmpi), Cint, (MPI_File,), file)
+    @mpichk ccall(:MPI_File_sync, Cint, (MPI_File,), file)
     return nothing
 end
 
@@ -151,7 +151,7 @@ function read!(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_read(MPI_File fh, void *buf,
     #                   int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -176,7 +176,7 @@ function read_all!(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_read_all(MPI_File fh, void *buf,
     #                       int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read_all, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read_all, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -200,7 +200,7 @@ function write(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write(MPI_File fh, const void *buf,
     #                    int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_write, libmpi), Cint,
+    @mpichk ccall(:MPI_File_write, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -225,7 +225,7 @@ function write_all(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write_all(MPI_File fh, const void *buf,
     #                    int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_write_all, libmpi), Cint,
+    @mpichk ccall(:MPI_File_write_all, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -250,7 +250,7 @@ function read_at!(file::FileHandle, offset::Integer, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count,
     #                      MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read_at, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read_at, Cint,
                   (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, offset, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -275,7 +275,7 @@ function read_at_all!(file::FileHandle, offset::Integer, buf::Buffer)
 
     # int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
     #                          int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read_at_all, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read_at_all, Cint,
                   (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, offset, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -298,7 +298,7 @@ function write_at(file::FileHandle, offset::Integer, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf,
     #                       int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_write_at, libmpi), Cint,
+    @mpichk ccall(:MPI_File_write_at, Cint,
                   (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, offset, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -322,7 +322,7 @@ function write_at_all(file::FileHandle, offset::Integer, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf,
     #                           int count, MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_write_at_all, libmpi), Cint,
+    @mpichk ccall(:MPI_File_write_at_all, Cint,
                   (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, offset, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -347,7 +347,7 @@ function read_shared!(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_read_shared(MPI_File fh, void *buf, int count,
     #              MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read_shared, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read_shared, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -370,7 +370,7 @@ function write_shared(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write_shared(MPI_File fh, const void *buf, int count,
     #          MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_write_shared, libmpi), Cint,
+    @mpichk ccall(:MPI_File_write_shared, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -396,7 +396,7 @@ function read_ordered!(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
     #              MPI_Datatype datatype, MPI_Status *status)
-    @mpichk ccall((:MPI_File_read_ordered, libmpi), Cint,
+    @mpichk ccall(:MPI_File_read_ordered, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -420,8 +420,8 @@ $(_doc_external("MPI_File_write_ordered"))
 function write_ordered(file::FileHandle, buf::Buffer)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_File_write_ordered(MPI_File fh, const void *buf, int count,
-    #              MPI_Datatype datatype, MPI_Status *status)    
-    @mpichk ccall((:MPI_File_write_ordered, libmpi), Cint,
+    #              MPI_Datatype datatype, MPI_Status *status)
+    @mpichk ccall(:MPI_File_write_ordered, Cint,
                   (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{Status}),
                   file, buf.data, buf.count, buf.datatype, stat_ref)
     return stat_ref[]
@@ -433,7 +433,7 @@ write_ordered(file::FileHandle, buf) = write_ordered(file, Buffer_send(buf))
     SEEK_SET = MPI.MPI_SEEK_SET
     SEEK_CUR = MPI.MPI_SEEK_CUR
     SEEK_END = MPI.MPI_SEEK_END
-end    
+end
 
 """
     MPI.File.seek_shared(file::FileHandle, offset::Integer, whence::Seek=SEEK_SET)
@@ -453,7 +453,7 @@ $(_doc_external("MPI_File_seek_shared"))
 """
 function seek_shared(file::FileHandle, offset::Integer, whence::Seek=SEEK_SET)
     # int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
-    @mpichk ccall((:MPI_File_seek_shared, libmpi), Cint,
+    @mpichk ccall(:MPI_File_seek_shared, Cint,
                   (MPI_File, MPI_Offset, Cint),
                   file, offset, whence)
 end
@@ -469,7 +469,7 @@ $(_doc_external("MPI_File_get_position_shared"))
 function get_position_shared(file::FileHandle)
     r = Ref{MPI_Offset}()
     # int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset)
-    @mpichk ccall((:MPI_File_get_position_shared, libmpi), Cint,
+    @mpichk ccall(:MPI_File_get_position_shared, Cint,
                   (MPI_File, Ptr{MPI_Offset}), file, r)
     return r[]
 end

--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -25,7 +25,7 @@ function Win_create(base::AbstractArray{T}, comm::Comm; infokws...) where T
     win = Win()
     # int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info,
     #                    MPI_Comm comm, MPI_Win *win)
-    @mpichk ccall((:MPI_Win_create, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_create, Cint,
                   (MPIPtr, Cptrdiff_t, Cint, MPI_Info, MPI_Comm, Ptr{MPI_Win}),
                   base, Cptrdiff_t(length(base)*sizeof(T)), sizeof(T), Info(infokws...), comm, win)
     finalizer(free, win)
@@ -46,7 +46,7 @@ This is a collective call over `comm`.
 function Win_create_dynamic(comm::Comm; kwargs...)
     win = Win()
     # int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win)
-    @mpichk ccall((:MPI_Win_create_dynamic, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_create_dynamic, Cint,
                   (MPI_Info, MPI_Comm, Ptr{MPI_Win}),
                   Info(kwargs...), comm, win)
     finalizer(free, win)
@@ -72,7 +72,7 @@ function Win_allocate_shared(::Type{T}, len::Int, comm::Comm; kwargs...) where T
     out_baseptr = Ref{Ptr{T}}()
     # int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info,
     #                             MPI_Comm comm, void *baseptr, MPI_Win *win)
-    @mpichk ccall((:MPI_Win_allocate_shared, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_allocate_shared, Cint,
                   (Cptrdiff_t, Cint, MPI_Info, MPI_Comm, Ref{Ptr{T}}, Ptr{MPI_Win}),
                   Cptrdiff_t(len*sizeof(T)), sizeof(T), Info(kwargs...), comm, out_baseptr, win)
     finalizer(free, win)
@@ -82,7 +82,7 @@ end
 function free(win::Win)
     if win.val != WIN_NULL.val && !Finalized()
         # int MPI_Win_free(MPI_Win *win)
-        @mpichk ccall((:MPI_Win_free, libmpi), Cint, (Ptr{MPI_Win},), win)
+        @mpichk ccall(:MPI_Win_free, Cint, (Ptr{MPI_Win},), win)
     end
     return nothing
 end
@@ -96,7 +96,7 @@ function Win_shared_query(win::Win, owner_rank::Int)
     out_baseptr = Ref{Ptr{Cvoid}}()
     # int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size,
     #                          int *disp_unit, void *baseptr)
-    @mpichk ccall((:MPI_Win_shared_query, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_shared_query, Cint,
                   (MPI_Win, Cint, Ref{Cptrdiff_t}, Ref{Cint}, Ref{Ptr{Cvoid}}),
                   win, owner_rank, out_len, out_sizeT, out_baseptr)
     out_len[], out_sizeT[], out_baseptr[]
@@ -104,43 +104,43 @@ end
 
 function Win_attach(win::Win, base::AbstractArray{T}) where T
     # int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size)
-    @mpichk ccall((:MPI_Win_attach, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_attach, Cint,
                   (MPI_Win, MPIPtr, Cptrdiff_t),
                   win, base, Cptrdiff_t(sizeof(base)))
 end
 
 function Win_detach(win::Win, base::AbstractArray{T}) where T
     # int MPI_Win_detach(MPI_Win win, const void *base)
-    @mpichk ccall((:MPI_Win_detach, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_detach, Cint,
                   (MPI_Win, MPIPtr),
                   win, base)
 end
 
 function Win_fence(assert::Integer, win::Win)
     # int MPI_Win_fence(int assert, MPI_Win win)
-    @mpichk ccall((:MPI_Win_fence, libmpi), Cint, (Cint, MPI_Win), assert, win)
+    @mpichk ccall(:MPI_Win_fence, Cint, (Cint, MPI_Win), assert, win)
 end
 
 function Win_flush(rank::Integer, win::Win)
     # int MPI_Win_flush(int rank, MPI_Win win)
-    @mpichk ccall((:MPI_Win_flush, libmpi), Cint,(Cint, MPI_Win), rank, win)
+    @mpichk ccall(:MPI_Win_flush, Cint,(Cint, MPI_Win), rank, win)
 end
 
 function Win_sync(win::Win)
     # int MPI_Win_sync(MPI_Win win)
-    @mpichk ccall((:MPI_Win_sync, libmpi), Cint, (MPI_Win,), win)
+    @mpichk ccall(:MPI_Win_sync, Cint, (MPI_Win,), win)
 end
 
 function Win_lock(lock_type::LockType, rank::Integer, assert::Integer, win::Win)
     # int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
-    @mpichk ccall((:MPI_Win_lock, libmpi), Cint,
+    @mpichk ccall(:MPI_Win_lock, Cint,
                   (Cint, Cint, Cint, MPI_Win),
                   lock_type.val, rank, assert, win)
 end
 
 function Win_unlock(rank::Integer, win::Win)
     # int MPI_Win_unlock(int rank, MPI_Win win)
-    @mpichk ccall((:MPI_Win_unlock, libmpi), Cint, (Cint, MPI_Win), rank, win)
+    @mpichk ccall(:MPI_Win_unlock, Cint, (Cint, MPI_Win), rank, win)
 end
 
 function Get(origin_buffer, count::Integer, target_rank::Integer, target_disp::Integer, win::Win)
@@ -149,7 +149,7 @@ function Get(origin_buffer, count::Integer, target_rank::Integer, target_disp::I
     #             MPI_Datatype origin_datatype, int target_rank,
     #             MPI_Aint target_disp, int target_count,
     #             MPI_Datatype target_datatype, MPI_Win win)
-    @mpichk ccall((:MPI_Get, libmpi), Cint,
+    @mpichk ccall(:MPI_Get, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Win),
                   origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), win)
 end
@@ -167,7 +167,7 @@ function Put(origin_buffer, count::Integer, target_rank::Integer, target_disp::I
     #             MPI_Aint target_disp, int target_count,
     #             MPI_Datatype target_datatype, MPI_Win win)
     T = eltype(origin_buffer)
-    @mpichk ccall((:MPI_Put, libmpi), Cint,
+    @mpichk ccall(:MPI_Put, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Win),
                   origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), win)
 end
@@ -185,7 +185,7 @@ function Fetch_and_op(sourceval, returnval, target_rank::Integer, target_disp::I
     #                      MPI_Op op, MPI_Win win)
     @assert eltype(sourceval) == eltype(returnval)
     T = eltype(sourceval)
-    @mpichk ccall((:MPI_Fetch_and_op, libmpi), Cint,
+    @mpichk ccall(:MPI_Fetch_and_op, Cint,
                   (MPIPtr, MPIPtr, MPI_Datatype, Cint, Cptrdiff_t, MPI_Op, MPI_Win),
                   sourceval, returnval, Datatype(T), target_rank, target_disp, op, win)
 end
@@ -196,7 +196,7 @@ function Accumulate(origin_buffer, count::Integer, target_rank::Integer, target_
     #                    MPI_Aint target_disp, int target_count,
     #                    MPI_Datatype target_datatype, MPI_Op op, MPI_Win win)
     T = eltype(origin_buffer)
-    @mpichk ccall((:MPI_Accumulate, libmpi), Cint,
+    @mpichk ccall(:MPI_Accumulate, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Op, MPI_Win),
                   origin_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), op, win)
 end
@@ -209,7 +209,7 @@ function Get_accumulate(origin_buffer, result_buffer, count::Integer, target_ran
     #                        MPI_Datatype target_datatype, MPI_Op op, MPI_Win win)
     @assert eltype(origin_buffer) == eltype(result_buffer)
     T = eltype(origin_buffer)
-    @mpichk ccall((:MPI_Get_accumulate, libmpi), Cint,
+    @mpichk ccall(:MPI_Get_accumulate, Cint,
                   (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, Cptrdiff_t, Cint, MPI_Datatype, MPI_Op, MPI_Win),
                   origin_buffer, count, Datatype(T), result_buffer, count, Datatype(T), target_rank, Cptrdiff_t(target_disp), count, Datatype(T), op, win)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -47,7 +47,7 @@ Op(::typeof(⊻), ::Type{T}; iscommutative=true) where {T<:MPIInteger} = BXOR
 
 function free(op::Op)
     if op.val != OP_NULL.val && !Finalized()
-        @mpichk ccall((:MPI_Op_free, libmpi), Cint, (Ptr{MPI_Op},), op)
+        @mpichk ccall(:MPI_Op_free, Cint, (Ptr{MPI_Op},), op)
     end
     return nothing
 end
@@ -74,10 +74,10 @@ function Op(f, T=Any; iscommutative=false)
     end
     w = OpWrapper{typeof(f),T}(f)
     fptr = @cfunction($w, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{MPI_Datatype}))
-    
+
     op = Op(OP_NULL.val, fptr)
     # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)
-    @mpichk ccall((:MPI_Op_create, libmpi), Cint,
+    @mpichk ccall(:MPI_Op_create, Cint,
                   (Ptr{Cvoid}, Cint, Ptr{MPI_Op}),
                   fptr, iscommutative, op)
 

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -101,7 +101,7 @@ isnull(req::Request) = req.val == REQUEST_NULL.val
 
 function free(req::Request)
     if !isnull(req) && !MPI.Finalized()
-        @mpichk ccall((:MPI_Request_free, libmpi), Cint, (Ptr{MPI_Request},), req)
+        @mpichk ccall(:MPI_Request_free, Cint, (Ptr{MPI_Request},), req)
         req.buffer = nothing
     end
     return nothing
@@ -119,7 +119,7 @@ $(_doc_external("MPI_Probe"))
 """
 function Probe(src::Integer, tag::Integer, comm::Comm)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
-    @mpichk ccall((:MPI_Probe, libmpi), Cint,
+    @mpichk ccall(:MPI_Probe, Cint,
           (Cint, Cint, MPI_Comm, Ptr{Status}),
           src, tag, comm, stat_ref)
     stat_ref[]
@@ -137,7 +137,7 @@ $(_doc_external("MPI_Iprobe"))
 function Iprobe(src::Integer, tag::Integer, comm::Comm)
     flag = Ref{Cint}()
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
-    @mpichk ccall((:MPI_Iprobe, libmpi), Cint,
+    @mpichk ccall(:MPI_Iprobe, Cint,
           (Cint, Cint, MPI_Comm, Ptr{Cint}, Ptr{Status}),
           src, tag, comm, flag, stat_ref)
     if flag[] == 0
@@ -158,7 +158,7 @@ $(_doc_external("MPI_Get_count"))
 """
 function Get_count(stat::Status, datatype::Datatype)
     count = Ref{Cint}()
-    @mpichk ccall((:MPI_Get_count, libmpi), Cint,
+    @mpichk ccall(:MPI_Get_count, Cint,
                   (Ptr{Status}, MPI_Datatype, Ptr{Cint}),
                   Ref(stat), datatype, count)
     Int(count[])
@@ -178,7 +178,7 @@ $(_doc_external("MPI_Send"))
 function Send(buf::Buffer, dest::Integer, tag::Integer, comm::Comm)
     # int MPI_Send(const void* buf, int count, MPI_Datatype datatype, int dest,
     #              int tag, MPI_Comm comm)
-    @mpichk ccall((:MPI_Send, libmpi), Cint,
+    @mpichk ccall(:MPI_Send, Cint,
           (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm),
           buf.data, buf.count, buf.datatype, dest, tag, comm)
     return nothing
@@ -226,7 +226,7 @@ function Isend(buf::Buffer, dest::Integer, tag::Integer, comm::Comm)
     req = Request()
     # int MPI_Isend(const void* buf, int count, MPI_Datatype datatype, int dest,
     #               int tag, MPI_Comm comm, MPI_Request *request)
-    @mpichk ccall((:MPI_Isend, libmpi), Cint,
+    @mpichk ccall(:MPI_Isend, Cint,
           (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}),
                   buf.data, buf.count, buf.datatype, dest, tag, comm, req)
     req.buffer = buf
@@ -260,8 +260,8 @@ Completes a blocking receive into the buffer `data` from MPI rank `src` of commu
 Returns the [`Status`](@ref) of the receive.
 
 # See also
-- [`Recv`](@ref) 
-- [`recv`](@ref) 
+- [`Recv`](@ref)
+- [`recv`](@ref)
 
 # External links
 $(_doc_external("MPI_Recv"))
@@ -270,7 +270,7 @@ function Recv!(buf::Buffer, src::Integer, tag::Integer, comm::Comm)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_Recv(void* buf, int count, MPI_Datatype datatype, int source,
     #              int tag, MPI_Comm comm, MPI_Status *status)
-    @mpichk ccall((:MPI_Recv, libmpi), Cint,
+    @mpichk ccall(:MPI_Recv, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{Status}),
                   buf.data, buf.count, buf.datatype, src, tag, comm, stat_ref)
     return stat_ref[]
@@ -287,8 +287,8 @@ Completes a blocking receive of an object of type `T` from MPI rank `src` of com
 Returns a tuple of the object of type `T` and the [`Status`](@ref) of the receive.
 
 # See also
-- [`Recv!`](@ref) 
-- [`recv`](@ref) 
+- [`Recv!`](@ref)
+- [`recv`](@ref)
 
 # External links
 $(_doc_external("MPI_Recv"))
@@ -329,10 +329,10 @@ Returns the [`Request`](@ref) for the nonblocking receive.
 $(_doc_external("MPI_Irecv"))
 """
 function Irecv!(buf::Buffer, src::Integer, tag::Integer, comm::Comm)
-    req = Request()    
+    req = Request()
     # int MPI_Irecv(void* buf, int count, MPI_Datatype datatype, int source,
     #               int tag, MPI_Comm comm, MPI_Request *request)
-    @mpichk ccall((:MPI_Irecv, libmpi), Cint,
+    @mpichk ccall(:MPI_Irecv, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}),
                   buf.data, buf.count, buf.datatype, src, tag, comm, req)
     req.buffer = buf
@@ -377,7 +377,7 @@ function Sendrecv!(sendbuf::Buffer, dest::Integer, sendtag::Integer,
     #                        void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag,
     #                    MPI_Comm comm, MPI_Status *status)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
-    @mpichk ccall((:MPI_Sendrecv, libmpi), Cint,
+    @mpichk ccall(:MPI_Sendrecv, Cint,
                   (MPIPtr, Cint, MPI_Datatype, Cint, Cint,
                    MPIPtr, Cint, MPI_Datatype, Cint, Cint,
                    MPI_Comm, Ptr{Status}),
@@ -402,7 +402,7 @@ function Wait!(req::Request)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     alreadynull = isnull(req)
     # int MPI_Wait(MPI_Request *request, MPI_Status *status)
-    @mpichk ccall((:MPI_Wait, libmpi), Cint,
+    @mpichk ccall(:MPI_Wait, Cint,
                   (Ptr{MPI_Request}, Ptr{Status}),
                   req, stat_ref)
     if !alreadynull
@@ -424,7 +424,7 @@ function Test!(req::Request)
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     alreadynull = isnull(req)
     # int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
-    @mpichk ccall((:MPI_Test, libmpi), Cint,
+    @mpichk ccall(:MPI_Test, Cint,
                   (Ptr{MPI_Request}, Ptr{Cint}, Ptr{Status}),
                   req, flag, stat_ref)
     if flag[] == 0
@@ -451,7 +451,7 @@ function Waitall!(reqs::Vector{Request})
     stats = fill(STATUS_EMPTY, count)
     # int MPI_Waitall(int count, MPI_Request array_of_requests[],
     #                 MPI_Status array_of_statuses[])
-    @mpichk ccall((:MPI_Waitall, libmpi), Cint,
+    @mpichk ccall(:MPI_Waitall, Cint,
                   (Cint, Ptr{MPI_Request}, Ptr{Status}),
                   count, reqvals, stats)
     for i in 1:count
@@ -482,7 +482,7 @@ function Testall!(reqs::Vector{Request})
     stats = fill(STATUS_EMPTY, count)
     # int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     #                 MPI_Status array_of_statuses[])
-    @mpichk ccall((:MPI_Testall, libmpi), Cint,
+    @mpichk ccall(:MPI_Testall, Cint,
                   (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Status}),
                   count, reqvals, flag, stats)
     if flag[] == 0
@@ -517,7 +517,7 @@ function Waitany!(reqs::Vector{Request})
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_Waitany(int count, MPI_Request array_of_requests[], int *index,
     #                 MPI_Status *status)
-    @mpichk ccall((:MPI_Waitany, libmpi), Cint,
+    @mpichk ccall(:MPI_Waitany, Cint,
                   (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Status}),
                   count, reqvals, ind, stat_ref)
     if ind[] == MPI_UNDEFINED
@@ -554,7 +554,7 @@ function Testany!(reqs::Vector{Request})
     stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
     # int MPI_Testany(int count, MPI_Request array_of_requests[], int *index,
     #                 int *flag, MPI_Status *status)
-    @mpichk ccall((:MPI_Testany, libmpi), Cint,
+    @mpichk ccall(:MPI_Testany, Cint,
                   (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{Status}),
                   count, reqvals, ind, flag, stat_ref)
     if flag[] == 0
@@ -591,7 +591,7 @@ function Waitsome!(reqs::Vector{Request})
     # int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     #                  int *outcount, int array_of_indices[],
     #                  MPI_Status array_of_statuses[])
-    @mpichk ccall((:MPI_Waitsome, libmpi), Cint,
+    @mpichk ccall(:MPI_Waitsome, Cint,
           (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{Status}),
           count, reqvals, outcnt, inds, stats)
     outcount = Int(outcnt[])
@@ -631,7 +631,7 @@ function Testsome!(reqs::Vector{Request})
     # int MPI_Testsome(int incount, MPI_Request array_of_requests[],
     #                  int *outcount, int array_of_indices[],
     #                  MPI_Status array_of_statuses[])
-    @mpichk ccall((:MPI_Testsome, libmpi), Cint,
+    @mpichk ccall(:MPI_Testsome, Cint,
                   (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{Status}),
                   count, reqvals, outcnt, inds, stats)
     outcount = outcnt[]
@@ -665,6 +665,6 @@ $(_doc_external("MPI_Cancel"))
 """
 function Cancel!(req::Request)
     # int MPI_Cancel(MPI_Request *request)
-    @mpichk ccall((:MPI_Cancel, libmpi), Cint, (Ptr{MPI_Request},), req)
+    @mpichk ccall(:MPI_Cancel, Cint, (Ptr{MPI_Request},), req)
     nothing
 end

--- a/src/topology.jl
+++ b/src/topology.jl
@@ -8,7 +8,7 @@ $(_doc_external("MPI_Dims_create"))
 """
 function Dims_create!(nnodes::Integer, ndims::Integer, dims::MPIBuffertype{T}) where {T <: Integer}
     # int MPI_Dims_create(int nnodes, int ndims, int dims[])
-    @mpichk ccall((:MPI_Dims_create, libmpi), Cint,
+    @mpichk ccall(:MPI_Dims_create, Cint,
                   (Cint, Cint, Ptr{Cint}), nnodes, ndims, dims)
 end
 
@@ -31,7 +31,7 @@ function Cart_create(comm_old::Comm, ndims::Integer, dims::MPIBuffertype{Cint}, 
     comm_cart = Comm()
     # int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[],
     #                     const int periods[], int reorder, MPI_Comm *comm_cart)
-    @mpichk ccall((:MPI_Cart_create, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_create, Cint,
                   (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{MPI_Comm}),
                   comm_old, ndims, dims, periods, reorder, comm_cart)
     if comm_cart.val != MPI_COMM_NULL
@@ -59,7 +59,7 @@ $(_doc_external("MPI_Cart_rank"))
 function Cart_rank(comm::Comm, coords::MPIBuffertype{Cint})
     rank = Ref{Cint}()
     # int MPI_Cart_rank(MPI_Comm comm, const int coords[], int *rank)
-    @mpichk ccall((:MPI_Cart_rank, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_rank, Cint,
                   (MPI_Comm, Ptr{Cint}, Ptr{Cint}),
                   comm, coords, rank)
     Int(rank[])
@@ -73,9 +73,9 @@ end
 """
     dims, periods, coords = Cart_get(comm::Comm)
 
-Obtain information on the Cartesian topology of dimension `N` underlying the 
+Obtain information on the Cartesian topology of dimension `N` underlying the
 communicator `comm`. This is specified by two `Cint` arrays of `N` elements
-for the number of processes and periodicity properties along each Cartesian dimension. 
+for the number of processes and periodicity properties along each Cartesian dimension.
 A third `Cint` array is returned, containing the Cartesian coordinates of the calling process.
 
 # External links
@@ -88,7 +88,7 @@ function Cart_get(comm::Comm)
     periods = Cint[-1 for i = 1:maxdims]
     coords  = Cint[-1 for i = 1:maxdims]
     # int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[], int periods[], int coords[])
-    @mpichk ccall((:MPI_Cart_get, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_get, Cint,
                   (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}),
                   comm, maxdims, dims, periods, coords)
     return dims, periods, coords
@@ -105,7 +105,7 @@ $(_doc_external("MPI_Cartdim_get"))
 function Cartdim_get(comm::Comm)
     dims = Ref{Cint}()
     # int MPI_Cartdim_get(MPI_Comm comm, int *ndims)
-    @mpichk ccall((:MPI_Cartdim_get, libmpi), Cint,
+    @mpichk ccall(:MPI_Cartdim_get, Cint,
                   (MPI_Comm, Ptr{Cint}),
                   comm, dims)
     return Int(dims[])
@@ -122,7 +122,7 @@ $(_doc_external("MPI_Cart_coords"))
 function Cart_coords!(comm::Comm, rank::Integer, coords::MPIBuffertype{Cint})
     maxdims = Cartdim_get(comm)
     # int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[])
-    @mpichk ccall((:MPI_Cart_coords, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_coords, Cint,
                   (MPI_Comm, Cint, Cint, Ptr{Cint}),
                   comm, rank, maxdims, coords)
 end
@@ -156,7 +156,7 @@ function Cart_shift(comm::Comm, direction::Integer, disp::Integer)
     rank_dest   = Ref{Cint}()
     # int MPI_Cart_shift(MPI_Comm comm, int direction, int disp,
     #                    int *rank_source, int *rank_dest)
-    @mpichk ccall((:MPI_Cart_shift, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_shift, Cint,
                   (MPI_Comm, Cint, Cint, Ptr{Cint}, Ptr{Cint}),
                   comm, direction, disp, rank_source, rank_dest)
     Int(rank_source[]), Int(rank_dest[])
@@ -177,7 +177,7 @@ $(_doc_external("MPI_Cart_sub"))
 function Cart_sub(comm::Comm, remain_dims::MPIBuffertype{Cint})
     comm_sub = Comm()
     # int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *comm_new)
-    @mpichk ccall((:MPI_Cart_sub, libmpi), Cint,
+    @mpichk ccall(:MPI_Cart_sub, Cint,
                   (MPI_Comm, Ptr{Cint}, Ptr{MPI_Comm}),
                   comm, remain_dims, comm_sub)
     if comm_sub.val != MPI_COMM_NULL


### PR DESCRIPTION
See #444. Use of `ccall( (func, lib), ...)` is not compatible with applications that use `LD_PRELOAD` to inject their own code for profiling and tracing. [Darshan](https://www.mcs.anl.gov/research/projects/darshan/) is an example of an application that does this for MPI and HDF5 I/O profiling. 

This PR has changes to explicitly load the `libmpi` shared object with `Libdl.dlopen` in `MPI.__init__`. Most `ccall` statements are changed to not specify the MPI library. There are some`ccall` statements in `implementations.jl` that I left alone because they get called before `MPI.__init__` and all they do is determine MPI version and implementation details. 

I tested on NERSC Cori Haswell nodes. MPI tests pass except for `test_spawn.jl`, but this fails with the released MPI.jl too. I was able to get Darshan to work with this PR. 

Happy New Year too!