### PR TITLE
Avoid InitError on Julia 1.3 with system MPI libraries

### DIFF
--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -11,7 +11,7 @@ macro mpicall(expr)
     # On unix systems we call the global symbols to allow for LD_PRELOAD interception
     # It can be emulated in Windows (via Libdl.dllist), but this is not fast.
     if Sys.isunix() && expr.args[2].head == :tuple &&
-            expr.args[2].args[1] != :(:MPI_Get_library_version)
+            (VERSION ≥ v"1.5-" || expr.args[2].args[1] ≠ :(:MPI_Get_library_version))
         expr.args[2] = expr.args[2].args[1]
     end
 

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -10,7 +10,8 @@ macro mpicall(expr)
 
     # On unix systems we call the global symbols to allow for LD_PRELOAD interception
     # It can be emulated in Windows (via Libdl.dllist), but this is not fast.
-    if Sys.isunix() && expr.args[2].head == :tuple
+    if Sys.isunix() && expr.args[2].head == :tuple &&
+            expr.args[2].args[1] != :(:MPI_Get_library_version)
         expr.args[2] = expr.args[2].args[1]
     end
 


### PR DESCRIPTION
This PR works around #455 by adding an exception when calling `MPI_Get_library_version` via `ccall` on Unix-like systems, when using Julia versions older than 1.5.

Closes #455.