### PR TITLE
[CI] Limit running invalidations to PRs which touch source code

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -2,6 +2,9 @@ name: Invalidations
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'lib/**'
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
This avoids running some useless jobs when editing, for example, only documentation.