### PR TITLE
Use corresponding aliases for C types in OpenMPI ABI file

### DIFF
--- a/src/consts/openmpi.jl
+++ b/src/consts/openmpi.jl
@@ -17,8 +17,8 @@ const MPI_MAX_PROCESSOR_NAME = Cint(256)
 # Various (signed) integer types:
 const MPI_Aint = Cptrdiff_t
 const MPI_Fint = Cint
-const MPI_Count = Clonglong
-const MPI_Offset = Clonglong
+const MPI_Count = Int  # needs to be Int to match different sizes on 32-bit/64-bit systems
+const MPI_Offset = Int # needs to be Int to match different sizes on 32-bit/64-bit systems
 
 # Status:
 struct MPI_Status

--- a/src/consts/openmpi.jl
+++ b/src/consts/openmpi.jl
@@ -15,10 +15,10 @@ const MPI_MAX_PROCESSOR_NAME = Cint(256)
 # Types
 
 # Various (signed) integer types:
-const MPI_Aint = Int
-const MPI_Fint = Int32
-const MPI_Count = Int
-const MPI_Offset = Int
+const MPI_Aint = Cptrdiff_t
+const MPI_Fint = Cint
+const MPI_Count = Clonglong
+const MPI_Offset = Clonglong
 
 # Status:
 struct MPI_Status


### PR DESCRIPTION
Make the code more portable by using corresponding C aliases instead of Julia types.

Xref: https://github.com/JuliaParallel/MPI.jl/issues/576#issue-1213221198, https://github.com/JuliaParallel/MPI.jl/issues/576#issuecomment-1140498016
CC @simonbyrne 