### PR TITLE
[MPIPreferences] Make package usable if libmpi can't be loaded

### DIFF
--- a/lib/MPIPreferences/Project.toml
+++ b/lib/MPIPreferences/Project.toml
@@ -1,7 +1,7 @@
 name = "MPIPreferences"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 authors = []
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/lib/MPIPreferences/src/system.jl
+++ b/lib/MPIPreferences/src/system.jl
@@ -8,6 +8,14 @@ module System
 
     libmpi_handle = C_NULL
     function __init__()
-        global libmpi_handle = Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+        global libmpi_handle = try
+            Libdl.dlopen(libmpi, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+        catch error
+            @error """
+                   $(libmpi) could not be loaded, see error message below.
+                   Use `MPIPreferences.use_system_binary` or `MPIPreferences.use_jll_binary` to reconfigure the package and then restart Julia.
+                   """ error
+            C_NULL
+        end
     end
 end


### PR DESCRIPTION
An error thrown during `__init__` makes the package unusable, leaving users
without the possibility to easily reset the preferences.  With this change it is
possible to change the preferences if something goes wrong while loading the
package.

This situation can happen when switching between different MPI implementations in an existing environment, if loading the modules for the new MPI library makes the previous one unloadable.