### PR TITLE
Wrap `MPI_Get_processor_name` function

### DIFF
--- a/docs/src/reference/environment.md
+++ b/docs/src/reference/environment.md
@@ -18,6 +18,7 @@ MPI.ThreadLevel
 ```@docs
 MPI.Abort
 MPI.Init
+MPI.Get_processor_name
 MPI.Query_thread
 MPI.Is_thread_main
 MPI.Initialized

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -307,3 +307,19 @@ function has_cuda()
         return parse(Bool, flag)
     end
 end
+
+"""
+    Get_processor_name()
+
+Return the name of the processor, as a `String`.
+
+# External links
+$(_doc_external("MPI_Get_processor_name"))
+"""
+function Get_processor_name()
+    proc_name = Array{UInt8}(undef, Consts.MPI_MAX_PROCESSOR_NAME)
+    name_len = Ref{Cint}(0)
+    @mpicall ccall((:MPI_Get_processor_name, libmpi), Cint, (Ptr{UInt8}, Ptr{Cint}), proc_name, name_len)
+    @assert name_len[] <= Consts.MPI_MAX_PROCESSOR_NAME
+    GC.@preserve proc_name unsafe_string(pointer(proc_name))
+end

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -2,6 +2,8 @@ include("common.jl")
 
 MPI.Init()
 
+@test MPI.Get_processor_name() == gethostname()
+
 comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)


### PR DESCRIPTION
I spent most of the time deciding where to put the test and the docstring.  I'm not sure I found sensible places, suggestions are welcome.

Fix #624.