### PR TITLE
Remove `Pkg` from test environment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,8 +24,7 @@ julia = "1"
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CUDA", "DoubleFloats", "Pkg", "Test"]
+test = ["CUDA", "DoubleFloats", "Test"]


### PR DESCRIPTION
`Pkg` is already present in the main environment and this causes a warning when
running the tests in Julia v1.8:

```
(jl_H7V8sZ) pkg> test MPI
     Testing MPI
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1497
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Dependency graph not a DAG, linearizing anyway
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:840
┌ Warning: Could not use exact versions of packages in manifest, re-resolving
└ @ Pkg.Operations ~/repo/julia/usr/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1497
```