### PR TITLE
Run CI on aarch64 with Drone

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,30 @@
+local Pipeline(os, arch, version, alpine=false) = {
+    kind: "pipeline",
+    name: os+" - "+arch+" - Julia "+version+(if alpine then " (Alpine)" else ""),
+    platform: {
+        os: os,
+        arch: arch
+    },
+    steps: [
+        {
+            name: "Run tests",
+            image: "julia:"+version+(if alpine then "-alpine" else ""),
+            commands: [
+                "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'",
+                "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'",
+                "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+            ]
+        }
+    ],
+    trigger: {
+        branch: ["master"]
+    }
+};
+
+[
+    # Pipeline("linux", "arm",   "1.3.1"),
+    # Pipeline("linux", "arm",   "1.6.1"),
+    Pipeline("linux", "arm64", "1.3"),
+    Pipeline("linux", "arm64", "1.6"),
+    # Pipeline("linux", "amd64", "1.6", true)
+]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,41 @@
+---
+kind: pipeline
+name: linux - arm64 - Julia 1.3
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Run tests
+  image: julia:1.3
+  commands:
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+
+trigger:
+  branch:
+  - master
+
+---
+kind: pipeline
+name: linux - arm64 - Julia 1.6
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Run tests
+  image: julia:1.6
+  commands:
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(verbose=true)'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.build()'"
+  - "julia --project=. --check-bounds=yes --color=yes -e 'using Pkg; Pkg.test(coverage=true)'"
+
+trigger:
+  branch:
+  - master
+
+...


### PR DESCRIPTION
With CPUs like A64FX, `aarch64` is an interesting platform for HPC.  I think
it'd be good to tests `MPI.jl` works here.  I just ran the tests on Isambard 2
and they are successful.

However, I have a small application which I tried to run on a MacBook M1
(`aarch64-apple-darwin`) and it crashes at
https://github.com/JuliaLang/julia/blob/58ffe7e3ed3a93a9d816097548e785284f57fbd4/src/codegen.cpp#L5531-L5536
in a call to `MPI.Reduce!`.  Tests are successful also here, so perhaps they
don't capture this error (or the error lies somewhere else), but I'll need to
produce a minimal working example to get a useful test out of it.

If you want to go on with this one, someone will need to enable this repository
at https://cloud.drone.io/.

---


*Edit*: regarding the error I got, I'm using a custom reduction, Valentin pointed out this is known to not work at the moment on non-Intel platforms and tests about them are skipped.