### PR TITLE
Define new method for `Datatype` to fix issue #462

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -308,6 +308,7 @@ function Datatype(::Type{T}; commit=true) where T
     if commit
         commit!(dt)
     end
+    @eval Datatype(::Type{$T}) = $dt
     return dt
 end
 

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -48,6 +48,11 @@ end
     end
 end
 
+@testset "Unique return type" begin
+    dt = MPI.Datatype(Boundary)
+    @test dt ===  MPI.Datatype(Boundary)
+end
+
 struct Boundary2
     a::UInt32
     b::Tuple{Int, UInt8}


### PR DESCRIPTION
I'm not sure whether this is the correct fix for the issue, but it seems to help with errors we are seeing when using one-sided communication as in [joachimbrand/Rimu.jl#47](https://github.com/joachimbrand/Rimu.jl/issues/47). Any comments are welcome.