### PR TITLE
Broadcasting without a bang

### DIFF
--- a/docs/src/reference/collective.md
+++ b/docs/src/reference/collective.md
@@ -11,6 +11,7 @@ MPI.Ibarrier
 
 ```@docs
 MPI.Bcast!
+MPI.Bcast
 MPI.bcast
 ```
 

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -65,11 +65,7 @@ end
 
 Broadcast the `obj` from `root` to all processes in `comm`. Returns the object.
 """
-function Bcast(obj::T, root::Integer, comm::Comm) where T
-    buf = Ref{T}(obj)
-    Bcast!(buf, root, comm)
-    return buf[]
-end
+Bcast(obj, root::Integer, comm::Comm) = Bcast!(Ref(obj), root, comm)[]
 Bcast(arr::AbstractArray, root::Integer, comm::Comm) = Bcast!(copy(arr), root, comm)
 Bcast(r::Ref, root::Integer, comm::Comm) = Ref(Bcast(r[], root, comm))
 

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -61,13 +61,17 @@ function Bcast!(data, root::Integer, comm::Comm)
 end
 
 """
-    Bcast(obj::T, root::Integer, comm::Comm) where T
+    Bcast(obj, root::Integer, comm::Comm)
 
 Broadcast the `obj` from `root` to all processes in `comm`. Returns the object.
+Currently `obj` must be `isbits`, i.e. `isbitstype(typeof(obj)) == true`.
 """
-Bcast(obj, root::Integer, comm::Comm) = Bcast!(Ref(obj), root, comm)[]
-Bcast(arr::AbstractArray, root::Integer, comm::Comm) = Bcast!(copy(arr), root, comm)
-Bcast(r::Ref, root::Integer, comm::Comm) = Ref(Bcast(r[], root, comm))
+function Bcast(obj::T, root::Integer, comm::Comm) where T
+    if !isbitstype(T)
+        throw(ArgumentError("Bcast currently only supports `isbitstype`s."))
+    end
+    Bcast!(Ref(obj), root, comm)[]
+end
 
 """
     bcast(obj, comm::Comm; root::Integer=0)

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -56,20 +56,22 @@ function Bcast!(buf::Buffer, root::Integer, comm::Comm)
     API.MPI_Bcast(buf.data, buf.count, buf.datatype, root, comm)
     return buf.data
 end
-function Bcast!(arr::Union{Ref,AbstractArray}, root::Integer, comm::Comm)
-    Bcast!(Buffer(arr), root, comm)
+function Bcast!(data, root::Integer, comm::Comm)
+    Bcast!(Buffer(data), root, comm)
 end
 
 """
-    Bcast!(obj::T, root::Integer, comm::Comm) where T
+    Bcast(obj::T, root::Integer, comm::Comm) where T
 
-Broadcast the `obj` from `root` to all processes in `comm`.
+Broadcast the `obj` from `root` to all processes in `comm`. Returns the object.
 """
-function Bcast!(obj::T, root::Integer, comm::Comm) where T
+function Bcast(obj::T, root::Integer, comm::Comm) where T
     buf = Ref{T}(obj)
     Bcast!(buf, root, comm)
     return buf[]
 end
+Bcast(arr::AbstractArray, root::Integer, comm::Comm) = Bcast!(copy(arr), root, comm)
+Bcast(r::Ref, root::Integer, comm::Comm) = Ref(Bcast(r[], root, comm))
 
 """
     bcast(obj, comm::Comm; root::Integer=0)

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -56,8 +56,19 @@ function Bcast!(buf::Buffer, root::Integer, comm::Comm)
     API.MPI_Bcast(buf.data, buf.count, buf.datatype, root, comm)
     return buf.data
 end
-function Bcast!(data, root::Integer, comm::Comm)
-    Bcast!(Buffer(data), root, comm)
+function Bcast!(arr::Union{Ref,AbstractArray}, root::Integer, comm::Comm)
+    Bcast!(Buffer(arr), root, comm)
+end
+
+"""
+    Bcast!(obj::T, root::Integer, comm::Comm) where T
+
+Broadcast the `obj` from `root` to all processes in `comm`.
+"""
+function Bcast!(obj::T, root::Integer, comm::Comm) where T
+    buf = Ref{T}(obj)
+    Bcast!(buf, root, comm)
+    return buf[]
 end
 
 """

--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -44,20 +44,10 @@ res = MPI.Bcast(B, root, comm)
 @test typeof(res) == typeof(A)
 @test res == A
 
-# Bcast: vector
+# Bcast: array
 A = rand(3)
 B = MPI.Comm_rank(comm) == root ? A : zeros(3)
-res = MPI.Bcast(B, root, comm)
-@test typeof(res) == typeof(A)
-@test res == A
-
-# Bcast: Ref
-A = Ref(1.23)
-B = MPI.Comm_rank(comm) == root ? A : Ref(0.0)
-res = MPI.Bcast(B, root, comm)
-@test typeof(res) == typeof(A)
-@test res[] == A[]
-
+@test_throws ArgumentError MPI.Bcast(B, root, comm)
 
 g = x -> x^2 + 2x - 1
 if MPI.Comm_rank(comm) == root

--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -46,7 +46,7 @@ res = MPI.Bcast(B, root, comm)
 
 # Bcast: vector
 A = rand(3)
-B = MPI.Comm_rank(comm) == root ? A : zeros(A)
+B = MPI.Comm_rank(comm) == root ? A : zeros(3)
 res = MPI.Bcast(B, root, comm)
 @test typeof(res) == typeof(A)
 @test res == A

--- a/test/test_bcast.jl
+++ b/test/test_bcast.jl
@@ -26,6 +26,39 @@ MPI.Bcast!(B, comm; root=root)
 @test B == A
 
 
+# Bcast: number
+A = 1.23
+B = MPI.Comm_rank(comm) == root ? 1.23 : 0.0
+res = MPI.Bcast(B, root, comm)
+@test typeof(res) == typeof(A)
+@test res == A
+
+# Bcast: scalar struct
+struct XY
+    x::Float64
+    y::Float32
+end
+A = XY(1.23, 4.56f0)
+B = MPI.Comm_rank(comm) == root ? A : XY(0.0, 0.0f0)
+res = MPI.Bcast(B, root, comm)
+@test typeof(res) == typeof(A)
+@test res == A
+
+# Bcast: vector
+A = rand(3)
+B = MPI.Comm_rank(comm) == root ? A : zeros(A)
+res = MPI.Bcast(B, root, comm)
+@test typeof(res) == typeof(A)
+@test res == A
+
+# Bcast: Ref
+A = Ref(1.23)
+B = MPI.Comm_rank(comm) == root ? A : Ref(0.0)
+res = MPI.Bcast(B, root, comm)
+@test typeof(res) == typeof(A)
+@test res[] == A[]
+
+
 g = x -> x^2 + 2x - 1
 if MPI.Comm_rank(comm) == root
     f = g


### PR DESCRIPTION
Introduces `Bcast` to complement `Bcast!`. Similar to `Send(obj, ...)` the new variant is useful to directly broadcast objects, scalars in particular, to all ranks without having to introduce buffers or the like.

The usecase that made me create this PR is as simple as `Bcast(1.23, ...)` or `Bcast(p, ...)` where `p` is an instantiation of a struct, say:
```julia
struct Params
    a::Float64
    b::Float64
    n::Int64
end
```
Before the PR, one had to wrap these objects manually into `Ref`s to then use `Bcast!(Ref(obj),...)`. This automates this process (and special cases arrays, where we'll simply make a copy, and `Ref` input objects).