### PR TITLE
Waitall!: Work around const-prop failure in setproperty!

### DIFF
--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -459,7 +459,7 @@ function Waitall!(reqs::Vector{Request})
         req = reqs[i]
         if !isnull(req)
             req.val = reqvals[i]
-            req.buffer = nothing
+            Base.setfield!(req, :buffer, nothing)
         end
     end
     return stats

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -406,7 +406,7 @@ function Wait!(req::Request)
                   (Ptr{MPI_Request}, Ptr{Status}),
                   req, stat_ref)
     if !alreadynull
-        req.buffer = nothing
+        Base.setfield!(req, :buffer, nothing)
     end
     stat_ref[]
 end


### PR DESCRIPTION
@aviatesk any ideas why `setproperty!` failed to const-prop?

On 1.7 I am seeing:

```
julia> using Cthulhu

julia> using MPI

julia> descend(MPI.Waitall!, Tuple{Vector{MPI.Request}})

462 └───        invoke Base.setproperty!(%84::MPI.Request, :buffer::Symbol, MPI.nothing::Nothing)::Any

   %95  = invoke setproperty!(::MPI.Request,::Symbol,::Nothing)::Any

```

