### PR TITLE
Fix indentation of `Comm_remote_group` docstring

### DIFF
--- a/src/comm.jl
+++ b/src/comm.jl
@@ -96,7 +96,7 @@ function Comm_group(comm::Comm)
 end
 
 """
-Comm_remote_group(comm::Comm)
+    Comm_remote_group(comm::Comm)
 
 Accesses the remote group associated with the given inter-communicator.
 


### PR DESCRIPTION
This is currently rendered incorrectly at https://juliaparallel.org/MPI.jl/dev/reference/comm/#MPI.Comm_remote_group because of the wrong indentation.