### PR TITLE
[CI] Cancel old jobs if there are new commits on same branch

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -15,6 +15,12 @@ on:
       - 'src/**'
       - 'lib/**'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ShellCheck.yml
+++ b/.github/workflows/ShellCheck.yml
@@ -12,6 +12,12 @@ on:
     paths:
       - 'bin/**'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -19,6 +19,12 @@ on:
       - 'test/**'
       - 'lib/**'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-default:
     timeout-minutes: 20


### PR DESCRIPTION
`MPI.jl` test suite is pretty big, and frequent pushes to PRs create a looong queue of jobs, which GitHub Actions kindly doesn't cancel by default.  This lets us clean up the queue automatically.  We're already doing it for invalidations: https://github.com/JuliaParallel/MPI.jl/blob/a9fbfc96208547d8c142ea44eb6a947fd6c79ef7/.github/workflows/Invalidations.yml#L6-L10