### PR TITLE
Add wrapper for MPI_Get_processor_name

### DIFF
--- a/src/environment.jl
+++ b/src/environment.jl
@@ -307,3 +307,21 @@ function has_cuda()
         return parse(Bool, flag)
     end
 end
+
+"""
+    Get_processor_name()
+
+Returns the name of the processor
+
+# External links
+$(_doc_external("MPI_Get_processor_name"))
+"""
+function Get_processor_name()
+    buf = Array{UInt8}(undef, MPI.Consts.MPI_MAX_PROCESSOR_NAME)
+    buflen = Ref{Cint}()
+
+    @mpicall ccall((:MPI_Get_processor_name, libmpi), Cint, (Ptr{UInt8}, Ref{Cint}), buf, buflen)
+    @assert buflen[] < MPI.Consts.MPI_MAX_PROCESSOR_NAME
+    resize!(buf, buflen[])
+    return String(buf)
+end


### PR DESCRIPTION
This PR add a wrapper for MPI_Get_processor_name

The MPI_Get_processor_name function can be handy for testing MPI programs but was not yet available in MPI.jl. Also, some introductory MPI examples for C and Fortran rely on this function, hence the lack of a wrapper in MPI.jl prevents porting these examples to Julia.

Since the result of this function is by definition dependent on the machine that executes the code, I wasn't able to come up with a meaningful test.
