### PR TITLE
Call constant init via invokelatest

### DIFF
--- a/src/consts/consts.jl
+++ b/src/consts/consts.jl
@@ -46,4 +46,7 @@ end
     $(Expr(:block, initexprs...))
 end
 
+# since this is called by invokelatest, it isn't automatically precompiled
+precompile(init_consts, ())
+
 end

--- a/src/consts/consts.jl
+++ b/src/consts/consts.jl
@@ -39,7 +39,10 @@ else
     error("Unknown MPI ABI $(MPIPreferences.abi)")
 end
 
-@eval function __init__()
+# Initialize the ref constants from the library.
+# This is not `Consts.__init__`, as it should be called _after_
+# `dlopen` to ensure the library is opened correctly.
+@eval function init_consts()
     $(Expr(:block, initexprs...))
 end
 


### PR DESCRIPTION
Yet another potential solution to #587. This appears to avoid early dlopen-ing of the library.

Thoughts @giordano @vchuravy @sloede ?