### PR TITLE
[docs] Minor fixes to configuration instructions

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -15,7 +15,7 @@ a single source of truth that can be used for JLL packages (Julia packages provi
 that link against MPI. It can be installed by
 
 ```sh
-julia -e 'using Pkg; Pkg.add("MPIPreferences")'
+julia --project -e 'using Pkg; Pkg.add("MPIPreferences")'
 ```
 
 ## Using a system-provided MPI backend
@@ -94,7 +94,7 @@ Preferences are merged across the Julia load path, such that it is feasible to p
    behavior of the Julia load path, e.g. `JULIA_LOAD_PATH=":/software/mpi/julia"`.
    If using environment modules, this can be achieved with
    ```
-   append-path  -d {} JULIA_LOAD_PATH :/software/mpi/julia
+   append-path -d {} JULIA_LOAD_PATH :/software/mpi/julia
    ```
    in the corresponding module file (preferably the module file for the MPI installation or for Julia).
 

--- a/docs/src/knownissues.md
+++ b/docs/src/knownissues.md
@@ -103,10 +103,9 @@ Make sure to:
     export JULIA_CUDA_USE_BINARYBUILDER=false
     ```
 - Add CUDA, MPIPreferences, and MPI packages in Julia. Switch to using the system binary
-    ```
-    julia -e 'using Pkg; pkg"add CUDA, MPIPreferences, MPI"'
-    julia -e 'using MPIPreferences; MPIPreferences.use_system_binary()'
-    ```
+  ```
+  julia --project -e 'using Pkg; Pkg.add(["CUDA", "MPIPreferences", "MPI"]); using MPIPreferences; MPIPreferences.use_system_binary()'
+  ```
 - Then in Julia, upon loading MPI and CUDA modules, you can check
   - CUDA version: `CUDA.versioninfo()`
   - If MPI has CUDA: `MPI.has_cuda()`
@@ -120,10 +119,10 @@ After that, it may be preferred to run the Julia MPI script (as suggested [here]
 
 Make sure to:
 - Have MPI and ROCm on path (or module loaded) that were used to build the ROCm-aware MPI
-- Add AMDGPU and MPI packages in Julia: 
-    ```
-    julia -e 'using Pkg; pkg"add AMDGPU"; pkg"add MPI"; using MPI; MPI.use_system_binary()'
-    ```
+- Add AMDGPU, MPIPreferences, and MPI packages in Julia:
+  ```
+  julia --project -e 'using Pkg; Pkg.add(["AMDGPU", "MPIPreferences", "MPI"]); using MPIPreferences; MPIPreferences.use_system_binary()'
+  ```
 - Then in Julia, upon loading MPI and CUDA modules, you can check
   - AMDGPU version: `AMDGPU.versioninfo()`
   - If you are using correct MPI implementation: `MPI.identify_implementation()`


### PR DESCRIPTION
* Consistently suggest to use the `--project` flag (it was already used in some places)
* Fix indentation of code blocks in lists, so that they are rendered correctly
* Do not use Pkg REPL API, which is not recommended for scripting usage
* Use `MPIPreferences.use_system_binary` instead of `MPI.use_system_binary` (which doesn't even exist)