### PR TITLE
Add a lightweight MPIABI sub-package that controls the MPI ABI

### DIFF
--- a/lib/MPIABI/Project.toml
+++ b/lib/MPIABI/Project.toml
@@ -1,0 +1,7 @@
+name = "MPIABI"
+uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+authors = []
+version = "0.1.0"
+
+[deps]
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"

--- a/lib/MPIABI/UNLICENSE
+++ b/lib/MPIABI/UNLICENSE
@@ -1,0 +1,25 @@
+This is free and unencumbered software released into the public
+domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/lib/MPIABI/src/MPIABI.jl
+++ b/lib/MPIABI/src/MPIABI.jl
@@ -1,0 +1,79 @@
+module MPIABI
+
+using Preferences
+
+function known_abis()
+    return (:MicrosoftMPI, :MPICH, :OpenMPI, :MPItrampoline)
+end
+
+# const abi = begin
+#     _abi = @load_preference("abi", nothing)
+#     if isnothing(_abi)
+#        _abi = find_abi()
+#        @set_preference!("abi" => _abi)
+#     end
+#     _abi
+# end
+
+const abi = @load_preference("abi", Sys.iswindows() ? :MicrosoftMPI : :MPICH)
+
+function __init__()
+    if Sys.iswindows()
+        if abi != :MicrosoftMPI
+            @error """
+                The MPI ABI is not compatible with the current platform.
+                Please set the MPI ABI to :MicrosoftMPI.
+            """
+        end
+    end
+end
+
+function set_abi(abi)
+    if abi ∉ known_abis()
+        error("""
+            The MPI ABI $abi is not supported.
+            Please set the MPI ABI to one of the following:
+            $(known_abis())
+        """)
+    end
+    @set_preferences!("abi" => abi)
+    @warn "The MPI abi has changed, you will need to restart Julia for the change to take effect" abi
+
+    if VERSION <= v"1.6.5" || VERSION == v"1.7.0"
+        @warn """
+        Due to a bug in Julia (until 1.6.5 and 1.7.1), setting preferences in transitive dependencies
+        is broken (https://github.com/JuliaPackaging/Preferences.jl/issues/24). As a workaround, we 
+        will now add MPIABI as a direct dependency in your current project.
+        """
+
+        uuid = Preferences.get_uuid(@__MODULE__)
+        project_toml, pkg_name = Preferences.find_first_project_with_uuid(uuid)
+
+        if project_toml === nothing && pkg_name === nothing
+            # If we couldn't find one, we're going to use `active_project()`
+            project_toml = Base.active_project()
+
+            # And we're going to need to add this UUID as an "extras" dependency:
+            # We're going to assume you want to name this this dependency in the
+            # same way as it's been loaded:
+            pkg_uuid_matches = filter(d -> d.uuid == uuid, keys(Base.loaded_modules))
+            if isempty(pkg_uuid_matches)
+                error("Cannot set preferences of an unknown package that is not loaded!")
+            end
+            pkg_name = first(pkg_uuid_matches).name
+
+            # Read in the project, add the deps, write it back out!
+            project = Base.parsed_toml(project_toml)
+            if !haskey(project, "deps")
+                project["deps"] = Dict{String,Any}()
+            end
+            project["deps"][pkg_name] = string(uuid)
+            open(project_toml, "w") do io
+                TOML.print(io, project; sorted=true)
+            end
+        end
+    end
+    return abi
+end
+
+end # module


### PR DESCRIPTION
The goal is to have a central source of truth to query the MPI ABI used by Julia and by binary dependencies.

With this we can change the ABI, and after a restart the user will download the appropriate binaries/complain that they are incompatible.

With this I can change https://github.com/JuliaPackaging/Yggdrasil/pull/4073 to contain

```
augmented_platform_block = """
    using Base.BinaryPlatforms
    using MPIABI
    function augmented_platform(platform)
        abi = MPI.abi
        BinaryPlatforms.add_tag!(platform.tags, "mpi", string(abi))
        return platform
    end
"""
```

and have the LAMMPS_jll use the right ABI. 

Open questions are:
- ABI vs System and Library? E.g. Can we assume that binaries built against OpenMPI_jll are compatible with a system OpenMPI? I think so, so switching on the ABI and not the library used "should" work.
- Do we need to have a separate package? I think so, we want the choice to be as lightweight as possible, and MPI.jl might use MPIABI to what it includes itself.

cc: @eschnett @staticfloat @simonbyrne 

