### PR TITLE
use global symbols on Unix to support LD_PRELOAD interception

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -80,9 +80,6 @@ if binary == "system"
     
     _doc_external(fname) = ""
     
-    if Sys.isunix()
-        Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
-    end
     include(joinpath("..","src","implementations.jl"))
 
     @info "Using implementation" libmpi mpiexec_cmd MPI_LIBRARY_VERSION_STRING

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -79,6 +79,10 @@ if binary == "system"
     const mpiexec_cmd = Cmd(mpiexec isa String ? [mpiexec] : mpiexec)
     
     _doc_external(fname) = ""
+    
+    if Sys.isunix()
+        Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+    end
     include(joinpath("..","src","implementations.jl"))
 
     @info "Using implementation" libmpi mpiexec_cmd MPI_LIBRARY_VERSION_STRING

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -1,5 +1,6 @@
 const use_stdcall = startswith(basename(libmpi), "msmpi")
 
+# This is required in addition to __init__() so that we can call library at precompilation time.
 if Sys.isunix()
     Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
 end

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -1,5 +1,9 @@
 const use_stdcall = startswith(basename(libmpi), "msmpi")
 
+if Sys.isunix()
+    Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+end
+
 macro mpicall(expr)
     @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
 

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -2,6 +2,13 @@ const use_stdcall = startswith(basename(libmpi), "msmpi")
 
 macro mpicall(expr)
     @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
+
+    # On unix systems we call the global symbols to allow for LD_PRELOAD interception
+    # It can be emulated in Windows (via Libdl.dllist), but this is not fast.
+    if Sys.isunix() && expr.args[2].head == :tuple
+        expr.args[2] = expr.args[2].args[1]
+    end
+
     # Microsoft MPI uses stdcall calling convention
     # this only affects 32-bit Windows
     # unfortunately we need to use ccall to call Get_library_version


### PR DESCRIPTION
This is an alternative to #450 that only uses global symbols on unix systems.

@lyon-fnal would you be able to try this out?