### PR TITLE
no need for mutable struct with container fields

### DIFF
--- a/src/nonblocking.jl
+++ b/src/nonblocking.jl
@@ -201,7 +201,7 @@ allocations in [`Waitall`](@ref), [`Testall`](@ref), [`Waitany`](@ref), [`Testan
 [`Waitsome`](@ref) or [`Testsome`](@ref).
 
 """
-mutable struct RequestSet <: AbstractVector{Request}
+struct RequestSet <: AbstractVector{Request}
     requests::Vector{Request}
     vals::Vector{MPI_Request}
 end


### PR DESCRIPTION
There is no need for the `struct` to be mutable when the `struct` field are containers.