### PR TITLE
Properly `dlopen` MPI library on Unix systems

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -99,19 +99,6 @@ include("mpiexec_wrapper.jl")
 include("deprecated.jl")
 
 function __init__()
-
-    @static if Sys.isunix()
-        # dlopen the MPI library before any ccall:
-        # - RTLD_GLOBAL is required for Open MPI
-        #   <https://www.open-mpi.org/community/lists/users/2010/04/12803.php>
-        # - also allows us to ccall global symbols, which enables
-        #   profilers which use LD_PRELOAD
-        # - don't use RTLD_DEEPBIND; this leads to segfaults at least
-        #   on Ubuntu 15.10
-        #   <https://github.com/JuliaParallel/MPI.jl/pull/109>
-        Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
-    end
-
     # disable UCX memory cache, since it doesn't work correctly
     # https://github.com/openucx/ucx/issues/5061
     if !haskey(ENV, "UCX_MEMTYPE_CACHE")

--- a/src/consts/consts.jl
+++ b/src/consts/consts.jl
@@ -52,7 +52,7 @@ function __init__()
         #   <https://github.com/JuliaParallel/MPI.jl/pull/109>
         #   and when using HPE's MPT MPI implementation
         #   <https://github.com/JuliaParallel/MPI.jl/pull/580>
-        # This call needs to be here instead of MPI.__init__ since the evaluation of
+        # This call needs to be here instead of `MPI.__init__` since the evaluation of
         # the `initexprs` below might otherwise load the MPI library in an uncontrolled
         # manner
         Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)


### PR DESCRIPTION
Due to the new `MPI.Consts` submodule and the use of the `@const_ref` macro for convenience, Julia might load the MPI library already before entering the `MPI.__init__` function, where it is explicitly `dlopen`ed on Unix systems to account for proper symbol resolution. This PR moves the appropriate call to `dlopen` to the `MPI.Consts.__init__` function and changes the way the `@const_ref` actions are evaluated to ensure that Julia does not already load the MPI library in an uncontrolled manner.

Fixes #587.