### PR TITLE
Add RMA examples to docs 

### DIFF
--- a/docs/examples/07-rma_active.jl
+++ b/docs/examples/07-rma_active.jl
@@ -1,0 +1,52 @@
+# This example demonstrates one-sided communication,
+# specifically activate Remote Memory Access (RMA)
+
+using MPI
+
+MPI.Init()
+const world_sz = MPI.Comm_size(MPI.COMM_WORLD)
+const rank = MPI.Comm_rank(MPI.COMM_WORLD)
+
+# allocate memory
+all_ranks = fill(-1, world_sz)
+# create RMA window on all ranks
+win = MPI.Win_create(all_ranks, MPI.COMM_WORLD)
+
+#### first, let's MPI.Put on all ranks
+
+# start the communication epoch
+MPI.Win_fence(0, win)
+# each rank writes to exposed windows of rank 0
+# Signature: obj, target_rank, target_displacement, window
+MPI.Put(rank, 0, rank, win)
+# finish the communication epoch
+MPI.Win_fence(0, win)
+# print window content on all ranks
+for j in 0:world_sz-1
+    if rank == j
+        println("After Put, Rank $rank:")
+        @show all_ranks
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+rank == 0 && println()
+
+#### now, let's MPI.Get on all ranks
+
+# start the communication epoch
+MPI.Win_fence(0, win)
+# each rank reads from exposed windows of rank 0
+MPI.Get(all_ranks, 0, win)
+# finish the communication epoch
+MPI.Win_fence(0, win)
+# print window content on all ranks
+for j in 0:world_sz-1
+    if rank == j
+        println("After Get, Rank $rank:")
+        @show all_ranks
+    end
+    MPI.Barrier(MPI.COMM_WORLD)
+end
+
+# free window
+MPI.free(win)

--- a/docs/examples/08-rma_passive.jl
+++ b/docs/examples/08-rma_passive.jl
@@ -1,0 +1,38 @@
+# This example demonstrates one-sided communication,
+# specifically passive Remote Memory Access (RMA)
+
+using MPI
+
+MPI.Init()
+const world_sz = MPI.Comm_size(MPI.COMM_WORLD)
+const rank = MPI.Comm_rank(MPI.COMM_WORLD)
+
+# allocate memory
+all_ranks = fill(-1, world_sz)
+# create RMA window on all ranks
+win = MPI.Win_create(all_ranks, MPI.COMM_WORLD)
+
+# let each rank write its rank number into window
+if rank != 0
+    # lock window (MPI.LOCK_SHARED works as well)
+    MPI.Win_lock(MPI.LOCK_EXCLUSIVE, 0, 0, win)
+    # each rank writes to exposed windows of rank 0
+    # Signature: obj, target_rank, target_displacement, window
+    MPI.Put(rank, 0, rank, win)
+    # finish the communication epoch
+    MPI.Win_unlock(0, win)
+else
+    all_ranks[1] = 0
+end
+
+# wait with printing
+MPI.Win_fence(0, win)
+
+# print window content on all ranks
+if rank == 0
+    println("After Put with lock / unlock, window content on rank 0:")
+    @show all_ranks
+end
+
+# free window
+MPI.free(win)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,8 @@ EXAMPLES = [
     "Send/receive" => "examples/04-sendrecv.md",
     "Job Scheduling" => "examples/05-job_schedule.md",
     "Scatterv and Gatherv" => "examples/06-scatterv.md",
+    "Active RMA" => "examples/07-rma_active.md",
+    "Passive RMA" => "examples/08-rma_passive.md",
 ]
 
 examples_md_dir = joinpath(@__DIR__,"src/examples")


### PR DESCRIPTION
Adds one-sided communication (active and passive RMA) examples to the docs. Building the docs worked locally. Feel free to suggest improvements to the examples or stylistic changes.

PS: I have more instructive examples like sending a subpart of a matrix via 1) views 2) explicitly using derived types etc. Should I prepare / add those as well? What do you think?