### PR TITLE
Import constants into `API` instead of creating non-const variables

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -79,10 +79,10 @@ include("error.jl")
 module API
     import ..libmpi, ..libmpi_handle, ..MPIPtr
     import ..use_stdcall, ..MPIError, ..@mpicall, ..@mpichk
-    using ..Consts
+    import ..Consts
 
     for name in filter(n -> startswith(string(n), "MPI_"), names(Consts; all = true))
-        @eval $name = Consts.$name  # signatures need types
+        @eval import ..Consts: $name  # signatures need types
     end
 
     include("auto_generated_api.jl")


### PR DESCRIPTION
On `master`:
```julia
julia> isconst(MPI.API, :MPI_File)
false
```
with this PR:
```julia
julia> isconst(MPI.API, :MPI_File)
true
```

CC: @t-bltg.