### PR TITLE
Move `Get_processor_name` to new Misc section, and fix test

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,6 +63,7 @@ makedocs(
             "reference/mpipreferences.md",
             "reference/library.md",
             "reference/environment.md",
+            "reference/misc.md",
             "reference/comm.md",
             "reference/buffers.md",
             "reference/pointtopoint.md",

--- a/docs/src/reference/environment.md
+++ b/docs/src/reference/environment.md
@@ -18,7 +18,6 @@ MPI.ThreadLevel
 ```@docs
 MPI.Abort
 MPI.Init
-MPI.Get_processor_name
 MPI.Query_thread
 MPI.Is_thread_main
 MPI.Initialized

--- a/docs/src/reference/misc.md
+++ b/docs/src/reference/misc.md
@@ -1,0 +1,7 @@
+# Miscellanea
+
+## Functions
+
+```@docs
+MPI.Get_processor_name
+```

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -103,6 +103,7 @@ include("onesided.jl")
 include("io.jl")
 include("errhandler.jl")
 include("mpiexec_wrapper.jl")
+include("misc.jl")
 
 include("deprecated.jl")
 

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -294,19 +294,3 @@ function has_cuda()
         return parse(Bool, flag)
     end
 end
-
-"""
-    Get_processor_name()
-
-Return the name of the processor, as a `String`.
-
-# External links
-$(_doc_external("MPI_Get_processor_name"))
-"""
-function Get_processor_name()
-    proc_name = Array{UInt8}(undef, Consts.MPI_MAX_PROCESSOR_NAME)
-    name_len = Ref{Cint}(0)
-    API.MPI_Get_processor_name(proc_name, name_len)
-    @assert name_len[] <= Consts.MPI_MAX_PROCESSOR_NAME
-    GC.@preserve proc_name unsafe_string(pointer(proc_name))
-end

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,0 +1,15 @@
+"""
+    Get_processor_name()
+
+Return the name of the processor, as a `String`.
+
+# External links
+$(_doc_external("MPI_Get_processor_name"))
+"""
+function Get_processor_name()
+    proc_name = Array{UInt8}(undef, Consts.MPI_MAX_PROCESSOR_NAME)
+    name_len = Ref{Cint}(0)
+    API.MPI_Get_processor_name(proc_name, name_len)
+    @assert name_len[] <= Consts.MPI_MAX_PROCESSOR_NAME
+    GC.@preserve proc_name unsafe_string(pointer(proc_name))
+end

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -1,0 +1,8 @@
+include("common.jl")
+
+MPI.Init()
+
+@test MPI.Get_processor_name() isa String
+
+MPI.Finalize()
+@test MPI.Finalized()

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -2,8 +2,6 @@ include("common.jl")
 
 MPI.Init()
 
-@test MPI.Get_processor_name() == gethostname()
-
 comm = MPI.COMM_WORLD
 size = MPI.Comm_size(comm)
 rank = MPI.Comm_rank(comm)


### PR DESCRIPTION
Following up from https://github.com/JuliaParallel/MPI.jl/pull/632#issuecomment-1250138261, @plessl found a system where `MPI.Get_processor_name()` doesn't indeed match `gethostname()`.  I guess we don't want tests to fail for this trivial issue, so I simplified the test to just check that the function returns a string, as suggested in https://github.com/JuliaParallel/MPI.jl/pull/630#discussion_r973322003.  Not super informative, but at least we still make sure the function runs and doesn't crash.

Also, following [mpi4py docs](https://mpi4py.readthedocs.io/en/stable/mpi4py.MPI.html#functions), I moved `MPI.Get_processor_name` to a new "Misc" section (also in source code, and tests).  I think that better classifies this function, and it was also my main doubt in https://github.com/JuliaParallel/MPI.jl/pull/630#issue-1376374138.  We may add more misc functions in the future.