### PR TITLE
Run CI only when relevant directories are modified

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -5,7 +5,13 @@ on:
     branches:
       - master
     tags: '*'
+    paths:
+      - 'docs/**'
+      - 'src/**'
   pull_request:
+    paths:
+      - 'docs/**'
+      - 'src/**'
 
 jobs:
   docs-build:

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -5,7 +5,11 @@ on:
     branches:
       - master
     tags: '*'
+    paths:
+      - 'bin/**'
   pull_request:
+    paths:
+      - 'bin/**'
 
 jobs:
   shellcheck:

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -1,11 +1,20 @@
-name: Unit Tests
+name: MPI.jl Unit Tests
 
 on:
   pull_request:
-
+    paths:
+      - 'bin/**'
+      - 'deps/**'
+      - 'src/**'
+      - 'test/**'
   push:
     branches:
       - master
+    paths:
+      - 'bin/**'
+      - 'deps/**'
+      - 'src/**'
+      - 'test/**'
 
 jobs:
   test-jll:
@@ -17,9 +26,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         julia_version:
-          # Unsupported - "1.3"
-          # Unsupported - "1.4"
-          # Unsupported - "1.5"
           - "1.6"
           - "1.7"
           - "nightly"


### PR DESCRIPTION
This avoids spawning dozens of jobs when modifying unrelated files (like README,
documentation, etc...)

This is related to #529, as we can have a CI job to test only MPIABI.jl,
although we'll probably want to run downstream MPI.jl tests when MPIABI.jl is
modified.