### PR TITLE
document how to pass MPI.Comm objects to C

### DIFF
--- a/docs/src/reference/comm.md
+++ b/docs/src/reference/comm.md
@@ -12,7 +12,7 @@ each process a unique *rank* (see [`MPI.Comm_rank`](@ref)) taking an integer val
 MPI.Comm
 ```
 
-If you need to pass a Julia `MPI.Comm` object to an external C/C++ library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
+If you need to pass a Julia `MPI.Comm` object to an external C/C++ library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `MPI.MPI_Comm` and the correct conversion will be performed.
 
 ## Constants
 

--- a/docs/src/reference/comm.md
+++ b/docs/src/reference/comm.md
@@ -12,6 +12,8 @@ each process a unique *rank* (see [`MPI.Comm_rank`](@ref)) taking an integer val
 MPI.Comm
 ```
 
+If you need to pass a Julia `MPI.Comm` to an external library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
+
 ## Constants
 
 ```@docs

--- a/docs/src/reference/comm.md
+++ b/docs/src/reference/comm.md
@@ -12,7 +12,7 @@ each process a unique *rank* (see [`MPI.Comm_rank`](@ref)) taking an integer val
 MPI.Comm
 ```
 
-If you need to pass a Julia `MPI.Comm` object to an external C/C++ library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `MPI.MPI_Comm` and the correct conversion will be performed.
+If you need to pass a Julia `MPI.Comm` object to an external C/C++ library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument type `MPI.API.MPI_Comm` and the correct conversion will be performed.
 
 ## Constants
 

--- a/docs/src/reference/comm.md
+++ b/docs/src/reference/comm.md
@@ -12,7 +12,7 @@ each process a unique *rank* (see [`MPI.Comm_rank`](@ref)) taking an integer val
 MPI.Comm
 ```
 
-If you need to pass a Julia `MPI.Comm` object to an external library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
+If you need to pass a Julia `MPI.Comm` object to an external C/C++ library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
 
 ## Constants
 

--- a/docs/src/reference/comm.md
+++ b/docs/src/reference/comm.md
@@ -12,7 +12,7 @@ each process a unique *rank* (see [`MPI.Comm_rank`](@ref)) taking an integer val
 MPI.Comm
 ```
 
-If you need to pass a Julia `MPI.Comm` to an external library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
+If you need to pass a Julia `MPI.Comm` object to an external library ([via `ccall`](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/)) that expects an `MPI_Comm` argument, you should declare the corresponding `ccall` argument as a `Ptr{MPI.MPI_Comm}` and the correct conversion will be performed.
 
 ## Constants
 


### PR DESCRIPTION
This seems to be missing from the docs ([discourse](https://discourse.julialang.org/t/how-can-i-pass-the-pointer-of-mpi-communicator-to-c-function/87070)).