### PR TITLE
fix typo in initialization error message

### DIFF
--- a/src/environment.jl
+++ b/src/environment.jl
@@ -93,7 +93,7 @@ function Init(;threadlevel=:serialized, finalize_atexit=true, errors_return=true
     else
         provided = _init_thread(threadlevel)
         if provided < threadlevel
-            @warn "MPI thread level requested = $required, provided = $provided"
+            @warn "MPI thread level requested = $threadlevel, provided = $provided"
         end
 
         if finalize_atexit


### PR DESCRIPTION
The error message issued when the requested and provided thread levels
do not match refers to an undefined variable `requested`.  Change this
to `threadlevel`.


This fixes an error I ran into

```
┌ Error: Exception while generating log record in module MPI at /mnt/lustre/space/nkm1020/.julia/packages/MPI/biSVL/src/environment.jl:96
│   exception =
│    UndefVarError: required not defined
│    Stacktrace:
│     [1] macro expansion
│       @ ./logging.jl:340 [inlined]
│     [2] Init(; threadlevel::Symbol, finalize_atexit::Bool, errors_return::Bool)
│       @ MPI ~/.julia/packages/MPI/biSVL/src/environment.jl:96
│     [3] Init()
│       @ MPI ~/.julia/packages/MPI/biSVL/src/environment.jl:82
│     [4] top-level scope
│       @ ~/UltraDark.jl/benchmarks/time_step/time_step.jl:27
│     [5] include(mod::Module, _path::String)
│       @ Base ./Base.jl:386
│     [6] exec_options(opts::Base.JLOptions)
│       @ Base ./client.jl:285
│     [7] _start()
│       @ Base ./client.jl:485
└ @ MPI ~/.julia/packages/MPI/biSVL/src/environment.jl:96
```