### PR TITLE
RFC: Define wait(req) to use threadcall

### DIFF
--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -411,6 +411,19 @@ function Wait!(req::Request)
     stat_ref[]
 end
 
+function Base.wait(req::Request)
+    stat_ref = Ref{Status}(MPI.STATUS_EMPTY)
+    alreadynull = isnull(req)
+    errcode = @threadcall((:MPI_Wait, libmpi), Cint,
+                          (Ptr{MPI_Request}, Ptr{Status}),
+                          req, stat_ref)
+    errcode == MPI_SUCCESS || throw(MPIError(errcode))
+    if !alreadynull
+        req.buffer = nothing
+    end
+    stat_ref[]
+end
+
 """
     (flag, status) = Test!(req::Request)
 

--- a/test/test_waitthread.jl
+++ b/test/test_waitthread.jl
@@ -1,0 +1,28 @@
+using MPI, Test
+
+MPI.Init()
+
+rank = MPI.Comm_rank(MPI.COMM_WORLD)
+
+
+X = zeros(10)
+if rank == 1
+    MPI.Recv!(X,0,2,MPI.COMM_WORLD)
+    MPI.Send(rand(10),0,0,MPI.COMM_WORLD)
+elseif rank == 0
+    X = zeros(10)
+    req = MPI.Irecv!(X,1,0,MPI.COMM_WORLD)
+    task = @async begin
+        wait(req)
+        # success!
+    end
+    yield()
+    
+    # trigger rank 1
+    MPI.Send(zeros(10),1,2,MPI.COMM_WORLD)
+    wait(task)
+    
+    flag,_ = MPI.Test!(req)
+    @test flag
+end
+


### PR DESCRIPTION
Prompted by [this discussion](https://discourse.julialang.org/t/how-to-combine-mpi-non-blocking-isend-irecv-and-julia-tasks/52524/5?u=simonbyrne) I tried to see if I could use [`@threadcall`](https://docs.julialang.org/en/v1/base/multi-threading/#Base.@threadcall) to wait on nonblocking MPI operations inside tasks.

And it seems to work! I've defined this to be a method of `Base.wait`, in that it acts mostly the same way (i.e. will yield until it is complete). Obviously one problem is that it is limited by the size of the libuv thread pool, but I don't think that would be a big issue.

If people are in favor, I can define analogous `waitany`/`waitall`/`waitsome` operations.

cc: @giordano @stevengj @vchuravy @fverdugo