### PR TITLE
check for length 0 in Win_shared_query

### DIFF
--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -130,8 +130,8 @@ end
 function Win_shared_query(::Type{Array{T}}, win::Win, owner_rank::Integer) where T
     len, sizeT, ptr = Win_shared_query(Ptr{T}, win, owner_rank)
     sizeT == sizeof(T) || error("type sizes don't match")
-    # the ptr can be invalid for empty arrays but unsafe_wrap always
-    # check the alignment of ptr, even for lenght 0
+    # the ptr may be invalid for empty arrays, which will cause an error as unsafe_wrap
+    # checks the alignment of ptr, even for length 0
     if len > 0
         return unsafe_wrap(Array, ptr, div(len, sizeT))
     else

--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -130,7 +130,13 @@ end
 function Win_shared_query(::Type{Array{T}}, win::Win, owner_rank::Integer) where T
     len, sizeT, ptr = Win_shared_query(Ptr{T}, win, owner_rank)
     sizeT == sizeof(T) || error("type sizes don't match")
-    return unsafe_wrap(Array, ptr, div(len, sizeT))
+    # the ptr can be invalid for empty arrays but unsafe_wrap always
+    # check the alignment of ptr, even for lenght 0
+    if len > 0
+        return unsafe_wrap(Array, ptr, div(len, sizeT))
+    else
+        return Array{T}(undef, 0)
+    end
 end
 Win_shared_query(::Type{Array{T}}, dims, win::Win, owner_rank::Integer) where T =
     reshape(Win_shared_query(Array{T}, win, owner_rank), dims)


### PR DESCRIPTION
The Intel MPI (2018.6.288) implementation returns in Win_shared_query invalid pointers in the case that the array on the owner_rank has length 0. In this case Win_shared_query should create an empty Array of type $T, but unsafe_wrap checks that the alignment of the return pointer is correct, which is now not always the case as the pointer is just uninitialized memory.  

So this pull request checks the returned length, and calls unsafe_wrap only when the length is greater then zero.