### PR TITLE
cache the created Datatypes

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -133,7 +133,7 @@ _defined_datatype_methods = nothing
 # called for the same type, e.g. when the Buffer object is implicitly
 # constructed in MPI.Get. Without the cache, each Get would commit the
 # same datatype over and over again.
-const created_datatypes = Dict{Type, Datatype}()
+const created_datatypes = IdDict{Type, Datatype}()
 
 function Datatype(::Type{T}) where {T}
     global created_datatypes

--- a/test/test_datatype.jl
+++ b/test/test_datatype.jl
@@ -31,6 +31,7 @@ struct Boundary
     b::UInt8
 end
 @testset "Compound type" begin
+    @test MPI.Datatype(Boundary) === MPI.Datatype(Boundary)
     sz = sizeof(Boundary)
     al = Base.datatype_alignment(Boundary)
     @test MPI.Types.extent(MPI.Datatype(Boundary)) == (0, cld(sz,al)*al)
@@ -59,6 +60,8 @@ struct Boundary2
     c::Nothing
 end
 @testset "nested types" begin
+    @test MPI.Datatype(Boundary2) === MPI.Datatype(Boundary2)
+
     sz = sizeof(Boundary2)
     al = Base.datatype_alignment(Boundary2)
     @test MPI.Types.extent(MPI.Datatype(Boundary2)) == (0, cld(sz,al)*al)


### PR DESCRIPTION
I did run into out of memory problems, first when I used MPI.Get (which I fixed by reusing always the same Buffer) and later also in Alltoall calls. This happens when derived datatypes are used in those calls, and the MPI.Datatype constructor is called implicitly, like in this example:

```
using MPI

struct Derived
    val::Int64
end    

MPI.Init()

comm = MPI.COMM_WORLD
size = MPI.Comm_size(comm)
rank = MPI.Comm_rank(comm)

send_counts = Vector{Cint}(1:size)
recv_counts = fill(Cint(rank+1), size)

send_vals = collect(Iterators.flatten([1:i for i = 1:size])) 
send_vals = map(Derived, send_vals)

A = Array{Derived}(send_vals)
C = Array{Derived}(undef, sum(recv_counts))

while true
    MPI.Alltoallv!(VBuffer(A,send_counts), VBuffer(C,recv_counts), comm)
end

MPI.Finalize()
```

This PR fixes this problem, by caching the created Datatypes, to avoid that in each repeated Alltoallv! call the Datatype is constructed (incl. a API.MPI_Type_create_struct call) and commited again.