### PR TITLE
Remove outdated references to {send,recv}{type,count} in `Sendrecv!` docstring

### DIFF
--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -237,8 +237,8 @@ end
             dest::Integer, sendtag::Integer=0, source::Integer=MPI_ANY_SOURCE, recvtag::Integer=MPI_ANY_TAG)
 
 Complete a blocking send-receive operation over the MPI communicator `comm`. Send `sendbuf`
-to the MPI rank `dest` using message tag `tag`, and receive from MPI rank `source` into the
-buffer `recvbuf` using message tag `tag`. Return a [`Status`](@ref) object.
+to the MPI rank `dest` using message tag `sendtag`, and receive from MPI rank `source` into the
+buffer `recvbuf` using message tag `recvtag`. Return a [`Status`](@ref) object.
 
 # External links
 $(_doc_external("MPI_Sendrecv"))

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -236,13 +236,9 @@ end
     data, status = Sendrecv!(sendbuf, recvbuf, comm, MPI.Status;
             dest::Integer, sendtag::Integer=0, source::Integer=MPI_ANY_SOURCE, recvtag::Integer=MPI_ANY_TAG)
 
-Complete a blocking send-receive operation over the MPI communicator `comm`. Send
-`sendcount` elements of type `sendtype` from `sendbuf` to the MPI rank `dest` using message
-tag `tag`, and receive `recvcount` elements of type `recvtype` from MPI rank `source` into
-the buffer `recvbuf` using message tag `tag`. Return a [`Status`](@ref) object.
-
-If not provided, `sendtype`/`recvtype` and `sendcount`/`recvcount` are derived from the
-element type and length of `sendbuf`/`recvbuf`, respectively.
+Complete a blocking send-receive operation over the MPI communicator `comm`. Send `sendbuf`
+to the MPI rank `dest` using message tag `tag`, and receive from MPI rank `source` into the
+buffer `recvbuf` using message tag `tag`. Return a [`Status`](@ref) object.
 
 # External links
 $(_doc_external("MPI_Sendrecv"))


### PR DESCRIPTION
As far as I can tell, these arguments were completely removed in #329, but the
docstring was still mentioning them.