### PR TITLE
Various fixes to documentation

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -10,6 +10,7 @@ MPI.free
 
 ```@docs
 MPI.Datatype
+MPI.to_type
 MPI.Types.extent
 MPI.Types.create_contiguous
 MPI.Types.create_vector
@@ -40,4 +41,3 @@ MPI.ErrorHandler
 MPI.get_errorhandler
 MPI.set_errorhandler!
 ```
-

--- a/docs/src/collective.md
+++ b/docs/src/collective.md
@@ -31,6 +31,7 @@ MPI.Allgatherv!
 
 ```@docs
 MPI.Scatter!
+MPI.Scatter
 MPI.Scatterv!
 ```
 
@@ -40,7 +41,6 @@ MPI.Scatterv!
 MPI.Alltoall!
 MPI.Alltoall
 MPI.Alltoallv!
-MPI.Alltoallv
 ```
 
 ## Reduce/Scan

--- a/docs/src/onesided.md
+++ b/docs/src/onesided.md
@@ -4,6 +4,7 @@
 MPI.Win_create
 MPI.Win_create_dynamic
 MPI.Win_allocate_shared
+MPI.Win_shared_query
 MPI.Win_flush
 MPI.Win_lock
 MPI.Win_unlock

--- a/docs/src/pointtopoint.md
+++ b/docs/src/pointtopoint.md
@@ -4,7 +4,9 @@
 
 ```@docs
 MPI.Request
+MPI.RequestSet
 MPI.Status
+MPI.StatusRef
 ```
 
 ### Accessors
@@ -37,14 +39,14 @@ MPI.Irecv!
 ### Completion
 
 ```@docs
-MPI.Test!
-MPI.Testall!
-MPI.Testany!
-MPI.Testsome!
-MPI.Wait!
-MPI.Waitall!
-MPI.Waitany!
-MPI.Waitsome!
+MPI.Test
+MPI.Testall
+MPI.Testany
+MPI.Testsome
+MPI.Wait
+MPI.Waitall
+MPI.Waitany
+MPI.Waitsome
 ```
 
 ### Probe/Cancel

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -315,7 +315,7 @@ if the length can be determined from `sendbuf`. On non-root processes it is igno
 can be `nothing`.
 
 # See also
-- [`Gatherv`](@ref) for the allocating operation
+- [`Gatherv!`](@ref) for the allocating operation
 - [`Gather!`](@ref)
 - [`Allgatherv!`](@ref) to send the result to all processes
 
@@ -432,7 +432,6 @@ If only one buffer `sendrecvbuf` is provided, then for each process, the data to
 is taken from the interval of `recvbuf` where it would store its own data.
 
 # See also
-- [`Allgatherv`](@ref) for the allocating operation
 - [`Gatherv!`](@ref) to send the result to a single process
 
 # External links

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -372,6 +372,13 @@ function create_resized!(newtype::Datatype, oldtype::Datatype, lb::Integer, exte
     return newtype
 end
 
+function duplicate!(newtype::Datatype, oldtype::Datatype)
+    # int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
+    @mpichk ccall((:MPI_Type_dup, libmpi), Cint,
+                  (MPI_Datatype, Ptr{MPI_Datatype}),
+                  oldtype, newtype)
+    return newtype
+end
 """
     MPI.Types.duplicate(oldtype::Datatype)
 
@@ -380,13 +387,6 @@ Duplicates the datatype `oldtype`.
 # External links
 $(_doc_external("MPI_Type_dup"))
 """
-function duplicate!(newtype::Datatype, oldtype::Datatype)
-    # int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
-    @mpichk ccall((:MPI_Type_dup, libmpi), Cint,
-                  (MPI_Datatype, Ptr{MPI_Datatype}),
-                  oldtype, newtype)
-    return newtype
-end
 duplicate(oldtype::Datatype) = duplicate!(Datatype(), oldtype::Datatype)
 
 """

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -134,7 +134,7 @@ An Enum denoting the level of threading support in the current process:
 
 # See also
 
-- [`Init_thread`](@ref)
+- [`Init`](@ref)
 - [`Query_thread`](@ref)
 """
 @enum ThreadLevel begin
@@ -200,12 +200,12 @@ end
 """
     Finalize()
 
-Marks MPI state for cleanup. This should be called after [`MPI.Init`](@ref) or
-[`MPI.Init_thread`](@ref), and can be called at most once. No further MPI calls (other
-than [`Initialized`](@ref) or [`Finalized`](@ref)) should be made after it is called.
+Marks MPI state for cleanup. This should be called after [`MPI.Init`](@ref), and
+can be called at most once. No further MPI calls (other than
+[`Initialized`](@ref) or [`Finalized`](@ref)) should be made after it is called.
 
-[`MPI.Init`](@ref) and [`MPI.Init_thread`](@ref) will automatically insert a hook to
-call this function when Julia exits, if it hasn't already been called.
+[`MPI.Init`](@ref) will automatically insert a hook to call this function when
+Julia exits, if it hasn't already been called.
 
 # External links
 $(_doc_external("MPI_Finalize"))

--- a/src/nonblocking.jl
+++ b/src/nonblocking.jl
@@ -528,4 +528,3 @@ function Cancel!(req::Request)
     @mpichk ccall((:MPI_Cancel, libmpi), Cint, (Ptr{MPI_Request},), req)
     nothing
 end
-


### PR DESCRIPTION
In the documentation there are currently plenty of missing docstrings and broken references in docstrings, see for example: https://juliaparallel.github.io/MPI.jl/dev/pointtopoint/

I tried to fix all issues and add to documentation all functions with docstrings.  Please double check I didn't mess up anything, and also that I didn't add docstrings you didn't want to show in the docs.  Now building the documentation locally gives me only a couple of innocuous warnings about `DocTestSetup` being already set.

_Edit_: see the clean log when building the documentation: https://github.com/JuliaParallel/MPI.jl/runs/4217747616?check_suite_focus=true#step:4:1