### PR TITLE
Update link to mpi4py project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov.io](https://codecov.io/github/JuliaParallel/MPI.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaParallel/MPI.jl?branch=master)
 [![Coverage Status](https://coveralls.io/repos/JuliaParallel/MPI.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaParallel/MPI.jl?branch=master)
 
-This provides [Julia](http://julialang.org/) interface to the Message Passing Interface ([MPI](http://www.mpi-forum.org/)), roughly inspired by [mpi4py](http://mpi4py.scipy.org).
+This provides [Julia](http://julialang.org/) interface to the Message Passing Interface ([MPI](http://www.mpi-forum.org/)), roughly inspired by [mpi4py](https://github.com/mpi4py/mpi4py/).
 
 Please see the [documentation](https://juliaparallel.github.io/MPI.jl/stable/) for instructions on [configuration](https://juliaparallel.github.io/MPI.jl/stable/configuration/) and [usage](https://juliaparallel.github.io/MPI.jl/stable/usage/).
 


### PR DESCRIPTION
[mpi4py.scipy.org](http://mpi4py.scipy.org/) doesn't seem to work anymore.  I'm undecided between https://github.com/mpi4py/mpi4py/ and the documentation at https://mpi4py.readthedocs.io/, but decided to use the GitHub link because the page on [PyPi](https://pypi.org/project/mpi4py/) indicates this one as homepage.