### PR TITLE
[MPIPreferences] add functions to check (and error) if the MPI implementation has changed

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -22,18 +22,32 @@ jobs:
     - uses: julia-actions/setup-julia@v1
       with:
         version: '1'
+    # current branch
     - uses: actions/checkout@v3
+    - name: add MPIPreferences
+      shell: julia --color=yes --project=. {0}
+      run: |
+        using Pkg
+        Pkg.develop(path="lib/MPIPreferences")
+
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_pr
 
+    # default branch
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.repository.default_branch }}
+    - name: add MPIPreferences
+      shell: julia --color=yes --project=. {0}
+      run: |
+        using Pkg
+        Pkg.develop(path="lib/MPIPreferences")
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_default
-    
+
+    # report
     - name: Report invalidation counts
       run: |
         echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.1"
+version = "0.20.2"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -18,6 +18,6 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 DocStringExtensions = "0.8, 0.9"
-MPIPreferences = "0.1.3"
+MPIPreferences = "0.1.6"
 Requires = "~0.5, 1.0"
 julia = "1.6"

--- a/docs/src/reference/mpipreferences.md
+++ b/docs/src/reference/mpipreferences.md
@@ -20,6 +20,7 @@ MPIPreferences.use_jll_binary
 ## Utils
 
 ```@docs
+MPIPreferences.check_unchanged
 MPIPreferences.identify_abi
 ```
 

--- a/lib/MPIPreferences/Project.toml
+++ b/lib/MPIPreferences/Project.toml
@@ -1,7 +1,7 @@
 name = "MPIPreferences"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 authors = []
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/lib/MPIPreferences/src/MPIPreferences.jl
+++ b/lib/MPIPreferences/src/MPIPreferences.jl
@@ -197,10 +197,10 @@ end
 """
     MPIPreferences.check_unchanged()
 
-This will throw an error if the MPIPreferences have been modified in the current
-Julia session, or if they are modified after this function is called.
+Throws an error if the preferences have been modified in the current Julia
+session, or if they are modified after this function is called.
 
-This is typically called from the `__init__()` function of any package which
+This is should be called from the `__init__()` function of any package which
 relies on the values of MPIPreferences.
 """
 function check_unchanged()
@@ -208,6 +208,7 @@ function check_unchanged()
         error("MPIPreferences have changed, you will need to restart Julia for the changes to take effect")
     end
     DEPS_LOADED[] = true
+    return nothing
 end
 
 function identify_implementation_version_abi(version_string::AbstractString)

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -3,6 +3,7 @@ module MPI
 using Libdl, Serialization
 using Requires
 using DocStringExtensions
+import MPIPreferences
 
 export mpiexec, UBuffer, VBuffer
 
@@ -58,7 +59,6 @@ function run_load_time_hooks()
     nothing
 end
 
-using MPIPreferences
 include("implementations.jl")
 include("error.jl")
 include("info.jl")
@@ -81,12 +81,13 @@ include("misc.jl")
 include("deprecated.jl")
 
 function __init__()
+    MPIPreferences.check_unchanged()
 
     # an empty string was used to indicate "default"
     # https://github.com/JuliaParallel/MPI.jl/blob/v0.19.2/deps/build.jl#L142
     mpi_env_binary = get(ENV, "JULIA_MPI_BINARY", "")
     if mpi_env_binary != "" && mpi_env_binary != MPIPreferences.binary
-        @info """
+        @warn """
         The JULIA_MPI_BINARY environment variable is no longer used to configure the MPI binary.
         Please use the MPIPreferences.jl package instead:
 


### PR DESCRIPTION
Currently call `@warn` if the MPI implementation has changed: in general I don't like using `@warn` unless something is bad.

Instead it will now use `@info` to print the information, but throws an error if MPI is already loaded, or is loaded subsequently.

It also modifies the message from #641 to be a warning (since that presumably _is_ bad).