### PR TITLE
Cleanup `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-libjuliampi.so
-libjuliampi.dylib
 *.cov
-*.dSYM
 *.mem
-*.so
 Manifest.toml
 LocalPreferences.toml


### PR DESCRIPTION
Do not ignore files that were previously generated by the build step, ~and the
`LocalPreferences.toml` (we shouldn't have to manually set the preference inside
this environment)~.