### PR TITLE
Allow `Waitall!` for an empty input `reqs = []`

### DIFF
--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -447,6 +447,7 @@ $(_doc_external("MPI_Waitall"))
 """
 function Waitall!(reqs::Vector{Request})
     count = length(reqs)
+    count == 0 && return []
     reqvals = [reqs[i].val for i in 1:count]
     stats = fill(STATUS_EMPTY, count)
     # int MPI_Waitall(int count, MPI_Request array_of_requests[],

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -447,7 +447,7 @@ $(_doc_external("MPI_Waitall"))
 """
 function Waitall!(reqs::Vector{Request})
     count = length(reqs)
-    count == 0 && return []
+    count == 0 && return Status[]
     reqvals = [reqs[i].val for i in 1:count]
     stats = fill(STATUS_EMPTY, count)
     # int MPI_Waitall(int count, MPI_Request array_of_requests[],

--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -132,5 +132,7 @@ MPI.Sendrecv!(a, dest_rank, 2,
 
 @test b == [(comm_rank+1) % comm_size, (comm_rank+1) % comm_size, (comm_rank+1) % comm_size]
 
+@test MPI.Waitall!([]) == MPI.Status[]
+
 MPI.Finalize()
 # @test MPI.Finalized()

--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -132,7 +132,7 @@ MPI.Sendrecv!(a, dest_rank, 2,
 
 @test b == [(comm_rank+1) % comm_size, (comm_rank+1) % comm_size, (comm_rank+1) % comm_size]
 
-@test MPI.Waitall!([]) == MPI.Status[]
+@test MPI.Waitall!(Request[]) == MPI.Status[]
 
 MPI.Finalize()
 # @test MPI.Finalized()

--- a/test/test_sendrecv.jl
+++ b/test/test_sendrecv.jl
@@ -132,7 +132,7 @@ MPI.Sendrecv!(a, dest_rank, 2,
 
 @test b == [(comm_rank+1) % comm_size, (comm_rank+1) % comm_size, (comm_rank+1) % comm_size]
 
-@test MPI.Waitall!(Request[]) == MPI.Status[]
+@test MPI.Waitall!(MPI.Request[]) == MPI.Status[]
 
 MPI.Finalize()
 # @test MPI.Finalized()


### PR DESCRIPTION
Not sure if this is a good change but I thought it would be nice if `MPI.Waitall!` didn't error when `reqs` is an empty array.

This is useful when you're filtering out MPI requests from an array containing other things, e.g. KernelAbstractions.jl events, and you end up with an array with no `MPI.Request`s.

Returning an empty array seemed like reasonable behavior.