### PR TITLE
Add finalizer to `create_struct`

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -213,6 +213,7 @@ function create_struct(blocklengths, displacements, types)
                       (Cint, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}),
                       N, blocklengths, displacements, mpi_types, newtype)
     end
+    finalizer(free, newtype)
     return newtype
 end
 


### PR DESCRIPTION
Adding a finalizer to the `Datatype` in `create_struct` fixes #459 
Please let me know if this is the correct fix.