### PR TITLE
Base `MPI.identify_implementation` on helper function in `MPIPreferences`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,6 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 DocStringExtensions = "0.8"
-MPIPreferences = "0.1"
+MPIPreferences = "0.1.2"
 Requires = "~0.5, 1.0"
 julia = "1.6"

--- a/docs/src/reference/library.md
+++ b/docs/src/reference/library.md
@@ -9,12 +9,6 @@ MPI.MPI_LIBRARY_VERSION
 MPI.MPI_LIBRARY_VERSION_STRING
 ```
 
-## Enums
-
-```@docs
-MPI.MPIImpl
-```
-
 ## Functions
 
 ```@docs

--- a/lib/MPIPreferences/Project.toml
+++ b/lib/MPIPreferences/Project.toml
@@ -1,7 +1,7 @@
 name = "MPIPreferences"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 authors = []
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -295,10 +295,10 @@ function has_cuda()
     flag = get(ENV, "JULIA_MPI_HAS_CUDA", nothing)
     if flag === nothing
         # Only Open MPI provides a function to check CUDA support
-        @static if MPI_LIBRARY == OpenMPI
+        @static if MPI_LIBRARY == "OpenMPI"
             # int MPIX_Query_cuda_support(void)
             return 0 != ccall((:MPIX_Query_cuda_support, libmpi), Cint, ())
-        elseif MPI_LIBRARY == IBMSpectrumMPI
+        elseif MPI_LIBRARY == "IBMSpectrumMPI"
             return true
         else
             return false

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -92,66 +92,7 @@ This function is only intended for internal use. Users should use [`MPI_LIBRARY`
 [`MPI_LIBRARY_VERSION`](@ref).
 """
 function identify_implementation()
-    impl = UnknownMPI
-    version = v"0"
-
-    if startswith(MPI_LIBRARY_VERSION_STRING, "MPICH")
-        impl = MPICH
-        # "MPICH Version:\t%s\n" / "MPICH2 Version:\t%s\n"
-        if (m = match(r"^MPICH2? Version:\t(\d+.\d+(?:.\d+)?\w*)\n", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[1])
-        end
-
-    elseif startswith(MPI_LIBRARY_VERSION_STRING, "MPItrampoline") || startswith(MPI_LIBRARY_VERSION_STRING, "MPIwrapper")
-        impl = MPItrampoline
-        # "MPItrampoline %d.%d.%d," / "MPIwrapper %d.%d.%d,"
-        if (m = match(r"^MPI(wrapper|trampoline) (\d+.\d+.\d+),", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[2])
-        end
-
-    elseif startswith(MPI_LIBRARY_VERSION_STRING, "Open MPI")
-        # Open MPI / Spectrum MPI
-        impl = occursin("IBM Spectrum MPI", MPI_LIBRARY_VERSION_STRING) ? IBMSpectrumMPI : OpenMPI
-
-        if (m = match(r"^Open MPI v(\d+.\d+.\d+\w*)", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[1])
-        end
-
-    elseif startswith(MPI_LIBRARY_VERSION_STRING, "Microsoft MPI")
-        impl = MicrosoftMPI
-        # "Microsoft MPI %u.%u.%u.%u%S"
-        # ignore last 2 (build numbers)
-        if (m = match(r"^Microsoft MPI (\d+.\d+)", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[1])
-        end
-
-    elseif startswith(MPI_LIBRARY_VERSION_STRING, "Intel")
-        impl = IntelMPI
-
-        # "Intel(R) MPI Library 2019 Update 4 for Linux* OS"
-        if (m = match(r"^Intel\(R\) MPI Library (\d+)(?: Update (\d+))?", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            if m.captures[2] === nothing
-                version = VersionNumber(m.captures[1])
-            else
-                version = VersionNumber(m.captures[1]*"."*m.captures[2])
-            end
-        end
-
-    elseif startswith(MPI_LIBRARY_VERSION_STRING, "MVAPICH2")
-        impl = MVAPICH
-        # "MVAPICH2 Version      :\t%s\n")
-        if (m = match(r"^MVAPICH2? Version\s*:\t(\S*)\n", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[1])
-        end
-
-    elseif occursin("CRAY MPICH", MPI_LIBRARY_VERSION_STRING)
-        impl = CrayMPICH
-        # "MPI VERSION    : CRAY MPICH version 7.7.10 (ANL base 3.2)\n"
-        if (m = match(r"CRAY MPICH version (\d+.\d+.\d+)", MPI_LIBRARY_VERSION_STRING)) !== nothing
-            version = VersionNumber(m.captures[1])
-        end
-    end
-
+    impl, version, abi = MPIPreferences.identify_implementation_version_abi(MPI_LIBRARY_VERSION_STRING)
     return impl, version
 end
 

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -50,42 +50,12 @@ $(_doc_external("MPI_Get_library_version"))
 const MPI_LIBRARY_VERSION_STRING = Get_library_version()
 
 """
-    MPIImpl
-
-An enum corresponding to known MPI implementations
-
-- `UnknownMPI`: unable to determine MPI implementation
-- `MPICH`: [MPICH](https://www.mpich.org/)
-- `OpenMPI`: [Open MPI](https://www.open-mpi.org/)
-- `MicrosoftMPI`: [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi)
-- `IntelMPI`: [Intel MPI](https://software.intel.com/en-us/mpi-library)
-- `SpectrimMPI`: [IBM Spectrum MPI](https://www.ibm.com/us-en/marketplace/spectrum-mpi)
-- `MVAPICH`: [MVAPICH](http://mvapich.cse.ohio-state.edu/)
-- `CrayMPICH`: Part of the Cray Message Passing Toolkit (MPT)
-
-# See also
-
-- [`MPI_LIBRARY`](@ref)
-"""
-@enum MPIImpl begin
-    UnknownMPI
-    MPICH
-    MPItrampoline
-    OpenMPI
-    MicrosoftMPI
-    IntelMPI
-    IBMSpectrumMPI
-    MVAPICH
-    CrayMPICH
-end
-
-"""
     impl, version = identify_implementation()
 
 Attempt to identify the MPI implementation based on
 [`MPI_LIBRARY_VERSION_STRING`](@ref). Returns a triple of values:
 
-- `impl`: a value of type [`MPIImpl`](@ref)
+- `impl`: a `String` with the name of the MPI implementation, or `"unknown"` if it cannot be determined,
 - `version`: a `VersionNumber` of the library, or `nothing` if it cannot be determined.
 
 This function is only intended for internal use. Users should use [`MPI_LIBRARY`](@ref),
@@ -99,12 +69,9 @@ end
 const MPI_LIBRARY, MPI_LIBRARY_VERSION = identify_implementation()
 
 """
-    MPI_LIBRARY :: MPIImpl
+    MPI_LIBRARY :: String
 
 The current MPI implementation: this is determined by
-
-# See also
-- [`MPIImpl`](@ref)
 """
 MPI_LIBRARY
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -89,7 +89,7 @@ end
 
 
 function Op(f, T=Any; iscommutative=false)
-    @static if MPI_LIBRARY == MicrosoftMPI && Sys.WORD_SIZE == 32
+    @static if MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32
         error("User-defined reduction operators are not supported on 32-bit Windows.\nSee https://github.com/JuliaParallel/MPI.jl/issues/246 for more details.")
     elseif Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) || startswith(lowercase(String(Sys.ARCH)), "arm")
         error("User-defined reduction operators are currently not supported on non-Intel architectures.\nSee https://github.com/JuliaParallel/MPI.jl/issues/404 for more details.")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,9 +48,9 @@ testfiles = sort(filter(istest, readdir(testdir)))
         elseif f == "test_error.jl"
             r = run(ignorestatus(cmd()))
             @test !success(r)
-        elseif f == "test_errorhandler.jl" && (MPI.identify_implementation()[1] == MPI.UnknownMPI ||
-            # Fujitsu MPI is known to not work with custom error handlers
-            startswith(MPI.MPI_LIBRARY_VERSION_STRING, "FUJITSU MPI"))
+        elseif f == "test_errorhandler.jl" && MPI.MPI_LIBRARY in ("unknown", "FujitsuMPI")
+            # Fujitsu MPI is known to not work with custom error handlers.  Also
+            # unknown implementations may fail for the same reason.
             try
                 run(cmd())
             catch e

--- a/test/test_allreduce.jl
+++ b/test/test_allreduce.jl
@@ -13,7 +13,7 @@ MPI.Init()
 comm_size = MPI.Comm_size(MPI.COMM_WORLD)
 
 if ArrayType != Array ||
-   MPI.MPI_LIBRARY == MPI.MicrosoftMPI && Sys.WORD_SIZE == 32 ||
+   MPI.MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32 ||
    Sys.ARCH === :powerpc64le || Sys.ARCH === :ppc64le ||
    Sys.ARCH === :aarch64 || startswith(string(Sys.ARCH), "arm")
     operators = [MPI.SUM, +]

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -11,7 +11,7 @@ end
 # Closures might not be supported by cfunction
 const can_do_closures =
     ArrayType === Array &&
-    !(MPI.MPI_LIBRARY == MPI.MicrosoftMPI && Sys.WORD_SIZE == 32) &&
+    !(MPI.MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32) &&
     Sys.ARCH !== :powerpc64le &&
     Sys.ARCH !== :ppc64le &&
     Sys.ARCH !== :aarch64 &&


### PR DESCRIPTION
We basically moved the detection of ABI/implementation to `MPIPreferences`, and
added only there the support for new ABIs/implementations, which means that
`MPI.identify_implementation` is now giving incorrect results for them, and also
the constants `MPI.MPI_LIBRARY` and `MPI.MPI_LIBRARY_VERSION` are now wrong.

By having a new helper function in `MPIPreferences` we can have all other
functions use it under the hood and keep everything in-sync.

---

***Note***: this is still incomplete, because now `MPI.identify_implementation` returns a string instead of an instance of the enum `MPI.MPIImpl` (which is incomplete because it's missing the new implementations Fujitsu MPI and HPE MPT).  What we should do about that?  Make `MPI.identify_implementation` return a string or create a mapping between the strings returned by `MPIPreferences.identify_implementation_version_abi` and the enum `MPI.MPIImpl`, move `MPI.MPIImpl` to `MPIPreferences`, or simply give up on the enum and use the strings everywhere?  It doesn't look like `MPIImpl` is [widely used](https://github.com/JuliaParallel/MPI.jl/search?q=MPIImpl&type=code).