### PR TITLE
[WIP] Use `FunctionWrappers` for custom reduction operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.20-dev"
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MPICH_jll = "7cb0a576-ebde-5e09-9194-50597f1243b4"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
@@ -18,6 +19,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 DocStringExtensions = "0.8, 0.9"
+FunctionWrappers = "1.1.2"
 MPIPreferences = "0.1.3"
 Requires = "~0.5, 1.0"
 julia = "1.6"

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -3,6 +3,7 @@ module MPI
 using Libdl, Serialization
 using Requires
 using DocStringExtensions
+using FunctionWrappers: FunctionWrapper
 
 export mpiexec, UBuffer, VBuffer
 

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -95,7 +95,7 @@ function Op(f, T=Any; iscommutative=false)
         error("User-defined reduction operators are currently not supported on non-Intel architectures.\nSee https://github.com/JuliaParallel/MPI.jl/issues/404 for more details.")
     end
     w = OpWrapper{typeof(f),T}(f)
-    fptr = @cfunction($w, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{MPI_Datatype}))
+    fptr = FunctionWrapper{Cvoid,Tuple{Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{MPI_Datatype}}}(w).ptr
 
     op = Op(OP_NULL.val, fptr)
     # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)


### PR DESCRIPTION
My attempt at addressing #404.  This is using [`FunctionWrappers.jl`](https://github.com/yuyichao/FunctionWrappers.jl) instead of `@cfunction`, as suggested in a recent JuliaHPC call.

Note: it doesn't work for me even on x86_64 when using more than 1 rank.  Simple reproducer:
```julia
using MPI
MPI.Init()
let
    T = Int
    dims = 1
    op = (x,y) -> 2x+y-x
    send_arr = Array(zeros(T, Tuple(3 for i in 1:dims)))
    send_arr[:] .= 1:length(send_arr)
    recv_arr = Array{T}(undef, size(send_arr))
    MPI.Reduce!(send_arr, recv_arr, op, MPI.COMM_WORLD; root=0)
end
```
Run the script with
```
mpiexecjl -np 2 julia /path/to/script
```
The program should die with a segmentation fault (but the generated pointer should be non-null, as far as I can tell)