### PR TITLE
Use `@ccall` for autogenerated API

### DIFF
--- a/gen/src/generator.toml
+++ b/gen/src/generator.toml
@@ -3,3 +3,6 @@ library_name = "libmpi"
 output_common_file_path = "./out/common.jl"
 output_api_file_path = "./out/api.jl"
 output_ignorelist = ["^[PQ]MPI[XR]?_", "^MPI[XR]_", "^MPI_T_", "^MPI_Session_", "^MPI_Status_[\\w_]*f08", "^MPI_Group_from_session_pset"]
+
+[codegen]
+use_ccall_macro = true

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -81,14 +81,25 @@ end
 
 const use_stdcall = startswith(basename(libmpi), "msmpi")
 
-macro mpicall(expr)
-    @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall
+macro mpicall(expr::Expr)
+    is_ccall = expr.head == :call && expr.args[1] == :ccall
+    is_at_ccall = expr.head == :macrocall && expr.args[1] == Symbol("@ccall")
+    if !is_ccall && !is_at_ccall
+        error("@mpicall can only be applied to `ccall`/`@ccall` expressions!")
+    end
 
     # On unix systems we call the global symbols to allow for LD_PRELOAD interception
     # It can be emulated in Windows (via Libdl.dllist), but this is not fast.
-    if Sys.isunix() && expr.args[2].head == :tuple &&
-            (VERSION ≥ v"1.5-" || expr.args[2].args[1] ≠ :(:MPI_Get_library_version))
-        expr.args[2] = expr.args[2].args[1]
+    @static if Sys.isunix()
+        if is_ccall
+            if expr.args[2].head == :tuple
+                expr.args[2] = expr.args[2].args[1]
+            end
+        elseif is_at_ccall
+            if expr.args[3].args[1].head == :call && expr.args[3].args[1].args[1].head == :.
+                expr.args[3].args[1].args[1] = expr.args[3].args[1].args[1].args[2].value
+            end
+        end
     end
 
     # Microsoft MPI uses stdcall calling convention

--- a/src/api/generated_api.jl
+++ b/src/api/generated_api.jl
@@ -1,4 +1,4 @@
-# WARNING: this signature file for MPICH_jll has been auto-generated, please edit MPI.jl/gen/src/MPIgenerator.jl instead !
+# WARNING: this signature file for MPICH_jll has been auto-generated, please edit ../../gen/src/MPIgenerator.jl instead!
 
 """
     MPI_Wait(request, status)
@@ -6,7 +6,7 @@
 $(_doc_external(:MPI_Wait))
 """
 function MPI_Wait(request, status)
-    @mpichk ccall((:MPI_Wait, libmpi), Cint, (Ptr{MPI_Request}, Ptr{MPI_Status}), request, status)
+    @mpichk @ccall libmpi.MPI_Wait(request::Ptr{MPI_Request}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -15,7 +15,7 @@ end
 $(_doc_external(:MPI_Test))
 """
 function MPI_Test(request, flag, status)
-    @mpichk ccall((:MPI_Test, libmpi), Cint, (Ptr{MPI_Request}, Ptr{Cint}, Ptr{MPI_Status}), request, flag, status)
+    @mpichk @ccall libmpi.MPI_Test(request::Ptr{MPI_Request}, flag::Ptr{Cint}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -24,7 +24,7 @@ end
 $(_doc_external(:MPI_Status_c2f))
 """
 function MPI_Status_c2f(c_status, f_status)
-    @mpichk ccall((:MPI_Status_c2f, libmpi), Cint, (Ptr{MPI_Status}, Ptr{MPI_Fint}), c_status, f_status)
+    @mpichk @ccall libmpi.MPI_Status_c2f(c_status::Ptr{MPI_Status}, f_status::Ptr{MPI_Fint})::Cint
 end
 
 """
@@ -33,7 +33,7 @@ end
 $(_doc_external(:MPI_Status_f2c))
 """
 function MPI_Status_f2c(f_status, c_status)
-    @mpichk ccall((:MPI_Status_f2c, libmpi), Cint, (Ptr{MPI_Fint}, Ptr{MPI_Status}), f_status, c_status)
+    @mpichk @ccall libmpi.MPI_Status_f2c(f_status::Ptr{MPI_Fint}, c_status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -42,7 +42,7 @@ end
 $(_doc_external(:MPI_Type_create_f90_integer))
 """
 function MPI_Type_create_f90_integer(r, newtype)
-    @mpichk ccall((:MPI_Type_create_f90_integer, libmpi), Cint, (Cint, Ptr{MPI_Datatype}), r, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_f90_integer(r::Cint, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -51,7 +51,7 @@ end
 $(_doc_external(:MPI_Type_create_f90_real))
 """
 function MPI_Type_create_f90_real(p, r, newtype)
-    @mpichk ccall((:MPI_Type_create_f90_real, libmpi), Cint, (Cint, Cint, Ptr{MPI_Datatype}), p, r, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_f90_real(p::Cint, r::Cint, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -60,7 +60,7 @@ end
 $(_doc_external(:MPI_Type_create_f90_complex))
 """
 function MPI_Type_create_f90_complex(p, r, newtype)
-    @mpichk ccall((:MPI_Type_create_f90_complex, libmpi), Cint, (Cint, Cint, Ptr{MPI_Datatype}), p, r, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_f90_complex(p::Cint, r::Cint, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -69,7 +69,7 @@ end
 $(_doc_external(:MPI_Attr_delete))
 """
 function MPI_Attr_delete(comm, keyval)
-    @mpichk ccall((:MPI_Attr_delete, libmpi), Cint, (MPI_Comm, Cint), comm, keyval)
+    @mpichk @ccall libmpi.MPI_Attr_delete(comm::MPI_Comm, keyval::Cint)::Cint
 end
 
 """
@@ -78,7 +78,7 @@ end
 $(_doc_external(:MPI_Attr_get))
 """
 function MPI_Attr_get(comm, keyval, attribute_val, flag)
-    @mpichk ccall((:MPI_Attr_get, libmpi), Cint, (MPI_Comm, Cint, MPIPtr, Ptr{Cint}), comm, keyval, attribute_val, flag)
+    @mpichk @ccall libmpi.MPI_Attr_get(comm::MPI_Comm, keyval::Cint, attribute_val::MPIPtr, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -87,7 +87,7 @@ end
 $(_doc_external(:MPI_Attr_put))
 """
 function MPI_Attr_put(comm, keyval, attribute_val)
-    @mpichk ccall((:MPI_Attr_put, libmpi), Cint, (MPI_Comm, Cint, MPIPtr), comm, keyval, attribute_val)
+    @mpichk @ccall libmpi.MPI_Attr_put(comm::MPI_Comm, keyval::Cint, attribute_val::MPIPtr)::Cint
 end
 
 """
@@ -96,7 +96,7 @@ end
 $(_doc_external(:MPI_Comm_create_keyval))
 """
 function MPI_Comm_create_keyval(comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state)
-    @mpichk ccall((:MPI_Comm_create_keyval, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPIPtr), comm_copy_attr_fn, comm_delete_attr_fn, comm_keyval, extra_state)
+    @mpichk @ccall libmpi.MPI_Comm_create_keyval(comm_copy_attr_fn::MPIPtr, comm_delete_attr_fn::MPIPtr, comm_keyval::Ptr{Cint}, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -105,7 +105,7 @@ end
 $(_doc_external(:MPI_Comm_delete_attr))
 """
 function MPI_Comm_delete_attr(comm, comm_keyval)
-    @mpichk ccall((:MPI_Comm_delete_attr, libmpi), Cint, (MPI_Comm, Cint), comm, comm_keyval)
+    @mpichk @ccall libmpi.MPI_Comm_delete_attr(comm::MPI_Comm, comm_keyval::Cint)::Cint
 end
 
 """
@@ -114,7 +114,7 @@ end
 $(_doc_external(:MPI_Comm_free_keyval))
 """
 function MPI_Comm_free_keyval(comm_keyval)
-    @mpichk ccall((:MPI_Comm_free_keyval, libmpi), Cint, (Ptr{Cint},), comm_keyval)
+    @mpichk @ccall libmpi.MPI_Comm_free_keyval(comm_keyval::Ptr{Cint})::Cint
 end
 
 """
@@ -123,7 +123,7 @@ end
 $(_doc_external(:MPI_Comm_get_attr))
 """
 function MPI_Comm_get_attr(comm, comm_keyval, attribute_val, flag)
-    @mpichk ccall((:MPI_Comm_get_attr, libmpi), Cint, (MPI_Comm, Cint, MPIPtr, Ptr{Cint}), comm, comm_keyval, attribute_val, flag)
+    @mpichk @ccall libmpi.MPI_Comm_get_attr(comm::MPI_Comm, comm_keyval::Cint, attribute_val::MPIPtr, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -132,7 +132,7 @@ end
 $(_doc_external(:MPI_Comm_set_attr))
 """
 function MPI_Comm_set_attr(comm, comm_keyval, attribute_val)
-    @mpichk ccall((:MPI_Comm_set_attr, libmpi), Cint, (MPI_Comm, Cint, MPIPtr), comm, comm_keyval, attribute_val)
+    @mpichk @ccall libmpi.MPI_Comm_set_attr(comm::MPI_Comm, comm_keyval::Cint, attribute_val::MPIPtr)::Cint
 end
 
 """
@@ -141,7 +141,7 @@ end
 $(_doc_external(:MPI_Keyval_create))
 """
 function MPI_Keyval_create(copy_fn, delete_fn, keyval, extra_state)
-    @mpichk ccall((:MPI_Keyval_create, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPIPtr), copy_fn, delete_fn, keyval, extra_state)
+    @mpichk @ccall libmpi.MPI_Keyval_create(copy_fn::MPIPtr, delete_fn::MPIPtr, keyval::Ptr{Cint}, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -150,7 +150,7 @@ end
 $(_doc_external(:MPI_Keyval_free))
 """
 function MPI_Keyval_free(keyval)
-    @mpichk ccall((:MPI_Keyval_free, libmpi), Cint, (Ptr{Cint},), keyval)
+    @mpichk @ccall libmpi.MPI_Keyval_free(keyval::Ptr{Cint})::Cint
 end
 
 """
@@ -159,7 +159,7 @@ end
 $(_doc_external(:MPI_Type_create_keyval))
 """
 function MPI_Type_create_keyval(type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state)
-    @mpichk ccall((:MPI_Type_create_keyval, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPIPtr), type_copy_attr_fn, type_delete_attr_fn, type_keyval, extra_state)
+    @mpichk @ccall libmpi.MPI_Type_create_keyval(type_copy_attr_fn::MPIPtr, type_delete_attr_fn::MPIPtr, type_keyval::Ptr{Cint}, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -168,7 +168,7 @@ end
 $(_doc_external(:MPI_Type_delete_attr))
 """
 function MPI_Type_delete_attr(datatype, type_keyval)
-    @mpichk ccall((:MPI_Type_delete_attr, libmpi), Cint, (MPI_Datatype, Cint), datatype, type_keyval)
+    @mpichk @ccall libmpi.MPI_Type_delete_attr(datatype::MPI_Datatype, type_keyval::Cint)::Cint
 end
 
 """
@@ -177,7 +177,7 @@ end
 $(_doc_external(:MPI_Type_free_keyval))
 """
 function MPI_Type_free_keyval(type_keyval)
-    @mpichk ccall((:MPI_Type_free_keyval, libmpi), Cint, (Ptr{Cint},), type_keyval)
+    @mpichk @ccall libmpi.MPI_Type_free_keyval(type_keyval::Ptr{Cint})::Cint
 end
 
 """
@@ -186,7 +186,7 @@ end
 $(_doc_external(:MPI_Type_get_attr))
 """
 function MPI_Type_get_attr(datatype, type_keyval, attribute_val, flag)
-    @mpichk ccall((:MPI_Type_get_attr, libmpi), Cint, (MPI_Datatype, Cint, MPIPtr, Ptr{Cint}), datatype, type_keyval, attribute_val, flag)
+    @mpichk @ccall libmpi.MPI_Type_get_attr(datatype::MPI_Datatype, type_keyval::Cint, attribute_val::MPIPtr, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -195,7 +195,7 @@ end
 $(_doc_external(:MPI_Type_set_attr))
 """
 function MPI_Type_set_attr(datatype, type_keyval, attribute_val)
-    @mpichk ccall((:MPI_Type_set_attr, libmpi), Cint, (MPI_Datatype, Cint, MPIPtr), datatype, type_keyval, attribute_val)
+    @mpichk @ccall libmpi.MPI_Type_set_attr(datatype::MPI_Datatype, type_keyval::Cint, attribute_val::MPIPtr)::Cint
 end
 
 """
@@ -204,7 +204,7 @@ end
 $(_doc_external(:MPI_Win_create_keyval))
 """
 function MPI_Win_create_keyval(win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state)
-    @mpichk ccall((:MPI_Win_create_keyval, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPIPtr), win_copy_attr_fn, win_delete_attr_fn, win_keyval, extra_state)
+    @mpichk @ccall libmpi.MPI_Win_create_keyval(win_copy_attr_fn::MPIPtr, win_delete_attr_fn::MPIPtr, win_keyval::Ptr{Cint}, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -213,7 +213,7 @@ end
 $(_doc_external(:MPI_Win_delete_attr))
 """
 function MPI_Win_delete_attr(win, win_keyval)
-    @mpichk ccall((:MPI_Win_delete_attr, libmpi), Cint, (MPI_Win, Cint), win, win_keyval)
+    @mpichk @ccall libmpi.MPI_Win_delete_attr(win::MPI_Win, win_keyval::Cint)::Cint
 end
 
 """
@@ -222,7 +222,7 @@ end
 $(_doc_external(:MPI_Win_free_keyval))
 """
 function MPI_Win_free_keyval(win_keyval)
-    @mpichk ccall((:MPI_Win_free_keyval, libmpi), Cint, (Ptr{Cint},), win_keyval)
+    @mpichk @ccall libmpi.MPI_Win_free_keyval(win_keyval::Ptr{Cint})::Cint
 end
 
 """
@@ -231,7 +231,7 @@ end
 $(_doc_external(:MPI_Win_get_attr))
 """
 function MPI_Win_get_attr(win, win_keyval, attribute_val, flag)
-    @mpichk ccall((:MPI_Win_get_attr, libmpi), Cint, (MPI_Win, Cint, MPIPtr, Ptr{Cint}), win, win_keyval, attribute_val, flag)
+    @mpichk @ccall libmpi.MPI_Win_get_attr(win::MPI_Win, win_keyval::Cint, attribute_val::MPIPtr, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -240,7 +240,7 @@ end
 $(_doc_external(:MPI_Win_set_attr))
 """
 function MPI_Win_set_attr(win, win_keyval, attribute_val)
-    @mpichk ccall((:MPI_Win_set_attr, libmpi), Cint, (MPI_Win, Cint, MPIPtr), win, win_keyval, attribute_val)
+    @mpichk @ccall libmpi.MPI_Win_set_attr(win::MPI_Win, win_keyval::Cint, attribute_val::MPIPtr)::Cint
 end
 
 """
@@ -249,7 +249,7 @@ end
 $(_doc_external(:MPI_Allgather))
 """
 function MPI_Allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Allgather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Allgather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -258,7 +258,7 @@ end
 $(_doc_external(:MPI_Allgather_init))
 """
 function MPI_Allgather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Allgather_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allgather_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -267,7 +267,7 @@ end
 $(_doc_external(:MPI_Allgatherv))
 """
 function MPI_Allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
-    @mpichk ccall((:MPI_Allgatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Allgatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -276,7 +276,7 @@ end
 $(_doc_external(:MPI_Allgatherv_init))
 """
 function MPI_Allgatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Allgatherv_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allgatherv_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -285,7 +285,7 @@ end
 $(_doc_external(:MPI_Allreduce))
 """
 function MPI_Allreduce(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Allreduce, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Allreduce(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -294,7 +294,7 @@ end
 $(_doc_external(:MPI_Allreduce_init))
 """
 function MPI_Allreduce_init(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Allreduce_init, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allreduce_init(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -303,7 +303,7 @@ end
 $(_doc_external(:MPI_Alltoall))
 """
 function MPI_Alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Alltoall, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Alltoall(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -312,7 +312,7 @@ end
 $(_doc_external(:MPI_Alltoall_init))
 """
 function MPI_Alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Alltoall_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoall_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -321,7 +321,7 @@ end
 $(_doc_external(:MPI_Alltoallv))
 """
 function MPI_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
-    @mpichk ccall((:MPI_Alltoallv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Alltoallv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -330,7 +330,7 @@ end
 $(_doc_external(:MPI_Alltoallv_init))
 """
 function MPI_Alltoallv_init(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Alltoallv_init, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoallv_init(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -339,7 +339,7 @@ end
 $(_doc_external(:MPI_Alltoallw))
 """
 function MPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
-    @mpichk ccall((:MPI_Alltoallw, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPI_Comm), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
+    @mpichk @ccall libmpi.MPI_Alltoallw(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -348,7 +348,7 @@ end
 $(_doc_external(:MPI_Alltoallw_init))
 """
 function MPI_Alltoallw_init(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
-    @mpichk ccall((:MPI_Alltoallw_init, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoallw_init(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -357,7 +357,7 @@ end
 $(_doc_external(:MPI_Barrier))
 """
 function MPI_Barrier(comm)
-    @mpichk ccall((:MPI_Barrier, libmpi), Cint, (MPI_Comm,), comm)
+    @mpichk @ccall libmpi.MPI_Barrier(comm::MPI_Comm)::Cint
 end
 
 """
@@ -366,7 +366,7 @@ end
 $(_doc_external(:MPI_Barrier_init))
 """
 function MPI_Barrier_init(comm, info, request)
-    @mpichk ccall((:MPI_Barrier_init, libmpi), Cint, (MPI_Comm, MPI_Info, Ptr{MPI_Request}), comm, info, request)
+    @mpichk @ccall libmpi.MPI_Barrier_init(comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -375,7 +375,7 @@ end
 $(_doc_external(:MPI_Bcast))
 """
 function MPI_Bcast(buffer, count, datatype, root, comm)
-    @mpichk ccall((:MPI_Bcast, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm), buffer, count, datatype, root, comm)
+    @mpichk @ccall libmpi.MPI_Bcast(buffer::MPIPtr, count::Cint, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -384,7 +384,7 @@ end
 $(_doc_external(:MPI_Bcast_init))
 """
 function MPI_Bcast_init(buffer, count, datatype, root, comm, info, request)
-    @mpichk ccall((:MPI_Bcast_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), buffer, count, datatype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Bcast_init(buffer::MPIPtr, count::Cint, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -393,7 +393,7 @@ end
 $(_doc_external(:MPI_Exscan))
 """
 function MPI_Exscan(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Exscan, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Exscan(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -402,7 +402,7 @@ end
 $(_doc_external(:MPI_Exscan_init))
 """
 function MPI_Exscan_init(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Exscan_init, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Exscan_init(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -411,7 +411,7 @@ end
 $(_doc_external(:MPI_Gather))
 """
 function MPI_Gather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Gather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Gather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -420,7 +420,7 @@ end
 $(_doc_external(:MPI_Gather_init))
 """
 function MPI_Gather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Gather_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Gather_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -429,7 +429,7 @@ end
 $(_doc_external(:MPI_Gatherv))
 """
 function MPI_Gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm)
-    @mpichk ccall((:MPI_Gatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Gatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -438,7 +438,7 @@ end
 $(_doc_external(:MPI_Gatherv_init))
 """
 function MPI_Gatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Gatherv_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Gatherv_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -447,7 +447,7 @@ end
 $(_doc_external(:MPI_Iallgather))
 """
 function MPI_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Iallgather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallgather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -456,7 +456,7 @@ end
 $(_doc_external(:MPI_Iallgatherv))
 """
 function MPI_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
-    @mpichk ccall((:MPI_Iallgatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallgatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -465,7 +465,7 @@ end
 $(_doc_external(:MPI_Iallreduce))
 """
 function MPI_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iallreduce, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallreduce(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -474,7 +474,7 @@ end
 $(_doc_external(:MPI_Ialltoall))
 """
 function MPI_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ialltoall, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoall(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -483,7 +483,7 @@ end
 $(_doc_external(:MPI_Ialltoallv))
 """
 function MPI_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ialltoallv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoallv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -492,7 +492,7 @@ end
 $(_doc_external(:MPI_Ialltoallw))
 """
 function MPI_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
-    @mpichk ccall((:MPI_Ialltoallw, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Datatype}, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoallw(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -501,7 +501,7 @@ end
 $(_doc_external(:MPI_Ibarrier))
 """
 function MPI_Ibarrier(comm, request)
-    @mpichk ccall((:MPI_Ibarrier, libmpi), Cint, (MPI_Comm, Ptr{MPI_Request}), comm, request)
+    @mpichk @ccall libmpi.MPI_Ibarrier(comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -510,7 +510,7 @@ end
 $(_doc_external(:MPI_Ibcast))
 """
 function MPI_Ibcast(buffer, count, datatype, root, comm, request)
-    @mpichk ccall((:MPI_Ibcast, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), buffer, count, datatype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Ibcast(buffer::MPIPtr, count::Cint, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -519,7 +519,7 @@ end
 $(_doc_external(:MPI_Iexscan))
 """
 function MPI_Iexscan(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iexscan, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iexscan(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -528,7 +528,7 @@ end
 $(_doc_external(:MPI_Igather))
 """
 function MPI_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Igather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Igather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -537,7 +537,7 @@ end
 $(_doc_external(:MPI_Igatherv))
 """
 function MPI_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Igatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Igatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -546,7 +546,7 @@ end
 $(_doc_external(:MPI_Ineighbor_allgather))
 """
 function MPI_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_allgather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_allgather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -555,7 +555,7 @@ end
 $(_doc_external(:MPI_Ineighbor_allgatherv))
 """
 function MPI_Ineighbor_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_allgatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_allgatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -564,7 +564,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoall))
 """
 function MPI_Ineighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoall, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoall(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -573,7 +573,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoallv))
 """
 function MPI_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoallv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoallv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -582,7 +582,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoallw))
 """
 function MPI_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoallw, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoallw(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -591,7 +591,7 @@ end
 $(_doc_external(:MPI_Ireduce))
 """
 function MPI_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm, request)
-    @mpichk ccall((:MPI_Ireduce, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -600,7 +600,7 @@ end
 $(_doc_external(:MPI_Ireduce_scatter))
 """
 function MPI_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Ireduce_scatter, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, recvcounts, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce_scatter(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -609,7 +609,7 @@ end
 $(_doc_external(:MPI_Ireduce_scatter_block))
 """
 function MPI_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Ireduce_scatter_block, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, recvcount, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce_scatter_block(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -618,7 +618,7 @@ end
 $(_doc_external(:MPI_Iscan))
 """
 function MPI_Iscan(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iscan, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscan(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -627,7 +627,7 @@ end
 $(_doc_external(:MPI_Iscatter))
 """
 function MPI_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Iscatter, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscatter(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -636,7 +636,7 @@ end
 $(_doc_external(:MPI_Iscatterv))
 """
 function MPI_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Iscatterv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscatterv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, displs::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -645,7 +645,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgather))
 """
 function MPI_Neighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_allgather, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm) v"3.0.0"
+    @mpichk @ccall libmpi.MPI_Neighbor_allgather(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -654,7 +654,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgather_init))
 """
 function MPI_Neighbor_allgather_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_allgather_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgather_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -663,7 +663,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgatherv))
 """
 function MPI_Neighbor_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_allgatherv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm) v"3.0.0"
+    @mpichk @ccall libmpi.MPI_Neighbor_allgatherv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -672,7 +672,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgatherv_init))
 """
 function MPI_Neighbor_allgatherv_init(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_allgatherv_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgatherv_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, displs::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -681,7 +681,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoall))
 """
 function MPI_Neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoall, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm) v"3.0.0"
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoall(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -690,7 +690,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoall_init))
 """
 function MPI_Neighbor_alltoall_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoall_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoall_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -699,7 +699,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallv))
 """
 function MPI_Neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoallv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm) v"3.0.0"
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -708,7 +708,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallv_init))
 """
 function MPI_Neighbor_alltoallv_init(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoallv_init, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallv_init(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{Cint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -717,7 +717,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallw))
 """
 function MPI_Neighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoallw, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallw(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -726,7 +726,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallw_init))
 """
 function MPI_Neighbor_alltoallw_init(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoallw_init, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallw_init(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -735,7 +735,7 @@ end
 $(_doc_external(:MPI_Reduce))
 """
 function MPI_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm)
-    @mpichk ccall((:MPI_Reduce, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, Cint, MPI_Comm), sendbuf, recvbuf, count, datatype, op, root, comm)
+    @mpichk @ccall libmpi.MPI_Reduce(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -744,7 +744,7 @@ end
 $(_doc_external(:MPI_Reduce_init))
 """
 function MPI_Reduce_init(sendbuf, recvbuf, count, datatype, op, root, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_init, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_init(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -753,7 +753,7 @@ end
 $(_doc_external(:MPI_Reduce_local))
 """
 function MPI_Reduce_local(inbuf, inoutbuf, count, datatype, op)
-    @mpichk ccall((:MPI_Reduce_local, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op), inbuf, inoutbuf, count, datatype, op)
+    @mpichk @ccall libmpi.MPI_Reduce_local(inbuf::MPIPtr, inoutbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op)::Cint
 end
 
 """
@@ -762,7 +762,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter))
 """
 function MPI_Reduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm)
-    @mpichk ccall((:MPI_Reduce_scatter, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, recvcounts, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -771,7 +771,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_block))
 """
 function MPI_Reduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm)
-    @mpichk ccall((:MPI_Reduce_scatter_block, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, recvcount, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_block(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -780,7 +780,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_block_init))
 """
 function MPI_Reduce_scatter_block_init(sendbuf, recvbuf, recvcount, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_scatter_block_init, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, recvcount, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_block_init(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -789,7 +789,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_init))
 """
 function MPI_Reduce_scatter_init(sendbuf, recvbuf, recvcounts, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_scatter_init, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{Cint}, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, recvcounts, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_init(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{Cint}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -798,7 +798,7 @@ end
 $(_doc_external(:MPI_Scan))
 """
 function MPI_Scan(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Scan, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Scan(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -807,7 +807,7 @@ end
 $(_doc_external(:MPI_Scan_init))
 """
 function MPI_Scan_init(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Scan_init, libmpi), Cint, (MPIPtr, MPIPtr, Cint, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scan_init(sendbuf::MPIPtr, recvbuf::MPIPtr, count::Cint, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -816,7 +816,7 @@ end
 $(_doc_external(:MPI_Scatter))
 """
 function MPI_Scatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Scatter, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Scatter(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -825,7 +825,7 @@ end
 $(_doc_external(:MPI_Scatter_init))
 """
 function MPI_Scatter_init(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Scatter_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scatter_init(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -834,7 +834,7 @@ end
 $(_doc_external(:MPI_Scatterv))
 """
 function MPI_Scatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Scatterv, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Scatterv(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, displs::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -843,7 +843,7 @@ end
 $(_doc_external(:MPI_Scatterv_init))
 """
 function MPI_Scatterv_init(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Scatterv_init, libmpi), Cint, (MPIPtr, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scatterv_init(sendbuf::MPIPtr, sendcounts::Ptr{Cint}, displs::Ptr{Cint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -852,7 +852,7 @@ end
 $(_doc_external(:MPI_Comm_compare))
 """
 function MPI_Comm_compare(comm1, comm2, result)
-    @mpichk ccall((:MPI_Comm_compare, libmpi), Cint, (MPI_Comm, MPI_Comm, Ptr{Cint}), comm1, comm2, result)
+    @mpichk @ccall libmpi.MPI_Comm_compare(comm1::MPI_Comm, comm2::MPI_Comm, result::Ptr{Cint})::Cint
 end
 
 """
@@ -861,7 +861,7 @@ end
 $(_doc_external(:MPI_Comm_create))
 """
 function MPI_Comm_create(comm, group, newcomm)
-    @mpichk ccall((:MPI_Comm_create, libmpi), Cint, (MPI_Comm, MPI_Group, Ptr{MPI_Comm}), comm, group, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_create(comm::MPI_Comm, group::MPI_Group, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -870,7 +870,7 @@ end
 $(_doc_external(:MPI_Comm_create_group))
 """
 function MPI_Comm_create_group(comm, group, tag, newcomm)
-    @mpichk ccall((:MPI_Comm_create_group, libmpi), Cint, (MPI_Comm, MPI_Group, Cint, Ptr{MPI_Comm}), comm, group, tag, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_create_group(comm::MPI_Comm, group::MPI_Group, tag::Cint, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -879,7 +879,7 @@ end
 $(_doc_external(:MPI_Comm_dup))
 """
 function MPI_Comm_dup(comm, newcomm)
-    @mpichk ccall((:MPI_Comm_dup, libmpi), Cint, (MPI_Comm, Ptr{MPI_Comm}), comm, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_dup(comm::MPI_Comm, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -888,7 +888,7 @@ end
 $(_doc_external(:MPI_Comm_dup_with_info))
 """
 function MPI_Comm_dup_with_info(comm, info, newcomm)
-    @mpichk ccall((:MPI_Comm_dup_with_info, libmpi), Cint, (MPI_Comm, MPI_Info, Ptr{MPI_Comm}), comm, info, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_dup_with_info(comm::MPI_Comm, info::MPI_Info, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -897,7 +897,7 @@ end
 $(_doc_external(:MPI_Comm_free))
 """
 function MPI_Comm_free(comm)
-    @mpichk ccall((:MPI_Comm_free, libmpi), Cint, (Ptr{MPI_Comm},), comm)
+    @mpichk @ccall libmpi.MPI_Comm_free(comm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -906,7 +906,7 @@ end
 $(_doc_external(:MPI_Comm_get_info))
 """
 function MPI_Comm_get_info(comm, info_used)
-    @mpichk ccall((:MPI_Comm_get_info, libmpi), Cint, (MPI_Comm, Ptr{MPI_Info}), comm, info_used)
+    @mpichk @ccall libmpi.MPI_Comm_get_info(comm::MPI_Comm, info_used::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -915,7 +915,7 @@ end
 $(_doc_external(:MPI_Comm_get_name))
 """
 function MPI_Comm_get_name(comm, comm_name, resultlen)
-    @mpichk ccall((:MPI_Comm_get_name, libmpi), Cint, (MPI_Comm, Ptr{Cchar}, Ptr{Cint}), comm, comm_name, resultlen)
+    @mpichk @ccall libmpi.MPI_Comm_get_name(comm::MPI_Comm, comm_name::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -924,7 +924,7 @@ end
 $(_doc_external(:MPI_Comm_group))
 """
 function MPI_Comm_group(comm, group)
-    @mpichk ccall((:MPI_Comm_group, libmpi), Cint, (MPI_Comm, Ptr{MPI_Group}), comm, group)
+    @mpichk @ccall libmpi.MPI_Comm_group(comm::MPI_Comm, group::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -933,7 +933,7 @@ end
 $(_doc_external(:MPI_Comm_idup))
 """
 function MPI_Comm_idup(comm, newcomm, request)
-    @mpichk ccall((:MPI_Comm_idup, libmpi), Cint, (MPI_Comm, Ptr{MPI_Comm}, Ptr{MPI_Request}), comm, newcomm, request)
+    @mpichk @ccall libmpi.MPI_Comm_idup(comm::MPI_Comm, newcomm::Ptr{MPI_Comm}, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -942,7 +942,7 @@ end
 $(_doc_external(:MPI_Comm_idup_with_info))
 """
 function MPI_Comm_idup_with_info(comm, info, newcomm, request)
-    @mpichk ccall((:MPI_Comm_idup_with_info, libmpi), Cint, (MPI_Comm, MPI_Info, Ptr{MPI_Comm}, Ptr{MPI_Request}), comm, info, newcomm, request)
+    @mpichk @ccall libmpi.MPI_Comm_idup_with_info(comm::MPI_Comm, info::MPI_Info, newcomm::Ptr{MPI_Comm}, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -951,7 +951,7 @@ end
 $(_doc_external(:MPI_Comm_rank))
 """
 function MPI_Comm_rank(comm, rank)
-    @mpichk ccall((:MPI_Comm_rank, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, rank)
+    @mpichk @ccall libmpi.MPI_Comm_rank(comm::MPI_Comm, rank::Ptr{Cint})::Cint
 end
 
 """
@@ -960,7 +960,7 @@ end
 $(_doc_external(:MPI_Comm_remote_group))
 """
 function MPI_Comm_remote_group(comm, group)
-    @mpichk ccall((:MPI_Comm_remote_group, libmpi), Cint, (MPI_Comm, Ptr{MPI_Group}), comm, group)
+    @mpichk @ccall libmpi.MPI_Comm_remote_group(comm::MPI_Comm, group::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -969,7 +969,7 @@ end
 $(_doc_external(:MPI_Comm_remote_size))
 """
 function MPI_Comm_remote_size(comm, size)
-    @mpichk ccall((:MPI_Comm_remote_size, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, size)
+    @mpichk @ccall libmpi.MPI_Comm_remote_size(comm::MPI_Comm, size::Ptr{Cint})::Cint
 end
 
 """
@@ -978,7 +978,7 @@ end
 $(_doc_external(:MPI_Comm_set_info))
 """
 function MPI_Comm_set_info(comm, info)
-    @mpichk ccall((:MPI_Comm_set_info, libmpi), Cint, (MPI_Comm, MPI_Info), comm, info)
+    @mpichk @ccall libmpi.MPI_Comm_set_info(comm::MPI_Comm, info::MPI_Info)::Cint
 end
 
 """
@@ -987,7 +987,7 @@ end
 $(_doc_external(:MPI_Comm_set_name))
 """
 function MPI_Comm_set_name(comm, comm_name)
-    @mpichk ccall((:MPI_Comm_set_name, libmpi), Cint, (MPI_Comm, Ptr{Cchar}), comm, comm_name)
+    @mpichk @ccall libmpi.MPI_Comm_set_name(comm::MPI_Comm, comm_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -996,7 +996,7 @@ end
 $(_doc_external(:MPI_Comm_size))
 """
 function MPI_Comm_size(comm, size)
-    @mpichk ccall((:MPI_Comm_size, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, size)
+    @mpichk @ccall libmpi.MPI_Comm_size(comm::MPI_Comm, size::Ptr{Cint})::Cint
 end
 
 """
@@ -1005,7 +1005,7 @@ end
 $(_doc_external(:MPI_Comm_split))
 """
 function MPI_Comm_split(comm, color, key, newcomm)
-    @mpichk ccall((:MPI_Comm_split, libmpi), Cint, (MPI_Comm, Cint, Cint, Ptr{MPI_Comm}), comm, color, key, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_split(comm::MPI_Comm, color::Cint, key::Cint, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1014,7 +1014,7 @@ end
 $(_doc_external(:MPI_Comm_split_type))
 """
 function MPI_Comm_split_type(comm, split_type, key, info, newcomm)
-    @mpichk ccall((:MPI_Comm_split_type, libmpi), Cint, (MPI_Comm, Cint, Cint, MPI_Info, Ptr{MPI_Comm}), comm, split_type, key, info, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_split_type(comm::MPI_Comm, split_type::Cint, key::Cint, info::MPI_Info, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1023,7 +1023,7 @@ end
 $(_doc_external(:MPI_Comm_test_inter))
 """
 function MPI_Comm_test_inter(comm, flag)
-    @mpichk ccall((:MPI_Comm_test_inter, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, flag)
+    @mpichk @ccall libmpi.MPI_Comm_test_inter(comm::MPI_Comm, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1032,7 +1032,7 @@ end
 $(_doc_external(:MPI_Intercomm_create))
 """
 function MPI_Intercomm_create(local_comm, local_leader, peer_comm, remote_leader, tag, newintercomm)
-    @mpichk ccall((:MPI_Intercomm_create, libmpi), Cint, (MPI_Comm, Cint, MPI_Comm, Cint, Cint, Ptr{MPI_Comm}), local_comm, local_leader, peer_comm, remote_leader, tag, newintercomm)
+    @mpichk @ccall libmpi.MPI_Intercomm_create(local_comm::MPI_Comm, local_leader::Cint, peer_comm::MPI_Comm, remote_leader::Cint, tag::Cint, newintercomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1041,7 +1041,7 @@ end
 $(_doc_external(:MPI_Intercomm_create_from_groups))
 """
 function MPI_Intercomm_create_from_groups(local_group, local_leader, remote_group, remote_leader, stringtag, info, errhandler, newintercomm)
-    @mpichk ccall((:MPI_Intercomm_create_from_groups, libmpi), Cint, (MPI_Group, Cint, MPI_Group, Cint, Ptr{Cchar}, MPI_Info, MPI_Errhandler, Ptr{MPI_Comm}), local_group, local_leader, remote_group, remote_leader, stringtag, info, errhandler, newintercomm)
+    @mpichk @ccall libmpi.MPI_Intercomm_create_from_groups(local_group::MPI_Group, local_leader::Cint, remote_group::MPI_Group, remote_leader::Cint, stringtag::Ptr{Cchar}, info::MPI_Info, errhandler::MPI_Errhandler, newintercomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1050,7 +1050,7 @@ end
 $(_doc_external(:MPI_Intercomm_merge))
 """
 function MPI_Intercomm_merge(intercomm, high, newintracomm)
-    @mpichk ccall((:MPI_Intercomm_merge, libmpi), Cint, (MPI_Comm, Cint, Ptr{MPI_Comm}), intercomm, high, newintracomm)
+    @mpichk @ccall libmpi.MPI_Intercomm_merge(intercomm::MPI_Comm, high::Cint, newintracomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1059,7 +1059,7 @@ end
 $(_doc_external(:MPI_Get_address))
 """
 function MPI_Get_address(location, address)
-    @mpichk ccall((:MPI_Get_address, libmpi), Cint, (MPIPtr, Ptr{MPI_Aint}), location, address)
+    @mpichk @ccall libmpi.MPI_Get_address(location::MPIPtr, address::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1068,7 +1068,7 @@ end
 $(_doc_external(:MPI_Get_count))
 """
 function MPI_Get_count(status, datatype, count)
-    @mpichk ccall((:MPI_Get_count, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Ptr{Cint}), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Get_count(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Ptr{Cint})::Cint
 end
 
 """
@@ -1077,7 +1077,7 @@ end
 $(_doc_external(:MPI_Get_elements))
 """
 function MPI_Get_elements(status, datatype, count)
-    @mpichk ccall((:MPI_Get_elements, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Ptr{Cint}), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Get_elements(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Ptr{Cint})::Cint
 end
 
 """
@@ -1086,7 +1086,7 @@ end
 $(_doc_external(:MPI_Get_elements_x))
 """
 function MPI_Get_elements_x(status, datatype, count)
-    @mpichk ccall((:MPI_Get_elements_x, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Ptr{MPI_Count}), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Get_elements_x(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -1095,7 +1095,7 @@ end
 $(_doc_external(:MPI_Pack))
 """
 function MPI_Pack(inbuf, incount, datatype, outbuf, outsize, position, comm)
-    @mpichk ccall((:MPI_Pack, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, Ptr{Cint}, MPI_Comm), inbuf, incount, datatype, outbuf, outsize, position, comm)
+    @mpichk @ccall libmpi.MPI_Pack(inbuf::MPIPtr, incount::Cint, datatype::MPI_Datatype, outbuf::MPIPtr, outsize::Cint, position::Ptr{Cint}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -1104,7 +1104,7 @@ end
 $(_doc_external(:MPI_Pack_external))
 """
 function MPI_Pack_external(datarep, inbuf, incount, datatype, outbuf, outsize, position)
-    @mpichk ccall((:MPI_Pack_external, libmpi), Cint, (Ptr{Cchar}, MPIPtr, Cint, MPI_Datatype, MPIPtr, MPI_Aint, Ptr{MPI_Aint}), datarep, inbuf, incount, datatype, outbuf, outsize, position)
+    @mpichk @ccall libmpi.MPI_Pack_external(datarep::Ptr{Cchar}, inbuf::MPIPtr, incount::Cint, datatype::MPI_Datatype, outbuf::MPIPtr, outsize::MPI_Aint, position::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1113,7 +1113,7 @@ end
 $(_doc_external(:MPI_Pack_external_size))
 """
 function MPI_Pack_external_size(datarep, incount, datatype, size)
-    @mpichk ccall((:MPI_Pack_external_size, libmpi), Cint, (Ptr{Cchar}, Cint, MPI_Datatype, Ptr{MPI_Aint}), datarep, incount, datatype, size)
+    @mpichk @ccall libmpi.MPI_Pack_external_size(datarep::Ptr{Cchar}, incount::Cint, datatype::MPI_Datatype, size::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1122,7 +1122,7 @@ end
 $(_doc_external(:MPI_Pack_size))
 """
 function MPI_Pack_size(incount, datatype, comm, size)
-    @mpichk ccall((:MPI_Pack_size, libmpi), Cint, (Cint, MPI_Datatype, MPI_Comm, Ptr{Cint}), incount, datatype, comm, size)
+    @mpichk @ccall libmpi.MPI_Pack_size(incount::Cint, datatype::MPI_Datatype, comm::MPI_Comm, size::Ptr{Cint})::Cint
 end
 
 """
@@ -1131,7 +1131,7 @@ end
 $(_doc_external(:MPI_Status_set_elements))
 """
 function MPI_Status_set_elements(status, datatype, count)
-    @mpichk ccall((:MPI_Status_set_elements, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Cint), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Status_set_elements(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Cint)::Cint
 end
 
 """
@@ -1140,7 +1140,7 @@ end
 $(_doc_external(:MPI_Status_set_elements_x))
 """
 function MPI_Status_set_elements_x(status, datatype, count)
-    @mpichk ccall((:MPI_Status_set_elements_x, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, MPI_Count), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Status_set_elements_x(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::MPI_Count)::Cint
 end
 
 """
@@ -1149,7 +1149,7 @@ end
 $(_doc_external(:MPI_Type_commit))
 """
 function MPI_Type_commit(datatype)
-    @mpichk ccall((:MPI_Type_commit, libmpi), Cint, (Ptr{MPI_Datatype},), datatype)
+    @mpichk @ccall libmpi.MPI_Type_commit(datatype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1158,7 +1158,7 @@ end
 $(_doc_external(:MPI_Type_contiguous))
 """
 function MPI_Type_contiguous(count, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_contiguous, libmpi), Cint, (Cint, MPI_Datatype, Ptr{MPI_Datatype}), count, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_contiguous(count::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1167,7 +1167,7 @@ end
 $(_doc_external(:MPI_Type_create_darray))
 """
 function MPI_Type_create_darray(size, rank, ndims, array_of_gsizes, array_of_distribs, array_of_dargs, array_of_psizes, order, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_darray, libmpi), Cint, (Cint, Cint, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint, MPI_Datatype, Ptr{MPI_Datatype}), size, rank, ndims, array_of_gsizes, array_of_distribs, array_of_dargs, array_of_psizes, order, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_darray(size::Cint, rank::Cint, ndims::Cint, array_of_gsizes::Ptr{Cint}, array_of_distribs::Ptr{Cint}, array_of_dargs::Ptr{Cint}, array_of_psizes::Ptr{Cint}, order::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1176,7 +1176,7 @@ end
 $(_doc_external(:MPI_Type_create_hindexed))
 """
 function MPI_Type_create_hindexed(count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hindexed, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{MPI_Aint}, MPI_Datatype, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hindexed(count::Cint, array_of_blocklengths::Ptr{Cint}, array_of_displacements::Ptr{MPI_Aint}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1185,7 +1185,7 @@ end
 $(_doc_external(:MPI_Type_create_hindexed_block))
 """
 function MPI_Type_create_hindexed_block(count, blocklength, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hindexed_block, libmpi), Cint, (Cint, Cint, Ptr{MPI_Aint}, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hindexed_block(count::Cint, blocklength::Cint, array_of_displacements::Ptr{MPI_Aint}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1194,7 +1194,7 @@ end
 $(_doc_external(:MPI_Type_create_hvector))
 """
 function MPI_Type_create_hvector(count, blocklength, stride, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hvector, libmpi), Cint, (Cint, Cint, MPI_Aint, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, stride, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hvector(count::Cint, blocklength::Cint, stride::MPI_Aint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1203,7 +1203,7 @@ end
 $(_doc_external(:MPI_Type_create_indexed_block))
 """
 function MPI_Type_create_indexed_block(count, blocklength, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_indexed_block, libmpi), Cint, (Cint, Cint, Ptr{Cint}, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_indexed_block(count::Cint, blocklength::Cint, array_of_displacements::Ptr{Cint}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1212,7 +1212,7 @@ end
 $(_doc_external(:MPI_Type_create_resized))
 """
 function MPI_Type_create_resized(oldtype, lb, extent, newtype)
-    @mpichk ccall((:MPI_Type_create_resized, libmpi), Cint, (MPI_Datatype, MPI_Aint, MPI_Aint, Ptr{MPI_Datatype}), oldtype, lb, extent, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_resized(oldtype::MPI_Datatype, lb::MPI_Aint, extent::MPI_Aint, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1221,7 +1221,7 @@ end
 $(_doc_external(:MPI_Type_create_struct))
 """
 function MPI_Type_create_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
-    @mpichk ccall((:MPI_Type_create_struct, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_struct(count::Cint, array_of_blocklengths::Ptr{Cint}, array_of_displacements::Ptr{MPI_Aint}, array_of_types::Ptr{MPI_Datatype}, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1230,7 +1230,7 @@ end
 $(_doc_external(:MPI_Type_create_subarray))
 """
 function MPI_Type_create_subarray(ndims, array_of_sizes, array_of_subsizes, array_of_starts, order, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_subarray, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint, MPI_Datatype, Ptr{MPI_Datatype}), ndims, array_of_sizes, array_of_subsizes, array_of_starts, order, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_subarray(ndims::Cint, array_of_sizes::Ptr{Cint}, array_of_subsizes::Ptr{Cint}, array_of_starts::Ptr{Cint}, order::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1239,7 +1239,7 @@ end
 $(_doc_external(:MPI_Type_dup))
 """
 function MPI_Type_dup(oldtype, newtype)
-    @mpichk ccall((:MPI_Type_dup, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Datatype}), oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_dup(oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1248,7 +1248,7 @@ end
 $(_doc_external(:MPI_Type_free))
 """
 function MPI_Type_free(datatype)
-    @mpichk ccall((:MPI_Type_free, libmpi), Cint, (Ptr{MPI_Datatype},), datatype)
+    @mpichk @ccall libmpi.MPI_Type_free(datatype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1257,7 +1257,7 @@ end
 $(_doc_external(:MPI_Type_get_contents))
 """
 function MPI_Type_get_contents(datatype, max_integers, max_addresses, max_datatypes, array_of_integers, array_of_addresses, array_of_datatypes)
-    @mpichk ccall((:MPI_Type_get_contents, libmpi), Cint, (MPI_Datatype, Cint, Cint, Cint, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}), datatype, max_integers, max_addresses, max_datatypes, array_of_integers, array_of_addresses, array_of_datatypes)
+    @mpichk @ccall libmpi.MPI_Type_get_contents(datatype::MPI_Datatype, max_integers::Cint, max_addresses::Cint, max_datatypes::Cint, array_of_integers::Ptr{Cint}, array_of_addresses::Ptr{MPI_Aint}, array_of_datatypes::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1266,7 +1266,7 @@ end
 $(_doc_external(:MPI_Type_get_envelope))
 """
 function MPI_Type_get_envelope(datatype, num_integers, num_addresses, num_datatypes, combiner)
-    @mpichk ccall((:MPI_Type_get_envelope, libmpi), Cint, (MPI_Datatype, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), datatype, num_integers, num_addresses, num_datatypes, combiner)
+    @mpichk @ccall libmpi.MPI_Type_get_envelope(datatype::MPI_Datatype, num_integers::Ptr{Cint}, num_addresses::Ptr{Cint}, num_datatypes::Ptr{Cint}, combiner::Ptr{Cint})::Cint
 end
 
 """
@@ -1275,7 +1275,7 @@ end
 $(_doc_external(:MPI_Type_get_extent))
 """
 function MPI_Type_get_extent(datatype, lb, extent)
-    @mpichk ccall((:MPI_Type_get_extent, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Aint}, Ptr{MPI_Aint}), datatype, lb, extent)
+    @mpichk @ccall libmpi.MPI_Type_get_extent(datatype::MPI_Datatype, lb::Ptr{MPI_Aint}, extent::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1284,7 +1284,7 @@ end
 $(_doc_external(:MPI_Type_get_extent_x))
 """
 function MPI_Type_get_extent_x(datatype, lb, extent)
-    @mpichk ccall((:MPI_Type_get_extent_x, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}, Ptr{MPI_Count}), datatype, lb, extent)
+    @mpichk @ccall libmpi.MPI_Type_get_extent_x(datatype::MPI_Datatype, lb::Ptr{MPI_Count}, extent::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -1293,7 +1293,7 @@ end
 $(_doc_external(:MPI_Type_get_name))
 """
 function MPI_Type_get_name(datatype, type_name, resultlen)
-    @mpichk ccall((:MPI_Type_get_name, libmpi), Cint, (MPI_Datatype, Ptr{Cchar}, Ptr{Cint}), datatype, type_name, resultlen)
+    @mpichk @ccall libmpi.MPI_Type_get_name(datatype::MPI_Datatype, type_name::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -1302,7 +1302,7 @@ end
 $(_doc_external(:MPI_Type_get_true_extent))
 """
 function MPI_Type_get_true_extent(datatype, true_lb, true_extent)
-    @mpichk ccall((:MPI_Type_get_true_extent, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Aint}, Ptr{MPI_Aint}), datatype, true_lb, true_extent)
+    @mpichk @ccall libmpi.MPI_Type_get_true_extent(datatype::MPI_Datatype, true_lb::Ptr{MPI_Aint}, true_extent::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1311,7 +1311,7 @@ end
 $(_doc_external(:MPI_Type_get_true_extent_x))
 """
 function MPI_Type_get_true_extent_x(datatype, true_lb, true_extent)
-    @mpichk ccall((:MPI_Type_get_true_extent_x, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}, Ptr{MPI_Count}), datatype, true_lb, true_extent)
+    @mpichk @ccall libmpi.MPI_Type_get_true_extent_x(datatype::MPI_Datatype, true_lb::Ptr{MPI_Count}, true_extent::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -1320,7 +1320,7 @@ end
 $(_doc_external(:MPI_Type_indexed))
 """
 function MPI_Type_indexed(count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_indexed, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{Cint}, MPI_Datatype, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_indexed(count::Cint, array_of_blocklengths::Ptr{Cint}, array_of_displacements::Ptr{Cint}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1329,7 +1329,7 @@ end
 $(_doc_external(:MPI_Type_match_size))
 """
 function MPI_Type_match_size(typeclass, size, datatype)
-    @mpichk ccall((:MPI_Type_match_size, libmpi), Cint, (Cint, Cint, Ptr{MPI_Datatype}), typeclass, size, datatype)
+    @mpichk @ccall libmpi.MPI_Type_match_size(typeclass::Cint, size::Cint, datatype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1338,7 +1338,7 @@ end
 $(_doc_external(:MPI_Type_set_name))
 """
 function MPI_Type_set_name(datatype, type_name)
-    @mpichk ccall((:MPI_Type_set_name, libmpi), Cint, (MPI_Datatype, Ptr{Cchar}), datatype, type_name)
+    @mpichk @ccall libmpi.MPI_Type_set_name(datatype::MPI_Datatype, type_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -1347,7 +1347,7 @@ end
 $(_doc_external(:MPI_Type_size))
 """
 function MPI_Type_size(datatype, size)
-    @mpichk ccall((:MPI_Type_size, libmpi), Cint, (MPI_Datatype, Ptr{Cint}), datatype, size)
+    @mpichk @ccall libmpi.MPI_Type_size(datatype::MPI_Datatype, size::Ptr{Cint})::Cint
 end
 
 """
@@ -1356,7 +1356,7 @@ end
 $(_doc_external(:MPI_Type_size_x))
 """
 function MPI_Type_size_x(datatype, size)
-    @mpichk ccall((:MPI_Type_size_x, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}), datatype, size)
+    @mpichk @ccall libmpi.MPI_Type_size_x(datatype::MPI_Datatype, size::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -1365,7 +1365,7 @@ end
 $(_doc_external(:MPI_Type_vector))
 """
 function MPI_Type_vector(count, blocklength, stride, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_vector, libmpi), Cint, (Cint, Cint, Cint, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, stride, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_vector(count::Cint, blocklength::Cint, stride::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1374,7 +1374,7 @@ end
 $(_doc_external(:MPI_Unpack))
 """
 function MPI_Unpack(inbuf, insize, position, outbuf, outcount, datatype, comm)
-    @mpichk ccall((:MPI_Unpack, libmpi), Cint, (MPIPtr, Cint, Ptr{Cint}, MPIPtr, Cint, MPI_Datatype, MPI_Comm), inbuf, insize, position, outbuf, outcount, datatype, comm)
+    @mpichk @ccall libmpi.MPI_Unpack(inbuf::MPIPtr, insize::Cint, position::Ptr{Cint}, outbuf::MPIPtr, outcount::Cint, datatype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -1383,7 +1383,7 @@ end
 $(_doc_external(:MPI_Unpack_external))
 """
 function MPI_Unpack_external(datarep, inbuf, insize, position, outbuf, outcount, datatype)
-    @mpichk ccall((:MPI_Unpack_external, libmpi), Cint, (Ptr{Cchar}, MPIPtr, MPI_Aint, Ptr{MPI_Aint}, MPIPtr, Cint, MPI_Datatype), datarep, inbuf, insize, position, outbuf, outcount, datatype)
+    @mpichk @ccall libmpi.MPI_Unpack_external(datarep::Ptr{Cchar}, inbuf::MPIPtr, insize::MPI_Aint, position::Ptr{MPI_Aint}, outbuf::MPIPtr, outcount::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -1392,7 +1392,7 @@ end
 $(_doc_external(:MPI_Address))
 """
 function MPI_Address(location, address)
-    @mpichk ccall((:MPI_Address, libmpi), Cint, (MPIPtr, Ptr{MPI_Aint}), location, address)
+    @mpichk @ccall libmpi.MPI_Address(location::MPIPtr, address::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1401,7 +1401,7 @@ end
 $(_doc_external(:MPI_Type_extent))
 """
 function MPI_Type_extent(datatype, extent)
-    @mpichk ccall((:MPI_Type_extent, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Aint}), datatype, extent)
+    @mpichk @ccall libmpi.MPI_Type_extent(datatype::MPI_Datatype, extent::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1410,7 +1410,7 @@ end
 $(_doc_external(:MPI_Type_lb))
 """
 function MPI_Type_lb(datatype, displacement)
-    @mpichk ccall((:MPI_Type_lb, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Aint}), datatype, displacement)
+    @mpichk @ccall libmpi.MPI_Type_lb(datatype::MPI_Datatype, displacement::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1419,7 +1419,7 @@ end
 $(_doc_external(:MPI_Type_ub))
 """
 function MPI_Type_ub(datatype, displacement)
-    @mpichk ccall((:MPI_Type_ub, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Aint}), datatype, displacement)
+    @mpichk @ccall libmpi.MPI_Type_ub(datatype::MPI_Datatype, displacement::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -1428,7 +1428,7 @@ end
 $(_doc_external(:MPI_Type_hindexed))
 """
 function MPI_Type_hindexed(count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_hindexed, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{MPI_Aint}, MPI_Datatype, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_hindexed(count::Cint, array_of_blocklengths::Ptr{Cint}, array_of_displacements::Ptr{MPI_Aint}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1437,7 +1437,7 @@ end
 $(_doc_external(:MPI_Type_hvector))
 """
 function MPI_Type_hvector(count, blocklength, stride, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_hvector, libmpi), Cint, (Cint, Cint, MPI_Aint, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, stride, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_hvector(count::Cint, blocklength::Cint, stride::MPI_Aint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1446,7 +1446,7 @@ end
 $(_doc_external(:MPI_Type_struct))
 """
 function MPI_Type_struct(count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
-    @mpichk ccall((:MPI_Type_struct, libmpi), Cint, (Cint, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
+    @mpichk @ccall libmpi.MPI_Type_struct(count::Cint, array_of_blocklengths::Ptr{Cint}, array_of_displacements::Ptr{MPI_Aint}, array_of_types::Ptr{MPI_Datatype}, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -1455,7 +1455,7 @@ end
 $(_doc_external(:MPI_Add_error_class))
 """
 function MPI_Add_error_class(errorclass)
-    @mpichk ccall((:MPI_Add_error_class, libmpi), Cint, (Ptr{Cint},), errorclass)
+    @mpichk @ccall libmpi.MPI_Add_error_class(errorclass::Ptr{Cint})::Cint
 end
 
 """
@@ -1464,7 +1464,7 @@ end
 $(_doc_external(:MPI_Add_error_code))
 """
 function MPI_Add_error_code(errorclass, errorcode)
-    @mpichk ccall((:MPI_Add_error_code, libmpi), Cint, (Cint, Ptr{Cint}), errorclass, errorcode)
+    @mpichk @ccall libmpi.MPI_Add_error_code(errorclass::Cint, errorcode::Ptr{Cint})::Cint
 end
 
 """
@@ -1473,7 +1473,7 @@ end
 $(_doc_external(:MPI_Add_error_string))
 """
 function MPI_Add_error_string(errorcode, string)
-    @mpichk ccall((:MPI_Add_error_string, libmpi), Cint, (Cint, Ptr{Cchar}), errorcode, string)
+    @mpichk @ccall libmpi.MPI_Add_error_string(errorcode::Cint, string::Ptr{Cchar})::Cint
 end
 
 """
@@ -1482,7 +1482,7 @@ end
 $(_doc_external(:MPI_Comm_call_errhandler))
 """
 function MPI_Comm_call_errhandler(comm, errorcode)
-    @mpichk ccall((:MPI_Comm_call_errhandler, libmpi), Cint, (MPI_Comm, Cint), comm, errorcode)
+    @mpichk @ccall libmpi.MPI_Comm_call_errhandler(comm::MPI_Comm, errorcode::Cint)::Cint
 end
 
 """
@@ -1491,7 +1491,7 @@ end
 $(_doc_external(:MPI_Comm_create_errhandler))
 """
 function MPI_Comm_create_errhandler(comm_errhandler_fn, errhandler)
-    @mpichk ccall((:MPI_Comm_create_errhandler, libmpi), Cint, (MPIPtr, Ptr{MPI_Errhandler}), comm_errhandler_fn, errhandler)
+    @mpichk @ccall libmpi.MPI_Comm_create_errhandler(comm_errhandler_fn::MPIPtr, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1500,7 +1500,7 @@ end
 $(_doc_external(:MPI_Comm_get_errhandler))
 """
 function MPI_Comm_get_errhandler(comm, errhandler)
-    @mpichk ccall((:MPI_Comm_get_errhandler, libmpi), Cint, (MPI_Comm, Ptr{MPI_Errhandler}), comm, errhandler)
+    @mpichk @ccall libmpi.MPI_Comm_get_errhandler(comm::MPI_Comm, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1509,7 +1509,7 @@ end
 $(_doc_external(:MPI_Comm_set_errhandler))
 """
 function MPI_Comm_set_errhandler(comm, errhandler)
-    @mpichk ccall((:MPI_Comm_set_errhandler, libmpi), Cint, (MPI_Comm, MPI_Errhandler), comm, errhandler)
+    @mpichk @ccall libmpi.MPI_Comm_set_errhandler(comm::MPI_Comm, errhandler::MPI_Errhandler)::Cint
 end
 
 """
@@ -1518,7 +1518,7 @@ end
 $(_doc_external(:MPI_Errhandler_free))
 """
 function MPI_Errhandler_free(errhandler)
-    @mpichk ccall((:MPI_Errhandler_free, libmpi), Cint, (Ptr{MPI_Errhandler},), errhandler)
+    @mpichk @ccall libmpi.MPI_Errhandler_free(errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1527,7 +1527,7 @@ end
 $(_doc_external(:MPI_Error_class))
 """
 function MPI_Error_class(errorcode, errorclass)
-    @mpichk ccall((:MPI_Error_class, libmpi), Cint, (Cint, Ptr{Cint}), errorcode, errorclass)
+    @mpichk @ccall libmpi.MPI_Error_class(errorcode::Cint, errorclass::Ptr{Cint})::Cint
 end
 
 """
@@ -1536,7 +1536,7 @@ end
 $(_doc_external(:MPI_Error_string))
 """
 function MPI_Error_string(errorcode, string, resultlen)
-    @mpichk ccall((:MPI_Error_string, libmpi), Cint, (Cint, Ptr{Cchar}, Ptr{Cint}), errorcode, string, resultlen)
+    @mpichk @ccall libmpi.MPI_Error_string(errorcode::Cint, string::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -1545,7 +1545,7 @@ end
 $(_doc_external(:MPI_File_call_errhandler))
 """
 function MPI_File_call_errhandler(fh, errorcode)
-    @mpichk ccall((:MPI_File_call_errhandler, libmpi), Cint, (MPI_File, Cint), fh, errorcode)
+    @mpichk @ccall libmpi.MPI_File_call_errhandler(fh::MPI_File, errorcode::Cint)::Cint
 end
 
 """
@@ -1554,7 +1554,7 @@ end
 $(_doc_external(:MPI_File_create_errhandler))
 """
 function MPI_File_create_errhandler(file_errhandler_fn, errhandler)
-    @mpichk ccall((:MPI_File_create_errhandler, libmpi), Cint, (MPIPtr, Ptr{MPI_Errhandler}), file_errhandler_fn, errhandler)
+    @mpichk @ccall libmpi.MPI_File_create_errhandler(file_errhandler_fn::MPIPtr, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1563,7 +1563,7 @@ end
 $(_doc_external(:MPI_File_get_errhandler))
 """
 function MPI_File_get_errhandler(file, errhandler)
-    @mpichk ccall((:MPI_File_get_errhandler, libmpi), Cint, (MPI_File, Ptr{MPI_Errhandler}), file, errhandler)
+    @mpichk @ccall libmpi.MPI_File_get_errhandler(file::MPI_File, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1572,7 +1572,7 @@ end
 $(_doc_external(:MPI_File_set_errhandler))
 """
 function MPI_File_set_errhandler(file, errhandler)
-    @mpichk ccall((:MPI_File_set_errhandler, libmpi), Cint, (MPI_File, MPI_Errhandler), file, errhandler)
+    @mpichk @ccall libmpi.MPI_File_set_errhandler(file::MPI_File, errhandler::MPI_Errhandler)::Cint
 end
 
 """
@@ -1581,7 +1581,7 @@ end
 $(_doc_external(:MPI_Win_call_errhandler))
 """
 function MPI_Win_call_errhandler(win, errorcode)
-    @mpichk ccall((:MPI_Win_call_errhandler, libmpi), Cint, (MPI_Win, Cint), win, errorcode)
+    @mpichk @ccall libmpi.MPI_Win_call_errhandler(win::MPI_Win, errorcode::Cint)::Cint
 end
 
 """
@@ -1590,7 +1590,7 @@ end
 $(_doc_external(:MPI_Win_create_errhandler))
 """
 function MPI_Win_create_errhandler(win_errhandler_fn, errhandler)
-    @mpichk ccall((:MPI_Win_create_errhandler, libmpi), Cint, (MPIPtr, Ptr{MPI_Errhandler}), win_errhandler_fn, errhandler)
+    @mpichk @ccall libmpi.MPI_Win_create_errhandler(win_errhandler_fn::MPIPtr, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1599,7 +1599,7 @@ end
 $(_doc_external(:MPI_Win_get_errhandler))
 """
 function MPI_Win_get_errhandler(win, errhandler)
-    @mpichk ccall((:MPI_Win_get_errhandler, libmpi), Cint, (MPI_Win, Ptr{MPI_Errhandler}), win, errhandler)
+    @mpichk @ccall libmpi.MPI_Win_get_errhandler(win::MPI_Win, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1608,7 +1608,7 @@ end
 $(_doc_external(:MPI_Win_set_errhandler))
 """
 function MPI_Win_set_errhandler(win, errhandler)
-    @mpichk ccall((:MPI_Win_set_errhandler, libmpi), Cint, (MPI_Win, MPI_Errhandler), win, errhandler)
+    @mpichk @ccall libmpi.MPI_Win_set_errhandler(win::MPI_Win, errhandler::MPI_Errhandler)::Cint
 end
 
 """
@@ -1617,7 +1617,7 @@ end
 $(_doc_external(:MPI_Errhandler_create))
 """
 function MPI_Errhandler_create(comm_errhandler_fn, errhandler)
-    @mpichk ccall((:MPI_Errhandler_create, libmpi), Cint, (MPIPtr, Ptr{MPI_Errhandler}), comm_errhandler_fn, errhandler)
+    @mpichk @ccall libmpi.MPI_Errhandler_create(comm_errhandler_fn::MPIPtr, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1626,7 +1626,7 @@ end
 $(_doc_external(:MPI_Errhandler_get))
 """
 function MPI_Errhandler_get(comm, errhandler)
-    @mpichk ccall((:MPI_Errhandler_get, libmpi), Cint, (MPI_Comm, Ptr{MPI_Errhandler}), comm, errhandler)
+    @mpichk @ccall libmpi.MPI_Errhandler_get(comm::MPI_Comm, errhandler::Ptr{MPI_Errhandler})::Cint
 end
 
 """
@@ -1635,7 +1635,7 @@ end
 $(_doc_external(:MPI_Errhandler_set))
 """
 function MPI_Errhandler_set(comm, errhandler)
-    @mpichk ccall((:MPI_Errhandler_set, libmpi), Cint, (MPI_Comm, MPI_Errhandler), comm, errhandler)
+    @mpichk @ccall libmpi.MPI_Errhandler_set(comm::MPI_Comm, errhandler::MPI_Errhandler)::Cint
 end
 
 """
@@ -1644,7 +1644,7 @@ end
 $(_doc_external(:MPI_Group_compare))
 """
 function MPI_Group_compare(group1, group2, result)
-    @mpichk ccall((:MPI_Group_compare, libmpi), Cint, (MPI_Group, MPI_Group, Ptr{Cint}), group1, group2, result)
+    @mpichk @ccall libmpi.MPI_Group_compare(group1::MPI_Group, group2::MPI_Group, result::Ptr{Cint})::Cint
 end
 
 """
@@ -1653,7 +1653,7 @@ end
 $(_doc_external(:MPI_Group_difference))
 """
 function MPI_Group_difference(group1, group2, newgroup)
-    @mpichk ccall((:MPI_Group_difference, libmpi), Cint, (MPI_Group, MPI_Group, Ptr{MPI_Group}), group1, group2, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_difference(group1::MPI_Group, group2::MPI_Group, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1662,7 +1662,7 @@ end
 $(_doc_external(:MPI_Group_excl))
 """
 function MPI_Group_excl(group, n, ranks, newgroup)
-    @mpichk ccall((:MPI_Group_excl, libmpi), Cint, (MPI_Group, Cint, Ptr{Cint}, Ptr{MPI_Group}), group, n, ranks, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_excl(group::MPI_Group, n::Cint, ranks::Ptr{Cint}, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1671,7 +1671,7 @@ end
 $(_doc_external(:MPI_Group_free))
 """
 function MPI_Group_free(group)
-    @mpichk ccall((:MPI_Group_free, libmpi), Cint, (Ptr{MPI_Group},), group)
+    @mpichk @ccall libmpi.MPI_Group_free(group::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1680,7 +1680,7 @@ end
 $(_doc_external(:MPI_Group_incl))
 """
 function MPI_Group_incl(group, n, ranks, newgroup)
-    @mpichk ccall((:MPI_Group_incl, libmpi), Cint, (MPI_Group, Cint, Ptr{Cint}, Ptr{MPI_Group}), group, n, ranks, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_incl(group::MPI_Group, n::Cint, ranks::Ptr{Cint}, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1689,7 +1689,7 @@ end
 $(_doc_external(:MPI_Group_intersection))
 """
 function MPI_Group_intersection(group1, group2, newgroup)
-    @mpichk ccall((:MPI_Group_intersection, libmpi), Cint, (MPI_Group, MPI_Group, Ptr{MPI_Group}), group1, group2, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_intersection(group1::MPI_Group, group2::MPI_Group, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1698,7 +1698,7 @@ end
 $(_doc_external(:MPI_Group_range_excl))
 """
 function MPI_Group_range_excl(group, n, ranges, newgroup)
-    @mpichk ccall((:MPI_Group_range_excl, libmpi), Cint, (MPI_Group, Cint, Ptr{NTuple{3, Cint}}, Ptr{MPI_Group}), group, n, ranges, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_range_excl(group::MPI_Group, n::Cint, ranges::Ptr{NTuple{3, Cint}}, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1707,7 +1707,7 @@ end
 $(_doc_external(:MPI_Group_range_incl))
 """
 function MPI_Group_range_incl(group, n, ranges, newgroup)
-    @mpichk ccall((:MPI_Group_range_incl, libmpi), Cint, (MPI_Group, Cint, Ptr{NTuple{3, Cint}}, Ptr{MPI_Group}), group, n, ranges, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_range_incl(group::MPI_Group, n::Cint, ranges::Ptr{NTuple{3, Cint}}, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1716,7 +1716,7 @@ end
 $(_doc_external(:MPI_Group_rank))
 """
 function MPI_Group_rank(group, rank)
-    @mpichk ccall((:MPI_Group_rank, libmpi), Cint, (MPI_Group, Ptr{Cint}), group, rank)
+    @mpichk @ccall libmpi.MPI_Group_rank(group::MPI_Group, rank::Ptr{Cint})::Cint
 end
 
 """
@@ -1725,7 +1725,7 @@ end
 $(_doc_external(:MPI_Group_size))
 """
 function MPI_Group_size(group, size)
-    @mpichk ccall((:MPI_Group_size, libmpi), Cint, (MPI_Group, Ptr{Cint}), group, size)
+    @mpichk @ccall libmpi.MPI_Group_size(group::MPI_Group, size::Ptr{Cint})::Cint
 end
 
 """
@@ -1734,7 +1734,7 @@ end
 $(_doc_external(:MPI_Group_translate_ranks))
 """
 function MPI_Group_translate_ranks(group1, n, ranks1, group2, ranks2)
-    @mpichk ccall((:MPI_Group_translate_ranks, libmpi), Cint, (MPI_Group, Cint, Ptr{Cint}, MPI_Group, Ptr{Cint}), group1, n, ranks1, group2, ranks2)
+    @mpichk @ccall libmpi.MPI_Group_translate_ranks(group1::MPI_Group, n::Cint, ranks1::Ptr{Cint}, group2::MPI_Group, ranks2::Ptr{Cint})::Cint
 end
 
 """
@@ -1743,7 +1743,7 @@ end
 $(_doc_external(:MPI_Group_union))
 """
 function MPI_Group_union(group1, group2, newgroup)
-    @mpichk ccall((:MPI_Group_union, libmpi), Cint, (MPI_Group, MPI_Group, Ptr{MPI_Group}), group1, group2, newgroup)
+    @mpichk @ccall libmpi.MPI_Group_union(group1::MPI_Group, group2::MPI_Group, newgroup::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -1752,7 +1752,7 @@ end
 $(_doc_external(:MPI_Info_create))
 """
 function MPI_Info_create(info)
-    @mpichk ccall((:MPI_Info_create, libmpi), Cint, (Ptr{MPI_Info},), info)
+    @mpichk @ccall libmpi.MPI_Info_create(info::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -1761,7 +1761,7 @@ end
 $(_doc_external(:MPI_Info_create_env))
 """
 function MPI_Info_create_env(argc, argv, info)
-    @mpichk ccall((:MPI_Info_create_env, libmpi), Cint, (Cint, Ptr{Ptr{Cchar}}, Ptr{MPI_Info}), argc, argv, info)
+    @mpichk @ccall libmpi.MPI_Info_create_env(argc::Cint, argv::Ptr{Ptr{Cchar}}, info::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -1770,7 +1770,7 @@ end
 $(_doc_external(:MPI_Info_delete))
 """
 function MPI_Info_delete(info, key)
-    @mpichk ccall((:MPI_Info_delete, libmpi), Cint, (MPI_Info, Ptr{Cchar}), info, key)
+    @mpichk @ccall libmpi.MPI_Info_delete(info::MPI_Info, key::Ptr{Cchar})::Cint
 end
 
 """
@@ -1779,7 +1779,7 @@ end
 $(_doc_external(:MPI_Info_dup))
 """
 function MPI_Info_dup(info, newinfo)
-    @mpichk ccall((:MPI_Info_dup, libmpi), Cint, (MPI_Info, Ptr{MPI_Info}), info, newinfo)
+    @mpichk @ccall libmpi.MPI_Info_dup(info::MPI_Info, newinfo::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -1788,7 +1788,7 @@ end
 $(_doc_external(:MPI_Info_free))
 """
 function MPI_Info_free(info)
-    @mpichk ccall((:MPI_Info_free, libmpi), Cint, (Ptr{MPI_Info},), info)
+    @mpichk @ccall libmpi.MPI_Info_free(info::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -1797,7 +1797,7 @@ end
 $(_doc_external(:MPI_Info_get))
 """
 function MPI_Info_get(info, key, valuelen, value, flag)
-    @mpichk ccall((:MPI_Info_get, libmpi), Cint, (MPI_Info, Ptr{Cchar}, Cint, Ptr{Cchar}, Ptr{Cint}), info, key, valuelen, value, flag)
+    @mpichk @ccall libmpi.MPI_Info_get(info::MPI_Info, key::Ptr{Cchar}, valuelen::Cint, value::Ptr{Cchar}, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1806,7 +1806,7 @@ end
 $(_doc_external(:MPI_Info_get_nkeys))
 """
 function MPI_Info_get_nkeys(info, nkeys)
-    @mpichk ccall((:MPI_Info_get_nkeys, libmpi), Cint, (MPI_Info, Ptr{Cint}), info, nkeys)
+    @mpichk @ccall libmpi.MPI_Info_get_nkeys(info::MPI_Info, nkeys::Ptr{Cint})::Cint
 end
 
 """
@@ -1815,7 +1815,7 @@ end
 $(_doc_external(:MPI_Info_get_nthkey))
 """
 function MPI_Info_get_nthkey(info, n, key)
-    @mpichk ccall((:MPI_Info_get_nthkey, libmpi), Cint, (MPI_Info, Cint, Ptr{Cchar}), info, n, key)
+    @mpichk @ccall libmpi.MPI_Info_get_nthkey(info::MPI_Info, n::Cint, key::Ptr{Cchar})::Cint
 end
 
 """
@@ -1824,7 +1824,7 @@ end
 $(_doc_external(:MPI_Info_get_string))
 """
 function MPI_Info_get_string(info, key, buflen, value, flag)
-    @mpichk ccall((:MPI_Info_get_string, libmpi), Cint, (MPI_Info, Ptr{Cchar}, Ptr{Cint}, Ptr{Cchar}, Ptr{Cint}), info, key, buflen, value, flag)
+    @mpichk @ccall libmpi.MPI_Info_get_string(info::MPI_Info, key::Ptr{Cchar}, buflen::Ptr{Cint}, value::Ptr{Cchar}, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1833,7 +1833,7 @@ end
 $(_doc_external(:MPI_Info_get_valuelen))
 """
 function MPI_Info_get_valuelen(info, key, valuelen, flag)
-    @mpichk ccall((:MPI_Info_get_valuelen, libmpi), Cint, (MPI_Info, Ptr{Cchar}, Ptr{Cint}, Ptr{Cint}), info, key, valuelen, flag)
+    @mpichk @ccall libmpi.MPI_Info_get_valuelen(info::MPI_Info, key::Ptr{Cchar}, valuelen::Ptr{Cint}, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1842,7 +1842,7 @@ end
 $(_doc_external(:MPI_Info_set))
 """
 function MPI_Info_set(info, key, value)
-    @mpichk ccall((:MPI_Info_set, libmpi), Cint, (MPI_Info, Ptr{Cchar}, Ptr{Cchar}), info, key, value)
+    @mpichk @ccall libmpi.MPI_Info_set(info::MPI_Info, key::Ptr{Cchar}, value::Ptr{Cchar})::Cint
 end
 
 """
@@ -1851,7 +1851,7 @@ end
 $(_doc_external(:MPI_Abort))
 """
 function MPI_Abort(comm, errorcode)
-    @mpichk ccall((:MPI_Abort, libmpi), Cint, (MPI_Comm, Cint), comm, errorcode)
+    @mpichk @ccall libmpi.MPI_Abort(comm::MPI_Comm, errorcode::Cint)::Cint
 end
 
 """
@@ -1860,7 +1860,7 @@ end
 $(_doc_external(:MPI_Comm_create_from_group))
 """
 function MPI_Comm_create_from_group(group, stringtag, info, errhandler, newcomm)
-    @mpichk ccall((:MPI_Comm_create_from_group, libmpi), Cint, (MPI_Group, Ptr{Cchar}, MPI_Info, MPI_Errhandler, Ptr{MPI_Comm}), group, stringtag, info, errhandler, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_create_from_group(group::MPI_Group, stringtag::Ptr{Cchar}, info::MPI_Info, errhandler::MPI_Errhandler, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -1869,7 +1869,7 @@ end
 $(_doc_external(:MPI_Finalize))
 """
 function MPI_Finalize()
-    @mpichk ccall((:MPI_Finalize, libmpi), Cint, ())
+    @mpichk @ccall libmpi.MPI_Finalize()::Cint
 end
 
 """
@@ -1878,7 +1878,7 @@ end
 $(_doc_external(:MPI_Finalized))
 """
 function MPI_Finalized(flag)
-    @mpichk ccall((:MPI_Finalized, libmpi), Cint, (Ptr{Cint},), flag)
+    @mpichk @ccall libmpi.MPI_Finalized(flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1887,7 +1887,7 @@ end
 $(_doc_external(:MPI_Init))
 """
 function MPI_Init(argc, argv)
-    @mpichk ccall((:MPI_Init, libmpi), Cint, (Ptr{Cint}, Ptr{Ptr{Ptr{Cchar}}}), argc, argv)
+    @mpichk @ccall libmpi.MPI_Init(argc::Ptr{Cint}, argv::Ptr{Ptr{Ptr{Cchar}}})::Cint
 end
 
 """
@@ -1896,7 +1896,7 @@ end
 $(_doc_external(:MPI_Init_thread))
 """
 function MPI_Init_thread(argc, argv, required, provided)
-    @mpichk ccall((:MPI_Init_thread, libmpi), Cint, (Ptr{Cint}, Ptr{Ptr{Ptr{Cchar}}}, Cint, Ptr{Cint}), argc, argv, required, provided)
+    @mpichk @ccall libmpi.MPI_Init_thread(argc::Ptr{Cint}, argv::Ptr{Ptr{Ptr{Cchar}}}, required::Cint, provided::Ptr{Cint})::Cint
 end
 
 """
@@ -1905,7 +1905,7 @@ end
 $(_doc_external(:MPI_Initialized))
 """
 function MPI_Initialized(flag)
-    @mpichk ccall((:MPI_Initialized, libmpi), Cint, (Ptr{Cint},), flag)
+    @mpichk @ccall libmpi.MPI_Initialized(flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1914,7 +1914,7 @@ end
 $(_doc_external(:MPI_Is_thread_main))
 """
 function MPI_Is_thread_main(flag)
-    @mpichk ccall((:MPI_Is_thread_main, libmpi), Cint, (Ptr{Cint},), flag)
+    @mpichk @ccall libmpi.MPI_Is_thread_main(flag::Ptr{Cint})::Cint
 end
 
 """
@@ -1923,7 +1923,7 @@ end
 $(_doc_external(:MPI_Query_thread))
 """
 function MPI_Query_thread(provided)
-    @mpichk ccall((:MPI_Query_thread, libmpi), Cint, (Ptr{Cint},), provided)
+    @mpichk @ccall libmpi.MPI_Query_thread(provided::Ptr{Cint})::Cint
 end
 
 """
@@ -1932,7 +1932,7 @@ end
 $(_doc_external(:MPI_Aint_add))
 """
 function MPI_Aint_add(base, disp)
-    @mpichk ccall((:MPI_Aint_add, libmpi), MPI_Aint, (MPI_Aint, MPI_Aint), base, disp)
+    @mpichk @ccall libmpi.MPI_Aint_add(base::MPI_Aint, disp::MPI_Aint)::MPI_Aint
 end
 
 """
@@ -1941,7 +1941,7 @@ end
 $(_doc_external(:MPI_Aint_diff))
 """
 function MPI_Aint_diff(addr1, addr2)
-    @mpichk ccall((:MPI_Aint_diff, libmpi), MPI_Aint, (MPI_Aint, MPI_Aint), addr1, addr2)
+    @mpichk @ccall libmpi.MPI_Aint_diff(addr1::MPI_Aint, addr2::MPI_Aint)::MPI_Aint
 end
 
 """
@@ -1950,7 +1950,7 @@ end
 $(_doc_external(:MPI_Get_library_version))
 """
 function MPI_Get_library_version(version, resultlen)
-    @mpicall ccall((:MPI_Get_library_version, libmpi), Cint, (Ptr{Cchar}, Ptr{Cint}), version, resultlen)
+    @mpichk @ccall libmpi.MPI_Get_library_version(version::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -1959,7 +1959,7 @@ end
 $(_doc_external(:MPI_Get_processor_name))
 """
 function MPI_Get_processor_name(name, resultlen)
-    @mpicall ccall((:MPI_Get_processor_name, libmpi), Cint, (Ptr{Cchar}, Ptr{Cint}), name, resultlen)
+    @mpichk @ccall libmpi.MPI_Get_processor_name(name::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -1968,7 +1968,7 @@ end
 $(_doc_external(:MPI_Get_version))
 """
 function MPI_Get_version(version, subversion)
-    @mpicall ccall((:MPI_Get_version, libmpi), Cint, (Ptr{Cint}, Ptr{Cint}), version, subversion)
+    @mpichk @ccall libmpi.MPI_Get_version(version::Ptr{Cint}, subversion::Ptr{Cint})::Cint
 end
 
 """
@@ -1977,7 +1977,7 @@ end
 $(_doc_external(:MPI_Op_commutative))
 """
 function MPI_Op_commutative(op, commute)
-    @mpichk ccall((:MPI_Op_commutative, libmpi), Cint, (MPI_Op, Ptr{Cint}), op, commute)
+    @mpichk @ccall libmpi.MPI_Op_commutative(op::MPI_Op, commute::Ptr{Cint})::Cint
 end
 
 """
@@ -1986,7 +1986,7 @@ end
 $(_doc_external(:MPI_Op_create))
 """
 function MPI_Op_create(user_fn, commute, op)
-    @mpichk ccall((:MPI_Op_create, libmpi), Cint, (MPIPtr, Cint, Ptr{MPI_Op}), user_fn, commute, op)
+    @mpichk @ccall libmpi.MPI_Op_create(user_fn::MPIPtr, commute::Cint, op::Ptr{MPI_Op})::Cint
 end
 
 """
@@ -1995,7 +1995,7 @@ end
 $(_doc_external(:MPI_Op_free))
 """
 function MPI_Op_free(op)
-    @mpichk ccall((:MPI_Op_free, libmpi), Cint, (Ptr{MPI_Op},), op)
+    @mpichk @ccall libmpi.MPI_Op_free(op::Ptr{MPI_Op})::Cint
 end
 
 """
@@ -2004,7 +2004,7 @@ end
 $(_doc_external(:MPI_Parrived))
 """
 function MPI_Parrived(request, partition, flag)
-    @mpichk ccall((:MPI_Parrived, libmpi), Cint, (MPI_Request, Cint, Ptr{Cint}), request, partition, flag)
+    @mpichk @ccall libmpi.MPI_Parrived(request::MPI_Request, partition::Cint, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -2013,7 +2013,7 @@ end
 $(_doc_external(:MPI_Pready))
 """
 function MPI_Pready(partition, request)
-    @mpichk ccall((:MPI_Pready, libmpi), Cint, (Cint, MPI_Request), partition, request)
+    @mpichk @ccall libmpi.MPI_Pready(partition::Cint, request::MPI_Request)::Cint
 end
 
 """
@@ -2022,7 +2022,7 @@ end
 $(_doc_external(:MPI_Pready_list))
 """
 function MPI_Pready_list(length, array_of_partitions, request)
-    @mpichk ccall((:MPI_Pready_list, libmpi), Cint, (Cint, Ptr{Cint}, MPI_Request), length, array_of_partitions, request)
+    @mpichk @ccall libmpi.MPI_Pready_list(length::Cint, array_of_partitions::Ptr{Cint}, request::MPI_Request)::Cint
 end
 
 """
@@ -2031,7 +2031,7 @@ end
 $(_doc_external(:MPI_Pready_range))
 """
 function MPI_Pready_range(partition_low, partition_high, request)
-    @mpichk ccall((:MPI_Pready_range, libmpi), Cint, (Cint, Cint, MPI_Request), partition_low, partition_high, request)
+    @mpichk @ccall libmpi.MPI_Pready_range(partition_low::Cint, partition_high::Cint, request::MPI_Request)::Cint
 end
 
 """
@@ -2040,7 +2040,7 @@ end
 $(_doc_external(:MPI_Precv_init))
 """
 function MPI_Precv_init(buf, partitions, count, datatype, dest, tag, comm, info, request)
-    @mpichk ccall((:MPI_Precv_init, libmpi), Cint, (MPIPtr, Cint, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), buf, partitions, count, datatype, dest, tag, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Precv_init(buf::MPIPtr, partitions::Cint, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2049,7 +2049,7 @@ end
 $(_doc_external(:MPI_Psend_init))
 """
 function MPI_Psend_init(buf, partitions, count, datatype, dest, tag, comm, info, request)
-    @mpichk ccall((:MPI_Psend_init, libmpi), Cint, (MPIPtr, Cint, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), buf, partitions, count, datatype, dest, tag, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Psend_init(buf::MPIPtr, partitions::Cint, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2058,7 +2058,7 @@ end
 $(_doc_external(:MPI_Bsend))
 """
 function MPI_Bsend(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Bsend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Bsend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -2067,7 +2067,7 @@ end
 $(_doc_external(:MPI_Bsend_init))
 """
 function MPI_Bsend_init(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Bsend_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Bsend_init(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2076,7 +2076,7 @@ end
 $(_doc_external(:MPI_Buffer_attach))
 """
 function MPI_Buffer_attach(buffer, size)
-    @mpichk ccall((:MPI_Buffer_attach, libmpi), Cint, (MPIPtr, Cint), buffer, size)
+    @mpichk @ccall libmpi.MPI_Buffer_attach(buffer::MPIPtr, size::Cint)::Cint
 end
 
 """
@@ -2085,7 +2085,7 @@ end
 $(_doc_external(:MPI_Buffer_detach))
 """
 function MPI_Buffer_detach(buffer_addr, size)
-    @mpichk ccall((:MPI_Buffer_detach, libmpi), Cint, (MPIPtr, Ptr{Cint}), buffer_addr, size)
+    @mpichk @ccall libmpi.MPI_Buffer_detach(buffer_addr::MPIPtr, size::Ptr{Cint})::Cint
 end
 
 """
@@ -2094,7 +2094,7 @@ end
 $(_doc_external(:MPI_Ibsend))
 """
 function MPI_Ibsend(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Ibsend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Ibsend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2103,7 +2103,7 @@ end
 $(_doc_external(:MPI_Improbe))
 """
 function MPI_Improbe(source, tag, comm, flag, message, status)
-    @mpichk ccall((:MPI_Improbe, libmpi), Cint, (Cint, Cint, MPI_Comm, Ptr{Cint}, Ptr{MPI_Message}, Ptr{MPI_Status}), source, tag, comm, flag, message, status)
+    @mpichk @ccall libmpi.MPI_Improbe(source::Cint, tag::Cint, comm::MPI_Comm, flag::Ptr{Cint}, message::Ptr{MPI_Message}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2112,7 +2112,7 @@ end
 $(_doc_external(:MPI_Imrecv))
 """
 function MPI_Imrecv(buf, count, datatype, message, request)
-    @mpichk ccall((:MPI_Imrecv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Message}, Ptr{MPI_Request}), buf, count, datatype, message, request)
+    @mpichk @ccall libmpi.MPI_Imrecv(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, message::Ptr{MPI_Message}, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2121,7 +2121,7 @@ end
 $(_doc_external(:MPI_Iprobe))
 """
 function MPI_Iprobe(source, tag, comm, flag, status)
-    @mpichk ccall((:MPI_Iprobe, libmpi), Cint, (Cint, Cint, MPI_Comm, Ptr{Cint}, Ptr{MPI_Status}), source, tag, comm, flag, status)
+    @mpichk @ccall libmpi.MPI_Iprobe(source::Cint, tag::Cint, comm::MPI_Comm, flag::Ptr{Cint}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2130,7 +2130,7 @@ end
 $(_doc_external(:MPI_Irecv))
 """
 function MPI_Irecv(buf, count, datatype, source, tag, comm, request)
-    @mpichk ccall((:MPI_Irecv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, source, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Irecv(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2139,7 +2139,7 @@ end
 $(_doc_external(:MPI_Irsend))
 """
 function MPI_Irsend(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Irsend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Irsend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2148,7 +2148,7 @@ end
 $(_doc_external(:MPI_Isend))
 """
 function MPI_Isend(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Isend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2157,7 +2157,7 @@ end
 $(_doc_external(:MPI_Isendrecv))
 """
 function MPI_Isendrecv(sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, request)
-    @mpichk ccall((:MPI_Isendrecv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isendrecv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, dest::Cint, sendtag::Cint, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, source::Cint, recvtag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2166,7 +2166,7 @@ end
 $(_doc_external(:MPI_Isendrecv_replace))
 """
 function MPI_Isendrecv_replace(buf, count, datatype, dest, sendtag, source, recvtag, comm, request)
-    @mpichk ccall((:MPI_Isendrecv_replace, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, sendtag, source, recvtag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isendrecv_replace(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, sendtag::Cint, source::Cint, recvtag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2175,7 +2175,7 @@ end
 $(_doc_external(:MPI_Issend))
 """
 function MPI_Issend(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Issend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Issend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2184,7 +2184,7 @@ end
 $(_doc_external(:MPI_Mprobe))
 """
 function MPI_Mprobe(source, tag, comm, message, status)
-    @mpichk ccall((:MPI_Mprobe, libmpi), Cint, (Cint, Cint, MPI_Comm, Ptr{MPI_Message}, Ptr{MPI_Status}), source, tag, comm, message, status)
+    @mpichk @ccall libmpi.MPI_Mprobe(source::Cint, tag::Cint, comm::MPI_Comm, message::Ptr{MPI_Message}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2193,7 +2193,7 @@ end
 $(_doc_external(:MPI_Mrecv))
 """
 function MPI_Mrecv(buf, count, datatype, message, status)
-    @mpichk ccall((:MPI_Mrecv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Message}, Ptr{MPI_Status}), buf, count, datatype, message, status)
+    @mpichk @ccall libmpi.MPI_Mrecv(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, message::Ptr{MPI_Message}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2202,7 +2202,7 @@ end
 $(_doc_external(:MPI_Probe))
 """
 function MPI_Probe(source, tag, comm, status)
-    @mpichk ccall((:MPI_Probe, libmpi), Cint, (Cint, Cint, MPI_Comm, Ptr{MPI_Status}), source, tag, comm, status)
+    @mpichk @ccall libmpi.MPI_Probe(source::Cint, tag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2211,7 +2211,7 @@ end
 $(_doc_external(:MPI_Recv))
 """
 function MPI_Recv(buf, count, datatype, source, tag, comm, status)
-    @mpichk ccall((:MPI_Recv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), buf, count, datatype, source, tag, comm, status)
+    @mpichk @ccall libmpi.MPI_Recv(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2220,7 +2220,7 @@ end
 $(_doc_external(:MPI_Recv_init))
 """
 function MPI_Recv_init(buf, count, datatype, source, tag, comm, request)
-    @mpichk ccall((:MPI_Recv_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, source, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Recv_init(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2229,7 +2229,7 @@ end
 $(_doc_external(:MPI_Rsend))
 """
 function MPI_Rsend(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Rsend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Rsend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -2238,7 +2238,7 @@ end
 $(_doc_external(:MPI_Rsend_init))
 """
 function MPI_Rsend_init(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Rsend_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Rsend_init(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2247,7 +2247,7 @@ end
 $(_doc_external(:MPI_Send))
 """
 function MPI_Send(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Send, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Send(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -2256,7 +2256,7 @@ end
 $(_doc_external(:MPI_Send_init))
 """
 function MPI_Send_init(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Send_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Send_init(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2265,7 +2265,7 @@ end
 $(_doc_external(:MPI_Sendrecv))
 """
 function MPI_Sendrecv(sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, status)
-    @mpichk ccall((:MPI_Sendrecv, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, status)
+    @mpichk @ccall libmpi.MPI_Sendrecv(sendbuf::MPIPtr, sendcount::Cint, sendtype::MPI_Datatype, dest::Cint, sendtag::Cint, recvbuf::MPIPtr, recvcount::Cint, recvtype::MPI_Datatype, source::Cint, recvtag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2274,7 +2274,7 @@ end
 $(_doc_external(:MPI_Sendrecv_replace))
 """
 function MPI_Sendrecv_replace(buf, count, datatype, dest, sendtag, source, recvtag, comm, status)
-    @mpichk ccall((:MPI_Sendrecv_replace, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), buf, count, datatype, dest, sendtag, source, recvtag, comm, status)
+    @mpichk @ccall libmpi.MPI_Sendrecv_replace(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, sendtag::Cint, source::Cint, recvtag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2283,7 +2283,7 @@ end
 $(_doc_external(:MPI_Ssend))
 """
 function MPI_Ssend(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Ssend, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Ssend(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -2292,7 +2292,7 @@ end
 $(_doc_external(:MPI_Ssend_init))
 """
 function MPI_Ssend_init(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Ssend_init, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Ssend_init(buf::MPIPtr, count::Cint, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2301,7 +2301,7 @@ end
 $(_doc_external(:MPI_Cancel))
 """
 function MPI_Cancel(request)
-    @mpichk ccall((:MPI_Cancel, libmpi), Cint, (Ptr{MPI_Request},), request)
+    @mpichk @ccall libmpi.MPI_Cancel(request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2310,7 +2310,7 @@ end
 $(_doc_external(:MPI_Grequest_complete))
 """
 function MPI_Grequest_complete(request)
-    @mpichk ccall((:MPI_Grequest_complete, libmpi), Cint, (MPI_Request,), request)
+    @mpichk @ccall libmpi.MPI_Grequest_complete(request::MPI_Request)::Cint
 end
 
 """
@@ -2319,7 +2319,7 @@ end
 $(_doc_external(:MPI_Grequest_start))
 """
 function MPI_Grequest_start(query_fn, free_fn, cancel_fn, extra_state, request)
-    @mpichk ccall((:MPI_Grequest_start, libmpi), Cint, (MPIPtr, MPIPtr, MPIPtr, MPIPtr, Ptr{MPI_Request}), query_fn, free_fn, cancel_fn, extra_state, request)
+    @mpichk @ccall libmpi.MPI_Grequest_start(query_fn::MPIPtr, free_fn::MPIPtr, cancel_fn::MPIPtr, extra_state::MPIPtr, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2328,7 +2328,7 @@ end
 $(_doc_external(:MPI_Request_free))
 """
 function MPI_Request_free(request)
-    @mpichk ccall((:MPI_Request_free, libmpi), Cint, (Ptr{MPI_Request},), request)
+    @mpichk @ccall libmpi.MPI_Request_free(request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2337,7 +2337,7 @@ end
 $(_doc_external(:MPI_Request_get_status))
 """
 function MPI_Request_get_status(request, flag, status)
-    @mpichk ccall((:MPI_Request_get_status, libmpi), Cint, (MPI_Request, Ptr{Cint}, Ptr{MPI_Status}), request, flag, status)
+    @mpichk @ccall libmpi.MPI_Request_get_status(request::MPI_Request, flag::Ptr{Cint}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2346,7 +2346,7 @@ end
 $(_doc_external(:MPI_Start))
 """
 function MPI_Start(request)
-    @mpichk ccall((:MPI_Start, libmpi), Cint, (Ptr{MPI_Request},), request)
+    @mpichk @ccall libmpi.MPI_Start(request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2355,7 +2355,7 @@ end
 $(_doc_external(:MPI_Startall))
 """
 function MPI_Startall(count, array_of_requests)
-    @mpichk ccall((:MPI_Startall, libmpi), Cint, (Cint, Ptr{MPI_Request}), count, array_of_requests)
+    @mpichk @ccall libmpi.MPI_Startall(count::Cint, array_of_requests::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2364,7 +2364,7 @@ end
 $(_doc_external(:MPI_Status_set_cancelled))
 """
 function MPI_Status_set_cancelled(status, flag)
-    @mpichk ccall((:MPI_Status_set_cancelled, libmpi), Cint, (Ptr{MPI_Status}, Cint), status, flag)
+    @mpichk @ccall libmpi.MPI_Status_set_cancelled(status::Ptr{MPI_Status}, flag::Cint)::Cint
 end
 
 """
@@ -2373,7 +2373,7 @@ end
 $(_doc_external(:MPI_Test_cancelled))
 """
 function MPI_Test_cancelled(status, flag)
-    @mpichk ccall((:MPI_Test_cancelled, libmpi), Cint, (Ptr{MPI_Status}, Ptr{Cint}), status, flag)
+    @mpichk @ccall libmpi.MPI_Test_cancelled(status::Ptr{MPI_Status}, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -2382,7 +2382,7 @@ end
 $(_doc_external(:MPI_Testall))
 """
 function MPI_Testall(count, array_of_requests, flag, array_of_statuses)
-    @mpichk ccall((:MPI_Testall, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{MPI_Status}), count, array_of_requests, flag, array_of_statuses)
+    @mpichk @ccall libmpi.MPI_Testall(count::Cint, array_of_requests::Ptr{MPI_Request}, flag::Ptr{Cint}, array_of_statuses::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2391,7 +2391,7 @@ end
 $(_doc_external(:MPI_Testany))
 """
 function MPI_Testany(count, array_of_requests, indx, flag, status)
-    @mpichk ccall((:MPI_Testany, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Status}), count, array_of_requests, indx, flag, status)
+    @mpichk @ccall libmpi.MPI_Testany(count::Cint, array_of_requests::Ptr{MPI_Request}, indx::Ptr{Cint}, flag::Ptr{Cint}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2400,7 +2400,7 @@ end
 $(_doc_external(:MPI_Testsome))
 """
 function MPI_Testsome(incount, array_of_requests, outcount, array_of_indices, array_of_statuses)
-    @mpichk ccall((:MPI_Testsome, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Status}), incount, array_of_requests, outcount, array_of_indices, array_of_statuses)
+    @mpichk @ccall libmpi.MPI_Testsome(incount::Cint, array_of_requests::Ptr{MPI_Request}, outcount::Ptr{Cint}, array_of_indices::Ptr{Cint}, array_of_statuses::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2409,7 +2409,7 @@ end
 $(_doc_external(:MPI_Waitall))
 """
 function MPI_Waitall(count, array_of_requests, array_of_statuses)
-    @mpichk ccall((:MPI_Waitall, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{MPI_Status}), count, array_of_requests, array_of_statuses)
+    @mpichk @ccall libmpi.MPI_Waitall(count::Cint, array_of_requests::Ptr{MPI_Request}, array_of_statuses::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2418,7 +2418,7 @@ end
 $(_doc_external(:MPI_Waitany))
 """
 function MPI_Waitany(count, array_of_requests, indx, status)
-    @mpichk ccall((:MPI_Waitany, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{MPI_Status}), count, array_of_requests, indx, status)
+    @mpichk @ccall libmpi.MPI_Waitany(count::Cint, array_of_requests::Ptr{MPI_Request}, indx::Ptr{Cint}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2427,7 +2427,7 @@ end
 $(_doc_external(:MPI_Waitsome))
 """
 function MPI_Waitsome(incount, array_of_requests, outcount, array_of_indices, array_of_statuses)
-    @mpichk ccall((:MPI_Waitsome, libmpi), Cint, (Cint, Ptr{MPI_Request}, Ptr{Cint}, Ptr{Cint}, Ptr{MPI_Status}), incount, array_of_requests, outcount, array_of_indices, array_of_statuses)
+    @mpichk @ccall libmpi.MPI_Waitsome(incount::Cint, array_of_requests::Ptr{MPI_Request}, outcount::Ptr{Cint}, array_of_indices::Ptr{Cint}, array_of_statuses::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -2436,7 +2436,7 @@ end
 $(_doc_external(:MPI_Accumulate))
 """
 function MPI_Accumulate(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
-    @mpichk ccall((:MPI_Accumulate, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Op, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
+    @mpichk @ccall libmpi.MPI_Accumulate(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win)::Cint
 end
 
 """
@@ -2445,7 +2445,7 @@ end
 $(_doc_external(:MPI_Alloc_mem))
 """
 function MPI_Alloc_mem(size, info, baseptr)
-    @mpichk ccall((:MPI_Alloc_mem, libmpi), Cint, (MPI_Aint, MPI_Info, MPIPtr), size, info, baseptr)
+    @mpichk @ccall libmpi.MPI_Alloc_mem(size::MPI_Aint, info::MPI_Info, baseptr::MPIPtr)::Cint
 end
 
 """
@@ -2454,7 +2454,7 @@ end
 $(_doc_external(:MPI_Compare_and_swap))
 """
 function MPI_Compare_and_swap(origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win)
-    @mpichk ccall((:MPI_Compare_and_swap, libmpi), Cint, (MPIPtr, MPIPtr, MPIPtr, MPI_Datatype, Cint, MPI_Aint, MPI_Win), origin_addr, compare_addr, result_addr, datatype, target_rank, target_disp, win)
+    @mpichk @ccall libmpi.MPI_Compare_and_swap(origin_addr::MPIPtr, compare_addr::MPIPtr, result_addr::MPIPtr, datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, win::MPI_Win)::Cint
 end
 
 """
@@ -2463,7 +2463,7 @@ end
 $(_doc_external(:MPI_Fetch_and_op))
 """
 function MPI_Fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp, op, win)
-    @mpichk ccall((:MPI_Fetch_and_op, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Datatype, Cint, MPI_Aint, MPI_Op, MPI_Win), origin_addr, result_addr, datatype, target_rank, target_disp, op, win)
+    @mpichk @ccall libmpi.MPI_Fetch_and_op(origin_addr::MPIPtr, result_addr::MPIPtr, datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, op::MPI_Op, win::MPI_Win)::Cint
 end
 
 """
@@ -2472,7 +2472,7 @@ end
 $(_doc_external(:MPI_Free_mem))
 """
 function MPI_Free_mem(base)
-    @mpichk ccall((:MPI_Free_mem, libmpi), Cint, (MPIPtr,), base)
+    @mpichk @ccall libmpi.MPI_Free_mem(base::MPIPtr)::Cint
 end
 
 """
@@ -2481,7 +2481,7 @@ end
 $(_doc_external(:MPI_Get))
 """
 function MPI_Get(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
-    @mpichk ccall((:MPI_Get, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
+    @mpichk @ccall libmpi.MPI_Get(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, win::MPI_Win)::Cint
 end
 
 """
@@ -2490,7 +2490,7 @@ end
 $(_doc_external(:MPI_Get_accumulate))
 """
 function MPI_Get_accumulate(origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
-    @mpichk ccall((:MPI_Get_accumulate, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Op, MPI_Win), origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
+    @mpichk @ccall libmpi.MPI_Get_accumulate(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, result_addr::MPIPtr, result_count::Cint, result_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win)::Cint
 end
 
 """
@@ -2499,7 +2499,7 @@ end
 $(_doc_external(:MPI_Put))
 """
 function MPI_Put(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
-    @mpichk ccall((:MPI_Put, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
+    @mpichk @ccall libmpi.MPI_Put(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, win::MPI_Win)::Cint
 end
 
 """
@@ -2508,7 +2508,7 @@ end
 $(_doc_external(:MPI_Raccumulate))
 """
 function MPI_Raccumulate(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
-    @mpichk ccall((:MPI_Raccumulate, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Op, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
+    @mpichk @ccall libmpi.MPI_Raccumulate(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2517,7 +2517,7 @@ end
 $(_doc_external(:MPI_Rget))
 """
 function MPI_Rget(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
-    @mpichk ccall((:MPI_Rget, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
+    @mpichk @ccall libmpi.MPI_Rget(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2526,7 +2526,7 @@ end
 $(_doc_external(:MPI_Rget_accumulate))
 """
 function MPI_Rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
-    @mpichk ccall((:MPI_Rget_accumulate, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Op, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
+    @mpichk @ccall libmpi.MPI_Rget_accumulate(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, result_addr::MPIPtr, result_count::Cint, result_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2535,7 +2535,7 @@ end
 $(_doc_external(:MPI_Rput))
 """
 function MPI_Rput(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
-    @mpichk ccall((:MPI_Rput, libmpi), Cint, (MPIPtr, Cint, MPI_Datatype, Cint, MPI_Aint, Cint, MPI_Datatype, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
+    @mpichk @ccall libmpi.MPI_Rput(origin_addr::MPIPtr, origin_count::Cint, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::Cint, target_datatype::MPI_Datatype, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -2544,7 +2544,7 @@ end
 $(_doc_external(:MPI_Win_allocate))
 """
 function MPI_Win_allocate(size, disp_unit, info, comm, baseptr, win)
-    @mpichk ccall((:MPI_Win_allocate, libmpi), Cint, (MPI_Aint, Cint, MPI_Info, MPI_Comm, MPIPtr, Ptr{MPI_Win}), size, disp_unit, info, comm, baseptr, win)
+    @mpichk @ccall libmpi.MPI_Win_allocate(size::MPI_Aint, disp_unit::Cint, info::MPI_Info, comm::MPI_Comm, baseptr::MPIPtr, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -2553,7 +2553,7 @@ end
 $(_doc_external(:MPI_Win_allocate_shared))
 """
 function MPI_Win_allocate_shared(size, disp_unit, info, comm, baseptr, win)
-    @mpichk ccall((:MPI_Win_allocate_shared, libmpi), Cint, (MPI_Aint, Cint, MPI_Info, MPI_Comm, MPIPtr, Ptr{MPI_Win}), size, disp_unit, info, comm, baseptr, win)
+    @mpichk @ccall libmpi.MPI_Win_allocate_shared(size::MPI_Aint, disp_unit::Cint, info::MPI_Info, comm::MPI_Comm, baseptr::MPIPtr, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -2562,7 +2562,7 @@ end
 $(_doc_external(:MPI_Win_attach))
 """
 function MPI_Win_attach(win, base, size)
-    @mpichk ccall((:MPI_Win_attach, libmpi), Cint, (MPI_Win, MPIPtr, MPI_Aint), win, base, size)
+    @mpichk @ccall libmpi.MPI_Win_attach(win::MPI_Win, base::MPIPtr, size::MPI_Aint)::Cint
 end
 
 """
@@ -2571,7 +2571,7 @@ end
 $(_doc_external(:MPI_Win_complete))
 """
 function MPI_Win_complete(win)
-    @mpichk ccall((:MPI_Win_complete, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_complete(win::MPI_Win)::Cint
 end
 
 """
@@ -2580,7 +2580,7 @@ end
 $(_doc_external(:MPI_Win_create))
 """
 function MPI_Win_create(base, size, disp_unit, info, comm, win)
-    @mpichk ccall((:MPI_Win_create, libmpi), Cint, (MPIPtr, MPI_Aint, Cint, MPI_Info, MPI_Comm, Ptr{MPI_Win}), base, size, disp_unit, info, comm, win)
+    @mpichk @ccall libmpi.MPI_Win_create(base::MPIPtr, size::MPI_Aint, disp_unit::Cint, info::MPI_Info, comm::MPI_Comm, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -2589,7 +2589,7 @@ end
 $(_doc_external(:MPI_Win_create_dynamic))
 """
 function MPI_Win_create_dynamic(info, comm, win)
-    @mpichk ccall((:MPI_Win_create_dynamic, libmpi), Cint, (MPI_Info, MPI_Comm, Ptr{MPI_Win}), info, comm, win)
+    @mpichk @ccall libmpi.MPI_Win_create_dynamic(info::MPI_Info, comm::MPI_Comm, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -2598,7 +2598,7 @@ end
 $(_doc_external(:MPI_Win_detach))
 """
 function MPI_Win_detach(win, base)
-    @mpichk ccall((:MPI_Win_detach, libmpi), Cint, (MPI_Win, MPIPtr), win, base)
+    @mpichk @ccall libmpi.MPI_Win_detach(win::MPI_Win, base::MPIPtr)::Cint
 end
 
 """
@@ -2607,7 +2607,7 @@ end
 $(_doc_external(:MPI_Win_fence))
 """
 function MPI_Win_fence(assert, win)
-    @mpichk ccall((:MPI_Win_fence, libmpi), Cint, (Cint, MPI_Win), assert, win)
+    @mpichk @ccall libmpi.MPI_Win_fence(assert::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2616,7 +2616,7 @@ end
 $(_doc_external(:MPI_Win_flush))
 """
 function MPI_Win_flush(rank, win)
-    @mpichk ccall((:MPI_Win_flush, libmpi), Cint, (Cint, MPI_Win), rank, win)
+    @mpichk @ccall libmpi.MPI_Win_flush(rank::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2625,7 +2625,7 @@ end
 $(_doc_external(:MPI_Win_flush_all))
 """
 function MPI_Win_flush_all(win)
-    @mpichk ccall((:MPI_Win_flush_all, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_flush_all(win::MPI_Win)::Cint
 end
 
 """
@@ -2634,7 +2634,7 @@ end
 $(_doc_external(:MPI_Win_flush_local))
 """
 function MPI_Win_flush_local(rank, win)
-    @mpichk ccall((:MPI_Win_flush_local, libmpi), Cint, (Cint, MPI_Win), rank, win)
+    @mpichk @ccall libmpi.MPI_Win_flush_local(rank::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2643,7 +2643,7 @@ end
 $(_doc_external(:MPI_Win_flush_local_all))
 """
 function MPI_Win_flush_local_all(win)
-    @mpichk ccall((:MPI_Win_flush_local_all, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_flush_local_all(win::MPI_Win)::Cint
 end
 
 """
@@ -2652,7 +2652,7 @@ end
 $(_doc_external(:MPI_Win_free))
 """
 function MPI_Win_free(win)
-    @mpichk ccall((:MPI_Win_free, libmpi), Cint, (Ptr{MPI_Win},), win)
+    @mpichk @ccall libmpi.MPI_Win_free(win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -2661,7 +2661,7 @@ end
 $(_doc_external(:MPI_Win_get_group))
 """
 function MPI_Win_get_group(win, group)
-    @mpichk ccall((:MPI_Win_get_group, libmpi), Cint, (MPI_Win, Ptr{MPI_Group}), win, group)
+    @mpichk @ccall libmpi.MPI_Win_get_group(win::MPI_Win, group::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -2670,7 +2670,7 @@ end
 $(_doc_external(:MPI_Win_get_info))
 """
 function MPI_Win_get_info(win, info_used)
-    @mpichk ccall((:MPI_Win_get_info, libmpi), Cint, (MPI_Win, Ptr{MPI_Info}), win, info_used)
+    @mpichk @ccall libmpi.MPI_Win_get_info(win::MPI_Win, info_used::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -2679,7 +2679,7 @@ end
 $(_doc_external(:MPI_Win_get_name))
 """
 function MPI_Win_get_name(win, win_name, resultlen)
-    @mpichk ccall((:MPI_Win_get_name, libmpi), Cint, (MPI_Win, Ptr{Cchar}, Ptr{Cint}), win, win_name, resultlen)
+    @mpichk @ccall libmpi.MPI_Win_get_name(win::MPI_Win, win_name::Ptr{Cchar}, resultlen::Ptr{Cint})::Cint
 end
 
 """
@@ -2688,7 +2688,7 @@ end
 $(_doc_external(:MPI_Win_lock))
 """
 function MPI_Win_lock(lock_type, rank, assert, win)
-    @mpichk ccall((:MPI_Win_lock, libmpi), Cint, (Cint, Cint, Cint, MPI_Win), lock_type, rank, assert, win)
+    @mpichk @ccall libmpi.MPI_Win_lock(lock_type::Cint, rank::Cint, assert::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2697,7 +2697,7 @@ end
 $(_doc_external(:MPI_Win_lock_all))
 """
 function MPI_Win_lock_all(assert, win)
-    @mpichk ccall((:MPI_Win_lock_all, libmpi), Cint, (Cint, MPI_Win), assert, win)
+    @mpichk @ccall libmpi.MPI_Win_lock_all(assert::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2706,7 +2706,7 @@ end
 $(_doc_external(:MPI_Win_post))
 """
 function MPI_Win_post(group, assert, win)
-    @mpichk ccall((:MPI_Win_post, libmpi), Cint, (MPI_Group, Cint, MPI_Win), group, assert, win)
+    @mpichk @ccall libmpi.MPI_Win_post(group::MPI_Group, assert::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2715,7 +2715,7 @@ end
 $(_doc_external(:MPI_Win_set_info))
 """
 function MPI_Win_set_info(win, info)
-    @mpichk ccall((:MPI_Win_set_info, libmpi), Cint, (MPI_Win, MPI_Info), win, info)
+    @mpichk @ccall libmpi.MPI_Win_set_info(win::MPI_Win, info::MPI_Info)::Cint
 end
 
 """
@@ -2724,7 +2724,7 @@ end
 $(_doc_external(:MPI_Win_set_name))
 """
 function MPI_Win_set_name(win, win_name)
-    @mpichk ccall((:MPI_Win_set_name, libmpi), Cint, (MPI_Win, Ptr{Cchar}), win, win_name)
+    @mpichk @ccall libmpi.MPI_Win_set_name(win::MPI_Win, win_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2733,7 +2733,7 @@ end
 $(_doc_external(:MPI_Win_shared_query))
 """
 function MPI_Win_shared_query(win, rank, size, disp_unit, baseptr)
-    @mpichk ccall((:MPI_Win_shared_query, libmpi), Cint, (MPI_Win, Cint, Ptr{MPI_Aint}, Ptr{Cint}, MPIPtr), win, rank, size, disp_unit, baseptr)
+    @mpichk @ccall libmpi.MPI_Win_shared_query(win::MPI_Win, rank::Cint, size::Ptr{MPI_Aint}, disp_unit::Ptr{Cint}, baseptr::MPIPtr)::Cint
 end
 
 """
@@ -2742,7 +2742,7 @@ end
 $(_doc_external(:MPI_Win_start))
 """
 function MPI_Win_start(group, assert, win)
-    @mpichk ccall((:MPI_Win_start, libmpi), Cint, (MPI_Group, Cint, MPI_Win), group, assert, win)
+    @mpichk @ccall libmpi.MPI_Win_start(group::MPI_Group, assert::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2751,7 +2751,7 @@ end
 $(_doc_external(:MPI_Win_sync))
 """
 function MPI_Win_sync(win)
-    @mpichk ccall((:MPI_Win_sync, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_sync(win::MPI_Win)::Cint
 end
 
 """
@@ -2760,7 +2760,7 @@ end
 $(_doc_external(:MPI_Win_test))
 """
 function MPI_Win_test(win, flag)
-    @mpichk ccall((:MPI_Win_test, libmpi), Cint, (MPI_Win, Ptr{Cint}), win, flag)
+    @mpichk @ccall libmpi.MPI_Win_test(win::MPI_Win, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -2769,7 +2769,7 @@ end
 $(_doc_external(:MPI_Win_unlock))
 """
 function MPI_Win_unlock(rank, win)
-    @mpichk ccall((:MPI_Win_unlock, libmpi), Cint, (Cint, MPI_Win), rank, win)
+    @mpichk @ccall libmpi.MPI_Win_unlock(rank::Cint, win::MPI_Win)::Cint
 end
 
 """
@@ -2778,7 +2778,7 @@ end
 $(_doc_external(:MPI_Win_unlock_all))
 """
 function MPI_Win_unlock_all(win)
-    @mpichk ccall((:MPI_Win_unlock_all, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_unlock_all(win::MPI_Win)::Cint
 end
 
 """
@@ -2787,7 +2787,7 @@ end
 $(_doc_external(:MPI_Win_wait))
 """
 function MPI_Win_wait(win)
-    @mpichk ccall((:MPI_Win_wait, libmpi), Cint, (MPI_Win,), win)
+    @mpichk @ccall libmpi.MPI_Win_wait(win::MPI_Win)::Cint
 end
 
 """
@@ -2796,7 +2796,7 @@ end
 $(_doc_external(:MPI_Close_port))
 """
 function MPI_Close_port(port_name)
-    @mpichk ccall((:MPI_Close_port, libmpi), Cint, (Ptr{Cchar},), port_name)
+    @mpichk @ccall libmpi.MPI_Close_port(port_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2805,7 +2805,7 @@ end
 $(_doc_external(:MPI_Comm_accept))
 """
 function MPI_Comm_accept(port_name, info, root, comm, newcomm)
-    @mpichk ccall((:MPI_Comm_accept, libmpi), Cint, (Ptr{Cchar}, MPI_Info, Cint, MPI_Comm, Ptr{MPI_Comm}), port_name, info, root, comm, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_accept(port_name::Ptr{Cchar}, info::MPI_Info, root::Cint, comm::MPI_Comm, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2814,7 +2814,7 @@ end
 $(_doc_external(:MPI_Comm_connect))
 """
 function MPI_Comm_connect(port_name, info, root, comm, newcomm)
-    @mpichk ccall((:MPI_Comm_connect, libmpi), Cint, (Ptr{Cchar}, MPI_Info, Cint, MPI_Comm, Ptr{MPI_Comm}), port_name, info, root, comm, newcomm)
+    @mpichk @ccall libmpi.MPI_Comm_connect(port_name::Ptr{Cchar}, info::MPI_Info, root::Cint, comm::MPI_Comm, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2823,7 +2823,7 @@ end
 $(_doc_external(:MPI_Comm_disconnect))
 """
 function MPI_Comm_disconnect(comm)
-    @mpichk ccall((:MPI_Comm_disconnect, libmpi), Cint, (Ptr{MPI_Comm},), comm)
+    @mpichk @ccall libmpi.MPI_Comm_disconnect(comm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2832,7 +2832,7 @@ end
 $(_doc_external(:MPI_Comm_get_parent))
 """
 function MPI_Comm_get_parent(parent)
-    @mpichk ccall((:MPI_Comm_get_parent, libmpi), Cint, (Ptr{MPI_Comm},), parent)
+    @mpichk @ccall libmpi.MPI_Comm_get_parent(parent::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2841,7 +2841,7 @@ end
 $(_doc_external(:MPI_Comm_join))
 """
 function MPI_Comm_join(fd, intercomm)
-    @mpichk ccall((:MPI_Comm_join, libmpi), Cint, (Cint, Ptr{MPI_Comm}), fd, intercomm)
+    @mpichk @ccall libmpi.MPI_Comm_join(fd::Cint, intercomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2850,7 +2850,7 @@ end
 $(_doc_external(:MPI_Comm_spawn))
 """
 function MPI_Comm_spawn(command, argv, maxprocs, info, root, comm, intercomm, array_of_errcodes)
-    @mpichk ccall((:MPI_Comm_spawn, libmpi), Cint, (Ptr{Cchar}, Ptr{Ptr{Cchar}}, Cint, MPI_Info, Cint, MPI_Comm, Ptr{MPI_Comm}, Ptr{Cint}), command, argv, maxprocs, info, root, comm, intercomm, array_of_errcodes)
+    @mpichk @ccall libmpi.MPI_Comm_spawn(command::Ptr{Cchar}, argv::Ptr{Ptr{Cchar}}, maxprocs::Cint, info::MPI_Info, root::Cint, comm::MPI_Comm, intercomm::Ptr{MPI_Comm}, array_of_errcodes::Ptr{Cint})::Cint
 end
 
 """
@@ -2859,7 +2859,7 @@ end
 $(_doc_external(:MPI_Comm_spawn_multiple))
 """
 function MPI_Comm_spawn_multiple(count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info, root, comm, intercomm, array_of_errcodes)
-    @mpichk ccall((:MPI_Comm_spawn_multiple, libmpi), Cint, (Cint, Ptr{Ptr{Cchar}}, Ptr{Ptr{Ptr{Cchar}}}, Ptr{Cint}, Ptr{MPI_Info}, Cint, MPI_Comm, Ptr{MPI_Comm}, Ptr{Cint}), count, array_of_commands, array_of_argv, array_of_maxprocs, array_of_info, root, comm, intercomm, array_of_errcodes)
+    @mpichk @ccall libmpi.MPI_Comm_spawn_multiple(count::Cint, array_of_commands::Ptr{Ptr{Cchar}}, array_of_argv::Ptr{Ptr{Ptr{Cchar}}}, array_of_maxprocs::Ptr{Cint}, array_of_info::Ptr{MPI_Info}, root::Cint, comm::MPI_Comm, intercomm::Ptr{MPI_Comm}, array_of_errcodes::Ptr{Cint})::Cint
 end
 
 """
@@ -2868,7 +2868,7 @@ end
 $(_doc_external(:MPI_Lookup_name))
 """
 function MPI_Lookup_name(service_name, info, port_name)
-    @mpichk ccall((:MPI_Lookup_name, libmpi), Cint, (Ptr{Cchar}, MPI_Info, Ptr{Cchar}), service_name, info, port_name)
+    @mpichk @ccall libmpi.MPI_Lookup_name(service_name::Ptr{Cchar}, info::MPI_Info, port_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2877,7 +2877,7 @@ end
 $(_doc_external(:MPI_Open_port))
 """
 function MPI_Open_port(info, port_name)
-    @mpichk ccall((:MPI_Open_port, libmpi), Cint, (MPI_Info, Ptr{Cchar}), info, port_name)
+    @mpichk @ccall libmpi.MPI_Open_port(info::MPI_Info, port_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2886,7 +2886,7 @@ end
 $(_doc_external(:MPI_Publish_name))
 """
 function MPI_Publish_name(service_name, info, port_name)
-    @mpichk ccall((:MPI_Publish_name, libmpi), Cint, (Ptr{Cchar}, MPI_Info, Ptr{Cchar}), service_name, info, port_name)
+    @mpichk @ccall libmpi.MPI_Publish_name(service_name::Ptr{Cchar}, info::MPI_Info, port_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2895,7 +2895,7 @@ end
 $(_doc_external(:MPI_Unpublish_name))
 """
 function MPI_Unpublish_name(service_name, info, port_name)
-    @mpichk ccall((:MPI_Unpublish_name, libmpi), Cint, (Ptr{Cchar}, MPI_Info, Ptr{Cchar}), service_name, info, port_name)
+    @mpichk @ccall libmpi.MPI_Unpublish_name(service_name::Ptr{Cchar}, info::MPI_Info, port_name::Ptr{Cchar})::Cint
 end
 
 """
@@ -2904,7 +2904,7 @@ end
 $(_doc_external(:MPI_Wtick))
 """
 function MPI_Wtick()
-    @mpicall ccall((:MPI_Wtick, libmpi), Cdouble, ())
+    @mpichk @ccall libmpi.MPI_Wtick()::Cdouble
 end
 
 """
@@ -2913,7 +2913,7 @@ end
 $(_doc_external(:MPI_Wtime))
 """
 function MPI_Wtime()
-    @mpicall ccall((:MPI_Wtime, libmpi), Cdouble, ())
+    @mpichk @ccall libmpi.MPI_Wtime()::Cdouble
 end
 
 """
@@ -2922,7 +2922,7 @@ end
 $(_doc_external(:MPI_Cart_coords))
 """
 function MPI_Cart_coords(comm, rank, maxdims, coords)
-    @mpichk ccall((:MPI_Cart_coords, libmpi), Cint, (MPI_Comm, Cint, Cint, Ptr{Cint}), comm, rank, maxdims, coords)
+    @mpichk @ccall libmpi.MPI_Cart_coords(comm::MPI_Comm, rank::Cint, maxdims::Cint, coords::Ptr{Cint})::Cint
 end
 
 """
@@ -2931,7 +2931,7 @@ end
 $(_doc_external(:MPI_Cart_create))
 """
 function MPI_Cart_create(comm_old, ndims, dims, periods, reorder, comm_cart)
-    @mpichk ccall((:MPI_Cart_create, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{MPI_Comm}), comm_old, ndims, dims, periods, reorder, comm_cart)
+    @mpichk @ccall libmpi.MPI_Cart_create(comm_old::MPI_Comm, ndims::Cint, dims::Ptr{Cint}, periods::Ptr{Cint}, reorder::Cint, comm_cart::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2940,7 +2940,7 @@ end
 $(_doc_external(:MPI_Cart_get))
 """
 function MPI_Cart_get(comm, maxdims, dims, periods, coords)
-    @mpichk ccall((:MPI_Cart_get, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), comm, maxdims, dims, periods, coords)
+    @mpichk @ccall libmpi.MPI_Cart_get(comm::MPI_Comm, maxdims::Cint, dims::Ptr{Cint}, periods::Ptr{Cint}, coords::Ptr{Cint})::Cint
 end
 
 """
@@ -2949,7 +2949,7 @@ end
 $(_doc_external(:MPI_Cart_map))
 """
 function MPI_Cart_map(comm, ndims, dims, periods, newrank)
-    @mpichk ccall((:MPI_Cart_map, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), comm, ndims, dims, periods, newrank)
+    @mpichk @ccall libmpi.MPI_Cart_map(comm::MPI_Comm, ndims::Cint, dims::Ptr{Cint}, periods::Ptr{Cint}, newrank::Ptr{Cint})::Cint
 end
 
 """
@@ -2958,7 +2958,7 @@ end
 $(_doc_external(:MPI_Cart_rank))
 """
 function MPI_Cart_rank(comm, coords, rank)
-    @mpichk ccall((:MPI_Cart_rank, libmpi), Cint, (MPI_Comm, Ptr{Cint}, Ptr{Cint}), comm, coords, rank)
+    @mpichk @ccall libmpi.MPI_Cart_rank(comm::MPI_Comm, coords::Ptr{Cint}, rank::Ptr{Cint})::Cint
 end
 
 """
@@ -2967,7 +2967,7 @@ end
 $(_doc_external(:MPI_Cart_shift))
 """
 function MPI_Cart_shift(comm, direction, disp, rank_source, rank_dest)
-    @mpichk ccall((:MPI_Cart_shift, libmpi), Cint, (MPI_Comm, Cint, Cint, Ptr{Cint}, Ptr{Cint}), comm, direction, disp, rank_source, rank_dest)
+    @mpichk @ccall libmpi.MPI_Cart_shift(comm::MPI_Comm, direction::Cint, disp::Cint, rank_source::Ptr{Cint}, rank_dest::Ptr{Cint})::Cint
 end
 
 """
@@ -2976,7 +2976,7 @@ end
 $(_doc_external(:MPI_Cart_sub))
 """
 function MPI_Cart_sub(comm, remain_dims, newcomm)
-    @mpichk ccall((:MPI_Cart_sub, libmpi), Cint, (MPI_Comm, Ptr{Cint}, Ptr{MPI_Comm}), comm, remain_dims, newcomm)
+    @mpichk @ccall libmpi.MPI_Cart_sub(comm::MPI_Comm, remain_dims::Ptr{Cint}, newcomm::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -2985,7 +2985,7 @@ end
 $(_doc_external(:MPI_Cartdim_get))
 """
 function MPI_Cartdim_get(comm, ndims)
-    @mpichk ccall((:MPI_Cartdim_get, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, ndims)
+    @mpichk @ccall libmpi.MPI_Cartdim_get(comm::MPI_Comm, ndims::Ptr{Cint})::Cint
 end
 
 """
@@ -2994,7 +2994,7 @@ end
 $(_doc_external(:MPI_Dims_create))
 """
 function MPI_Dims_create(nnodes, ndims, dims)
-    @mpichk ccall((:MPI_Dims_create, libmpi), Cint, (Cint, Cint, Ptr{Cint}), nnodes, ndims, dims)
+    @mpichk @ccall libmpi.MPI_Dims_create(nnodes::Cint, ndims::Cint, dims::Ptr{Cint})::Cint
 end
 
 """
@@ -3003,7 +3003,7 @@ end
 $(_doc_external(:MPI_Dist_graph_create))
 """
 function MPI_Dist_graph_create(comm_old, n, sources, degrees, destinations, weights, info, reorder, comm_dist_graph)
-    @mpichk ccall((:MPI_Dist_graph_create, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, MPI_Info, Cint, Ptr{MPI_Comm}), comm_old, n, sources, degrees, destinations, weights, info, reorder, comm_dist_graph) v"2.2.0"
+    @mpichk @ccall libmpi.MPI_Dist_graph_create(comm_old::MPI_Comm, n::Cint, sources::Ptr{Cint}, degrees::Ptr{Cint}, destinations::Ptr{Cint}, weights::Ptr{Cint}, info::MPI_Info, reorder::Cint, comm_dist_graph::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -3012,7 +3012,7 @@ end
 $(_doc_external(:MPI_Dist_graph_create_adjacent))
 """
 function MPI_Dist_graph_create_adjacent(comm_old, indegree, sources, sourceweights, outdegree, destinations, destweights, info, reorder, comm_dist_graph)
-    @mpichk ccall((:MPI_Dist_graph_create_adjacent, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{Cint}, Ptr{Cint}, MPI_Info, Cint, Ptr{MPI_Comm}), comm_old, indegree, sources, sourceweights, outdegree, destinations, destweights, info, reorder, comm_dist_graph) v"2.2.0"
+    @mpichk @ccall libmpi.MPI_Dist_graph_create_adjacent(comm_old::MPI_Comm, indegree::Cint, sources::Ptr{Cint}, sourceweights::Ptr{Cint}, outdegree::Cint, destinations::Ptr{Cint}, destweights::Ptr{Cint}, info::MPI_Info, reorder::Cint, comm_dist_graph::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -3021,7 +3021,7 @@ end
 $(_doc_external(:MPI_Dist_graph_neighbors))
 """
 function MPI_Dist_graph_neighbors(comm, maxindegree, sources, sourceweights, maxoutdegree, destinations, destweights)
-    @mpichk ccall((:MPI_Dist_graph_neighbors, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{Cint}, Ptr{Cint}), comm, maxindegree, sources, sourceweights, maxoutdegree, destinations, destweights) v"2.2.0"
+    @mpichk @ccall libmpi.MPI_Dist_graph_neighbors(comm::MPI_Comm, maxindegree::Cint, sources::Ptr{Cint}, sourceweights::Ptr{Cint}, maxoutdegree::Cint, destinations::Ptr{Cint}, destweights::Ptr{Cint})::Cint
 end
 
 """
@@ -3030,7 +3030,7 @@ end
 $(_doc_external(:MPI_Dist_graph_neighbors_count))
 """
 function MPI_Dist_graph_neighbors_count(comm, indegree, outdegree, weighted)
-    @mpichk ccall((:MPI_Dist_graph_neighbors_count, libmpi), Cint, (MPI_Comm, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), comm, indegree, outdegree, weighted) v"2.2.0"
+    @mpichk @ccall libmpi.MPI_Dist_graph_neighbors_count(comm::MPI_Comm, indegree::Ptr{Cint}, outdegree::Ptr{Cint}, weighted::Ptr{Cint})::Cint
 end
 
 """
@@ -3039,7 +3039,7 @@ end
 $(_doc_external(:MPI_Graph_create))
 """
 function MPI_Graph_create(comm_old, nnodes, indx, edges, reorder, comm_graph)
-    @mpichk ccall((:MPI_Graph_create, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Cint, Ptr{MPI_Comm}), comm_old, nnodes, indx, edges, reorder, comm_graph)
+    @mpichk @ccall libmpi.MPI_Graph_create(comm_old::MPI_Comm, nnodes::Cint, indx::Ptr{Cint}, edges::Ptr{Cint}, reorder::Cint, comm_graph::Ptr{MPI_Comm})::Cint
 end
 
 """
@@ -3048,7 +3048,7 @@ end
 $(_doc_external(:MPI_Graph_get))
 """
 function MPI_Graph_get(comm, maxindex, maxedges, indx, edges)
-    @mpichk ccall((:MPI_Graph_get, libmpi), Cint, (MPI_Comm, Cint, Cint, Ptr{Cint}, Ptr{Cint}), comm, maxindex, maxedges, indx, edges)
+    @mpichk @ccall libmpi.MPI_Graph_get(comm::MPI_Comm, maxindex::Cint, maxedges::Cint, indx::Ptr{Cint}, edges::Ptr{Cint})::Cint
 end
 
 """
@@ -3057,7 +3057,7 @@ end
 $(_doc_external(:MPI_Graph_map))
 """
 function MPI_Graph_map(comm, nnodes, indx, edges, newrank)
-    @mpichk ccall((:MPI_Graph_map, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}), comm, nnodes, indx, edges, newrank)
+    @mpichk @ccall libmpi.MPI_Graph_map(comm::MPI_Comm, nnodes::Cint, indx::Ptr{Cint}, edges::Ptr{Cint}, newrank::Ptr{Cint})::Cint
 end
 
 """
@@ -3066,7 +3066,7 @@ end
 $(_doc_external(:MPI_Graph_neighbors))
 """
 function MPI_Graph_neighbors(comm, rank, maxneighbors, neighbors)
-    @mpichk ccall((:MPI_Graph_neighbors, libmpi), Cint, (MPI_Comm, Cint, Cint, Ptr{Cint}), comm, rank, maxneighbors, neighbors)
+    @mpichk @ccall libmpi.MPI_Graph_neighbors(comm::MPI_Comm, rank::Cint, maxneighbors::Cint, neighbors::Ptr{Cint})::Cint
 end
 
 """
@@ -3075,7 +3075,7 @@ end
 $(_doc_external(:MPI_Graph_neighbors_count))
 """
 function MPI_Graph_neighbors_count(comm, rank, nneighbors)
-    @mpichk ccall((:MPI_Graph_neighbors_count, libmpi), Cint, (MPI_Comm, Cint, Ptr{Cint}), comm, rank, nneighbors)
+    @mpichk @ccall libmpi.MPI_Graph_neighbors_count(comm::MPI_Comm, rank::Cint, nneighbors::Ptr{Cint})::Cint
 end
 
 """
@@ -3084,7 +3084,7 @@ end
 $(_doc_external(:MPI_Graphdims_get))
 """
 function MPI_Graphdims_get(comm, nnodes, nedges)
-    @mpichk ccall((:MPI_Graphdims_get, libmpi), Cint, (MPI_Comm, Ptr{Cint}, Ptr{Cint}), comm, nnodes, nedges)
+    @mpichk @ccall libmpi.MPI_Graphdims_get(comm::MPI_Comm, nnodes::Ptr{Cint}, nedges::Ptr{Cint})::Cint
 end
 
 """
@@ -3093,7 +3093,7 @@ end
 $(_doc_external(:MPI_Topo_test))
 """
 function MPI_Topo_test(comm, status)
-    @mpichk ccall((:MPI_Topo_test, libmpi), Cint, (MPI_Comm, Ptr{Cint}), comm, status)
+    @mpichk @ccall libmpi.MPI_Topo_test(comm::MPI_Comm, status::Ptr{Cint})::Cint
 end
 
 """
@@ -3102,7 +3102,7 @@ end
 $(_doc_external(:MPI_Allgather_c))
 """
 function MPI_Allgather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Allgather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Allgather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3111,7 +3111,7 @@ end
 $(_doc_external(:MPI_Allgather_init_c))
 """
 function MPI_Allgather_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Allgather_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allgather_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3120,7 +3120,7 @@ end
 $(_doc_external(:MPI_Allgatherv_c))
 """
 function MPI_Allgatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
-    @mpichk ccall((:MPI_Allgatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Allgatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3129,7 +3129,7 @@ end
 $(_doc_external(:MPI_Allgatherv_init_c))
 """
 function MPI_Allgatherv_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Allgatherv_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allgatherv_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3138,7 +3138,7 @@ end
 $(_doc_external(:MPI_Allreduce_c))
 """
 function MPI_Allreduce_c(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Allreduce_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Allreduce_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3147,7 +3147,7 @@ end
 $(_doc_external(:MPI_Allreduce_init_c))
 """
 function MPI_Allreduce_init_c(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Allreduce_init_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Allreduce_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3156,7 +3156,7 @@ end
 $(_doc_external(:MPI_Alltoall_c))
 """
 function MPI_Alltoall_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Alltoall_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Alltoall_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3165,7 +3165,7 @@ end
 $(_doc_external(:MPI_Alltoall_init_c))
 """
 function MPI_Alltoall_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Alltoall_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoall_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3174,7 +3174,7 @@ end
 $(_doc_external(:MPI_Alltoallv_c))
 """
 function MPI_Alltoallv_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
-    @mpichk ccall((:MPI_Alltoallv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Alltoallv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3183,7 +3183,7 @@ end
 $(_doc_external(:MPI_Alltoallv_init_c))
 """
 function MPI_Alltoallv_init_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Alltoallv_init_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoallv_init_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3192,7 +3192,7 @@ end
 $(_doc_external(:MPI_Alltoallw_c))
 """
 function MPI_Alltoallw_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
-    @mpichk ccall((:MPI_Alltoallw_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
+    @mpichk @ccall libmpi.MPI_Alltoallw_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3201,7 +3201,7 @@ end
 $(_doc_external(:MPI_Alltoallw_init_c))
 """
 function MPI_Alltoallw_init_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
-    @mpichk ccall((:MPI_Alltoallw_init_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Alltoallw_init_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3210,7 +3210,7 @@ end
 $(_doc_external(:MPI_Bcast_c))
 """
 function MPI_Bcast_c(buffer, count, datatype, root, comm)
-    @mpichk ccall((:MPI_Bcast_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm), buffer, count, datatype, root, comm)
+    @mpichk @ccall libmpi.MPI_Bcast_c(buffer::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3219,7 +3219,7 @@ end
 $(_doc_external(:MPI_Bcast_init_c))
 """
 function MPI_Bcast_init_c(buffer, count, datatype, root, comm, info, request)
-    @mpichk ccall((:MPI_Bcast_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), buffer, count, datatype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Bcast_init_c(buffer::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3228,7 +3228,7 @@ end
 $(_doc_external(:MPI_Exscan_c))
 """
 function MPI_Exscan_c(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Exscan_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Exscan_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3237,7 +3237,7 @@ end
 $(_doc_external(:MPI_Exscan_init_c))
 """
 function MPI_Exscan_init_c(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Exscan_init_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Exscan_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3246,7 +3246,7 @@ end
 $(_doc_external(:MPI_Gather_c))
 """
 function MPI_Gather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Gather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Gather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3255,7 +3255,7 @@ end
 $(_doc_external(:MPI_Gather_init_c))
 """
 function MPI_Gather_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Gather_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Gather_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3264,7 +3264,7 @@ end
 $(_doc_external(:MPI_Gatherv_c))
 """
 function MPI_Gatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm)
-    @mpichk ccall((:MPI_Gatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Gatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3273,7 +3273,7 @@ end
 $(_doc_external(:MPI_Gatherv_init_c))
 """
 function MPI_Gatherv_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Gatherv_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Gatherv_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3282,7 +3282,7 @@ end
 $(_doc_external(:MPI_Iallgather_c))
 """
 function MPI_Iallgather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Iallgather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallgather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3291,7 +3291,7 @@ end
 $(_doc_external(:MPI_Iallgatherv_c))
 """
 function MPI_Iallgatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
-    @mpichk ccall((:MPI_Iallgatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallgatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3300,7 +3300,7 @@ end
 $(_doc_external(:MPI_Iallreduce_c))
 """
 function MPI_Iallreduce_c(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iallreduce_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iallreduce_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3309,7 +3309,7 @@ end
 $(_doc_external(:MPI_Ialltoall_c))
 """
 function MPI_Ialltoall_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ialltoall_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoall_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3318,7 +3318,7 @@ end
 $(_doc_external(:MPI_Ialltoallv_c))
 """
 function MPI_Ialltoallv_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ialltoallv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoallv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3327,7 +3327,7 @@ end
 $(_doc_external(:MPI_Ialltoallw_c))
 """
 function MPI_Ialltoallw_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
-    @mpichk ccall((:MPI_Ialltoallw_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
+    @mpichk @ccall libmpi.MPI_Ialltoallw_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3336,7 +3336,7 @@ end
 $(_doc_external(:MPI_Ibcast_c))
 """
 function MPI_Ibcast_c(buffer, count, datatype, root, comm, request)
-    @mpichk ccall((:MPI_Ibcast_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), buffer, count, datatype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Ibcast_c(buffer::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3345,7 +3345,7 @@ end
 $(_doc_external(:MPI_Iexscan_c))
 """
 function MPI_Iexscan_c(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iexscan_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iexscan_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3354,7 +3354,7 @@ end
 $(_doc_external(:MPI_Igather_c))
 """
 function MPI_Igather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Igather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Igather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3363,7 +3363,7 @@ end
 $(_doc_external(:MPI_Igatherv_c))
 """
 function MPI_Igatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Igatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Igatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3372,7 +3372,7 @@ end
 $(_doc_external(:MPI_Ineighbor_allgather_c))
 """
 function MPI_Ineighbor_allgather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_allgather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_allgather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3381,7 +3381,7 @@ end
 $(_doc_external(:MPI_Ineighbor_allgatherv_c))
 """
 function MPI_Ineighbor_allgatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_allgatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_allgatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3390,7 +3390,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoall_c))
 """
 function MPI_Ineighbor_alltoall_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoall_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoall_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3399,7 +3399,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoallv_c))
 """
 function MPI_Ineighbor_alltoallv_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoallv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoallv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3408,7 +3408,7 @@ end
 $(_doc_external(:MPI_Ineighbor_alltoallw_c))
 """
 function MPI_Ineighbor_alltoallw_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
-    @mpichk ccall((:MPI_Ineighbor_alltoallw_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request)
+    @mpichk @ccall libmpi.MPI_Ineighbor_alltoallw_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3417,7 +3417,7 @@ end
 $(_doc_external(:MPI_Ireduce_c))
 """
 function MPI_Ireduce_c(sendbuf, recvbuf, count, datatype, op, root, comm, request)
-    @mpichk ccall((:MPI_Ireduce_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3426,7 +3426,7 @@ end
 $(_doc_external(:MPI_Ireduce_scatter_c))
 """
 function MPI_Ireduce_scatter_c(sendbuf, recvbuf, recvcounts, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Ireduce_scatter_c, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{MPI_Count}, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, recvcounts, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce_scatter_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3435,7 +3435,7 @@ end
 $(_doc_external(:MPI_Ireduce_scatter_block_c))
 """
 function MPI_Ireduce_scatter_block_c(sendbuf, recvbuf, recvcount, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Ireduce_scatter_block_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, recvcount, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Ireduce_scatter_block_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3444,7 +3444,7 @@ end
 $(_doc_external(:MPI_Iscan_c))
 """
 function MPI_Iscan_c(sendbuf, recvbuf, count, datatype, op, comm, request)
-    @mpichk ccall((:MPI_Iscan_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscan_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3453,7 +3453,7 @@ end
 $(_doc_external(:MPI_Iscatter_c))
 """
 function MPI_Iscatter_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Iscatter_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscatter_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3462,7 +3462,7 @@ end
 $(_doc_external(:MPI_Iscatterv_c))
 """
 function MPI_Iscatterv_c(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
-    @mpichk ccall((:MPI_Iscatterv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, request)
+    @mpichk @ccall libmpi.MPI_Iscatterv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3471,7 +3471,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgather_c))
 """
 function MPI_Neighbor_allgather_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_allgather_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgather_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3480,7 +3480,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgather_init_c))
 """
 function MPI_Neighbor_allgather_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_allgather_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgather_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3489,7 +3489,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgatherv_c))
 """
 function MPI_Neighbor_allgatherv_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_allgatherv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgatherv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3498,7 +3498,7 @@ end
 $(_doc_external(:MPI_Neighbor_allgatherv_init_c))
 """
 function MPI_Neighbor_allgatherv_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_allgatherv_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_allgatherv_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3507,7 +3507,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoall_c))
 """
 function MPI_Neighbor_alltoall_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoall_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoall_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3516,7 +3516,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoall_init_c))
 """
 function MPI_Neighbor_alltoall_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoall_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoall_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3525,7 +3525,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallv_c))
 """
 function MPI_Neighbor_alltoallv_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoallv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3534,7 +3534,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallv_init_c))
 """
 function MPI_Neighbor_alltoallv_init_c(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoallv_init_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallv_init_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtype::MPI_Datatype, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3543,7 +3543,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallw_c))
 """
 function MPI_Neighbor_alltoallw_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
-    @mpichk ccall((:MPI_Neighbor_alltoallw_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallw_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3552,7 +3552,7 @@ end
 $(_doc_external(:MPI_Neighbor_alltoallw_init_c))
 """
 function MPI_Neighbor_alltoallw_init_c(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
-    @mpichk ccall((:MPI_Neighbor_alltoallw_init_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, Ptr{MPI_Datatype}, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Neighbor_alltoallw_init_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, sdispls::Ptr{MPI_Aint}, sendtypes::Ptr{MPI_Datatype}, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, rdispls::Ptr{MPI_Aint}, recvtypes::Ptr{MPI_Datatype}, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3561,7 +3561,7 @@ end
 $(_doc_external(:MPI_Reduce_c))
 """
 function MPI_Reduce_c(sendbuf, recvbuf, count, datatype, op, root, comm)
-    @mpichk ccall((:MPI_Reduce_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, Cint, MPI_Comm), sendbuf, recvbuf, count, datatype, op, root, comm)
+    @mpichk @ccall libmpi.MPI_Reduce_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3570,7 +3570,7 @@ end
 $(_doc_external(:MPI_Reduce_init_c))
 """
 function MPI_Reduce_init_c(sendbuf, recvbuf, count, datatype, op, root, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_init_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3579,7 +3579,7 @@ end
 $(_doc_external(:MPI_Reduce_local_c))
 """
 function MPI_Reduce_local_c(inbuf, inoutbuf, count, datatype, op)
-    @mpichk ccall((:MPI_Reduce_local_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op), inbuf, inoutbuf, count, datatype, op)
+    @mpichk @ccall libmpi.MPI_Reduce_local_c(inbuf::MPIPtr, inoutbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op)::Cint
 end
 
 """
@@ -3588,7 +3588,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_c))
 """
 function MPI_Reduce_scatter_c(sendbuf, recvbuf, recvcounts, datatype, op, comm)
-    @mpichk ccall((:MPI_Reduce_scatter_c, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{MPI_Count}, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, recvcounts, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3597,7 +3597,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_block_c))
 """
 function MPI_Reduce_scatter_block_c(sendbuf, recvbuf, recvcount, datatype, op, comm)
-    @mpichk ccall((:MPI_Reduce_scatter_block_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, recvcount, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_block_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3606,7 +3606,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_block_init_c))
 """
 function MPI_Reduce_scatter_block_init_c(sendbuf, recvbuf, recvcount, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_scatter_block_init_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, recvcount, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_block_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcount::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3615,7 +3615,7 @@ end
 $(_doc_external(:MPI_Reduce_scatter_init_c))
 """
 function MPI_Reduce_scatter_init_c(sendbuf, recvbuf, recvcounts, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Reduce_scatter_init_c, libmpi), Cint, (MPIPtr, MPIPtr, Ptr{MPI_Count}, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, recvcounts, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Reduce_scatter_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, recvcounts::Ptr{MPI_Count}, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3624,7 +3624,7 @@ end
 $(_doc_external(:MPI_Scan_c))
 """
 function MPI_Scan_c(sendbuf, recvbuf, count, datatype, op, comm)
-    @mpichk ccall((:MPI_Scan_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm), sendbuf, recvbuf, count, datatype, op, comm)
+    @mpichk @ccall libmpi.MPI_Scan_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3633,7 +3633,7 @@ end
 $(_doc_external(:MPI_Scan_init_c))
 """
 function MPI_Scan_init_c(sendbuf, recvbuf, count, datatype, op, comm, info, request)
-    @mpichk ccall((:MPI_Scan_init_c, libmpi), Cint, (MPIPtr, MPIPtr, MPI_Count, MPI_Datatype, MPI_Op, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, recvbuf, count, datatype, op, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scan_init_c(sendbuf::MPIPtr, recvbuf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, op::MPI_Op, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3642,7 +3642,7 @@ end
 $(_doc_external(:MPI_Scatter_c))
 """
 function MPI_Scatter_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Scatter_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Scatter_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3651,7 +3651,7 @@ end
 $(_doc_external(:MPI_Scatter_init_c))
 """
 function MPI_Scatter_init_c(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Scatter_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scatter_init_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3660,7 +3660,7 @@ end
 $(_doc_external(:MPI_Scatterv_c))
 """
 function MPI_Scatterv_c(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm)
-    @mpichk ccall((:MPI_Scatterv_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm)
+    @mpichk @ccall libmpi.MPI_Scatterv_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3669,7 +3669,7 @@ end
 $(_doc_external(:MPI_Scatterv_init_c))
 """
 function MPI_Scatterv_init_c(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
-    @mpichk ccall((:MPI_Scatterv_init_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}, Ptr{MPI_Aint}, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Comm, MPI_Info, Ptr{MPI_Request}), sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, info, request)
+    @mpichk @ccall libmpi.MPI_Scatterv_init_c(sendbuf::MPIPtr, sendcounts::Ptr{MPI_Count}, displs::Ptr{MPI_Aint}, sendtype::MPI_Datatype, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, root::Cint, comm::MPI_Comm, info::MPI_Info, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3678,7 +3678,7 @@ end
 $(_doc_external(:MPI_Get_count_c))
 """
 function MPI_Get_count_c(status, datatype, count)
-    @mpichk ccall((:MPI_Get_count_c, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Ptr{MPI_Count}), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Get_count_c(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3687,7 +3687,7 @@ end
 $(_doc_external(:MPI_Get_elements_c))
 """
 function MPI_Get_elements_c(status, datatype, count)
-    @mpichk ccall((:MPI_Get_elements_c, libmpi), Cint, (Ptr{MPI_Status}, MPI_Datatype, Ptr{MPI_Count}), status, datatype, count)
+    @mpichk @ccall libmpi.MPI_Get_elements_c(status::Ptr{MPI_Status}, datatype::MPI_Datatype, count::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3696,7 +3696,7 @@ end
 $(_doc_external(:MPI_Pack_c))
 """
 function MPI_Pack_c(inbuf, incount, datatype, outbuf, outsize, position, comm)
-    @mpichk ccall((:MPI_Pack_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, Ptr{MPI_Count}, MPI_Comm), inbuf, incount, datatype, outbuf, outsize, position, comm)
+    @mpichk @ccall libmpi.MPI_Pack_c(inbuf::MPIPtr, incount::MPI_Count, datatype::MPI_Datatype, outbuf::MPIPtr, outsize::MPI_Count, position::Ptr{MPI_Count}, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3705,7 +3705,7 @@ end
 $(_doc_external(:MPI_Pack_external_c))
 """
 function MPI_Pack_external_c(datarep, inbuf, incount, datatype, outbuf, outsize, position)
-    @mpichk ccall((:MPI_Pack_external_c, libmpi), Cint, (Ptr{Cchar}, MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, Ptr{MPI_Count}), datarep, inbuf, incount, datatype, outbuf, outsize, position)
+    @mpichk @ccall libmpi.MPI_Pack_external_c(datarep::Ptr{Cchar}, inbuf::MPIPtr, incount::MPI_Count, datatype::MPI_Datatype, outbuf::MPIPtr, outsize::MPI_Count, position::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3714,7 +3714,7 @@ end
 $(_doc_external(:MPI_Pack_external_size_c))
 """
 function MPI_Pack_external_size_c(datarep, incount, datatype, size)
-    @mpichk ccall((:MPI_Pack_external_size_c, libmpi), Cint, (Ptr{Cchar}, MPI_Count, MPI_Datatype, Ptr{MPI_Count}), datarep, incount, datatype, size)
+    @mpichk @ccall libmpi.MPI_Pack_external_size_c(datarep::Ptr{Cchar}, incount::MPI_Count, datatype::MPI_Datatype, size::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3723,7 +3723,7 @@ end
 $(_doc_external(:MPI_Pack_size_c))
 """
 function MPI_Pack_size_c(incount, datatype, comm, size)
-    @mpichk ccall((:MPI_Pack_size_c, libmpi), Cint, (MPI_Count, MPI_Datatype, MPI_Comm, Ptr{MPI_Count}), incount, datatype, comm, size)
+    @mpichk @ccall libmpi.MPI_Pack_size_c(incount::MPI_Count, datatype::MPI_Datatype, comm::MPI_Comm, size::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3732,7 +3732,7 @@ end
 $(_doc_external(:MPI_Type_contiguous_c))
 """
 function MPI_Type_contiguous_c(count, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_contiguous_c, libmpi), Cint, (MPI_Count, MPI_Datatype, Ptr{MPI_Datatype}), count, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_contiguous_c(count::MPI_Count, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3741,7 +3741,7 @@ end
 $(_doc_external(:MPI_Type_create_darray_c))
 """
 function MPI_Type_create_darray_c(size, rank, ndims, array_of_gsizes, array_of_distribs, array_of_dargs, array_of_psizes, order, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_darray_c, libmpi), Cint, (Cint, Cint, Cint, Ptr{MPI_Count}, Ptr{Cint}, Ptr{Cint}, Ptr{Cint}, Cint, MPI_Datatype, Ptr{MPI_Datatype}), size, rank, ndims, array_of_gsizes, array_of_distribs, array_of_dargs, array_of_psizes, order, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_darray_c(size::Cint, rank::Cint, ndims::Cint, array_of_gsizes::Ptr{MPI_Count}, array_of_distribs::Ptr{Cint}, array_of_dargs::Ptr{Cint}, array_of_psizes::Ptr{Cint}, order::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3750,7 +3750,7 @@ end
 $(_doc_external(:MPI_Type_create_hindexed_c))
 """
 function MPI_Type_create_hindexed_c(count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hindexed_c, libmpi), Cint, (MPI_Count, Ptr{MPI_Count}, Ptr{MPI_Count}, MPI_Datatype, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hindexed_c(count::MPI_Count, array_of_blocklengths::Ptr{MPI_Count}, array_of_displacements::Ptr{MPI_Count}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3759,7 +3759,7 @@ end
 $(_doc_external(:MPI_Type_create_hindexed_block_c))
 """
 function MPI_Type_create_hindexed_block_c(count, blocklength, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hindexed_block_c, libmpi), Cint, (MPI_Count, MPI_Count, Ptr{MPI_Count}, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hindexed_block_c(count::MPI_Count, blocklength::MPI_Count, array_of_displacements::Ptr{MPI_Count}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3768,7 +3768,7 @@ end
 $(_doc_external(:MPI_Type_create_hvector_c))
 """
 function MPI_Type_create_hvector_c(count, blocklength, stride, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_hvector_c, libmpi), Cint, (MPI_Count, MPI_Count, MPI_Count, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, stride, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_hvector_c(count::MPI_Count, blocklength::MPI_Count, stride::MPI_Count, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3777,7 +3777,7 @@ end
 $(_doc_external(:MPI_Type_create_indexed_block_c))
 """
 function MPI_Type_create_indexed_block_c(count, blocklength, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_indexed_block_c, libmpi), Cint, (MPI_Count, MPI_Count, Ptr{MPI_Count}, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_indexed_block_c(count::MPI_Count, blocklength::MPI_Count, array_of_displacements::Ptr{MPI_Count}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3786,7 +3786,7 @@ end
 $(_doc_external(:MPI_Type_create_resized_c))
 """
 function MPI_Type_create_resized_c(oldtype, lb, extent, newtype)
-    @mpichk ccall((:MPI_Type_create_resized_c, libmpi), Cint, (MPI_Datatype, MPI_Count, MPI_Count, Ptr{MPI_Datatype}), oldtype, lb, extent, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_resized_c(oldtype::MPI_Datatype, lb::MPI_Count, extent::MPI_Count, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3795,7 +3795,7 @@ end
 $(_doc_external(:MPI_Type_create_struct_c))
 """
 function MPI_Type_create_struct_c(count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
-    @mpichk ccall((:MPI_Type_create_struct_c, libmpi), Cint, (MPI_Count, Ptr{MPI_Count}, Ptr{MPI_Count}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, array_of_types, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_struct_c(count::MPI_Count, array_of_blocklengths::Ptr{MPI_Count}, array_of_displacements::Ptr{MPI_Count}, array_of_types::Ptr{MPI_Datatype}, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3804,7 +3804,7 @@ end
 $(_doc_external(:MPI_Type_create_subarray_c))
 """
 function MPI_Type_create_subarray_c(ndims, array_of_sizes, array_of_subsizes, array_of_starts, order, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_create_subarray_c, libmpi), Cint, (Cint, Ptr{MPI_Count}, Ptr{MPI_Count}, Ptr{MPI_Count}, Cint, MPI_Datatype, Ptr{MPI_Datatype}), ndims, array_of_sizes, array_of_subsizes, array_of_starts, order, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_create_subarray_c(ndims::Cint, array_of_sizes::Ptr{MPI_Count}, array_of_subsizes::Ptr{MPI_Count}, array_of_starts::Ptr{MPI_Count}, order::Cint, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3813,7 +3813,7 @@ end
 $(_doc_external(:MPI_Type_get_contents_c))
 """
 function MPI_Type_get_contents_c(datatype, max_integers, max_addresses, max_large_counts, max_datatypes, array_of_integers, array_of_addresses, array_of_large_counts, array_of_datatypes)
-    @mpichk ccall((:MPI_Type_get_contents_c, libmpi), Cint, (MPI_Datatype, MPI_Count, MPI_Count, MPI_Count, MPI_Count, Ptr{Cint}, Ptr{MPI_Aint}, Ptr{MPI_Count}, Ptr{MPI_Datatype}), datatype, max_integers, max_addresses, max_large_counts, max_datatypes, array_of_integers, array_of_addresses, array_of_large_counts, array_of_datatypes)
+    @mpichk @ccall libmpi.MPI_Type_get_contents_c(datatype::MPI_Datatype, max_integers::MPI_Count, max_addresses::MPI_Count, max_large_counts::MPI_Count, max_datatypes::MPI_Count, array_of_integers::Ptr{Cint}, array_of_addresses::Ptr{MPI_Aint}, array_of_large_counts::Ptr{MPI_Count}, array_of_datatypes::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3822,7 +3822,7 @@ end
 $(_doc_external(:MPI_Type_get_envelope_c))
 """
 function MPI_Type_get_envelope_c(datatype, num_integers, num_addresses, num_large_counts, num_datatypes, combiner)
-    @mpichk ccall((:MPI_Type_get_envelope_c, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}, Ptr{MPI_Count}, Ptr{MPI_Count}, Ptr{MPI_Count}, Ptr{Cint}), datatype, num_integers, num_addresses, num_large_counts, num_datatypes, combiner)
+    @mpichk @ccall libmpi.MPI_Type_get_envelope_c(datatype::MPI_Datatype, num_integers::Ptr{MPI_Count}, num_addresses::Ptr{MPI_Count}, num_large_counts::Ptr{MPI_Count}, num_datatypes::Ptr{MPI_Count}, combiner::Ptr{Cint})::Cint
 end
 
 """
@@ -3831,7 +3831,7 @@ end
 $(_doc_external(:MPI_Type_get_extent_c))
 """
 function MPI_Type_get_extent_c(datatype, lb, extent)
-    @mpichk ccall((:MPI_Type_get_extent_c, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}, Ptr{MPI_Count}), datatype, lb, extent)
+    @mpichk @ccall libmpi.MPI_Type_get_extent_c(datatype::MPI_Datatype, lb::Ptr{MPI_Count}, extent::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3840,7 +3840,7 @@ end
 $(_doc_external(:MPI_Type_get_true_extent_c))
 """
 function MPI_Type_get_true_extent_c(datatype, true_lb, true_extent)
-    @mpichk ccall((:MPI_Type_get_true_extent_c, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}, Ptr{MPI_Count}), datatype, true_lb, true_extent)
+    @mpichk @ccall libmpi.MPI_Type_get_true_extent_c(datatype::MPI_Datatype, true_lb::Ptr{MPI_Count}, true_extent::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3849,7 +3849,7 @@ end
 $(_doc_external(:MPI_Type_indexed_c))
 """
 function MPI_Type_indexed_c(count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_indexed_c, libmpi), Cint, (MPI_Count, Ptr{MPI_Count}, Ptr{MPI_Count}, MPI_Datatype, Ptr{MPI_Datatype}), count, array_of_blocklengths, array_of_displacements, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_indexed_c(count::MPI_Count, array_of_blocklengths::Ptr{MPI_Count}, array_of_displacements::Ptr{MPI_Count}, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3858,7 +3858,7 @@ end
 $(_doc_external(:MPI_Type_size_c))
 """
 function MPI_Type_size_c(datatype, size)
-    @mpichk ccall((:MPI_Type_size_c, libmpi), Cint, (MPI_Datatype, Ptr{MPI_Count}), datatype, size)
+    @mpichk @ccall libmpi.MPI_Type_size_c(datatype::MPI_Datatype, size::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3867,7 +3867,7 @@ end
 $(_doc_external(:MPI_Type_vector_c))
 """
 function MPI_Type_vector_c(count, blocklength, stride, oldtype, newtype)
-    @mpichk ccall((:MPI_Type_vector_c, libmpi), Cint, (MPI_Count, MPI_Count, MPI_Count, MPI_Datatype, Ptr{MPI_Datatype}), count, blocklength, stride, oldtype, newtype)
+    @mpichk @ccall libmpi.MPI_Type_vector_c(count::MPI_Count, blocklength::MPI_Count, stride::MPI_Count, oldtype::MPI_Datatype, newtype::Ptr{MPI_Datatype})::Cint
 end
 
 """
@@ -3876,7 +3876,7 @@ end
 $(_doc_external(:MPI_Unpack_c))
 """
 function MPI_Unpack_c(inbuf, insize, position, outbuf, outcount, datatype, comm)
-    @mpichk ccall((:MPI_Unpack_c, libmpi), Cint, (MPIPtr, MPI_Count, Ptr{MPI_Count}, MPIPtr, MPI_Count, MPI_Datatype, MPI_Comm), inbuf, insize, position, outbuf, outcount, datatype, comm)
+    @mpichk @ccall libmpi.MPI_Unpack_c(inbuf::MPIPtr, insize::MPI_Count, position::Ptr{MPI_Count}, outbuf::MPIPtr, outcount::MPI_Count, datatype::MPI_Datatype, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3885,7 +3885,7 @@ end
 $(_doc_external(:MPI_Unpack_external_c))
 """
 function MPI_Unpack_external_c(datarep, inbuf, insize, position, outbuf, outcount, datatype)
-    @mpichk ccall((:MPI_Unpack_external_c, libmpi), Cint, (Ptr{Cchar}, MPIPtr, MPI_Count, Ptr{MPI_Count}, MPIPtr, MPI_Count, MPI_Datatype), datarep, inbuf, insize, position, outbuf, outcount, datatype)
+    @mpichk @ccall libmpi.MPI_Unpack_external_c(datarep::Ptr{Cchar}, inbuf::MPIPtr, insize::MPI_Count, position::Ptr{MPI_Count}, outbuf::MPIPtr, outcount::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -3894,7 +3894,7 @@ end
 $(_doc_external(:MPI_Op_create_c))
 """
 function MPI_Op_create_c(user_fn, commute, op)
-    @mpichk ccall((:MPI_Op_create_c, libmpi), Cint, (MPIPtr, Cint, Ptr{MPI_Op}), user_fn, commute, op)
+    @mpichk @ccall libmpi.MPI_Op_create_c(user_fn::MPIPtr, commute::Cint, op::Ptr{MPI_Op})::Cint
 end
 
 """
@@ -3903,7 +3903,7 @@ end
 $(_doc_external(:MPI_Bsend_c))
 """
 function MPI_Bsend_c(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Bsend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Bsend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -3912,7 +3912,7 @@ end
 $(_doc_external(:MPI_Bsend_init_c))
 """
 function MPI_Bsend_init_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Bsend_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Bsend_init_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3921,7 +3921,7 @@ end
 $(_doc_external(:MPI_Buffer_attach_c))
 """
 function MPI_Buffer_attach_c(buffer, size)
-    @mpichk ccall((:MPI_Buffer_attach_c, libmpi), Cint, (MPIPtr, MPI_Count), buffer, size)
+    @mpichk @ccall libmpi.MPI_Buffer_attach_c(buffer::MPIPtr, size::MPI_Count)::Cint
 end
 
 """
@@ -3930,7 +3930,7 @@ end
 $(_doc_external(:MPI_Buffer_detach_c))
 """
 function MPI_Buffer_detach_c(buffer_addr, size)
-    @mpichk ccall((:MPI_Buffer_detach_c, libmpi), Cint, (MPIPtr, Ptr{MPI_Count}), buffer_addr, size)
+    @mpichk @ccall libmpi.MPI_Buffer_detach_c(buffer_addr::MPIPtr, size::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -3939,7 +3939,7 @@ end
 $(_doc_external(:MPI_Ibsend_c))
 """
 function MPI_Ibsend_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Ibsend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Ibsend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3948,7 +3948,7 @@ end
 $(_doc_external(:MPI_Imrecv_c))
 """
 function MPI_Imrecv_c(buf, count, datatype, message, request)
-    @mpichk ccall((:MPI_Imrecv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Message}, Ptr{MPI_Request}), buf, count, datatype, message, request)
+    @mpichk @ccall libmpi.MPI_Imrecv_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, message::Ptr{MPI_Message}, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3957,7 +3957,7 @@ end
 $(_doc_external(:MPI_Irecv_c))
 """
 function MPI_Irecv_c(buf, count, datatype, source, tag, comm, request)
-    @mpichk ccall((:MPI_Irecv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, source, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Irecv_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3966,7 +3966,7 @@ end
 $(_doc_external(:MPI_Irsend_c))
 """
 function MPI_Irsend_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Irsend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Irsend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3975,7 +3975,7 @@ end
 $(_doc_external(:MPI_Isend_c))
 """
 function MPI_Isend_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Isend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3984,7 +3984,7 @@ end
 $(_doc_external(:MPI_Isendrecv_c))
 """
 function MPI_Isendrecv_c(sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, request)
-    @mpichk ccall((:MPI_Isendrecv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isendrecv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, dest::Cint, sendtag::Cint, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, source::Cint, recvtag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -3993,7 +3993,7 @@ end
 $(_doc_external(:MPI_Isendrecv_replace_c))
 """
 function MPI_Isendrecv_replace_c(buf, count, datatype, dest, sendtag, source, recvtag, comm, request)
-    @mpichk ccall((:MPI_Isendrecv_replace_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, sendtag, source, recvtag, comm, request)
+    @mpichk @ccall libmpi.MPI_Isendrecv_replace_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, sendtag::Cint, source::Cint, recvtag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4002,7 +4002,7 @@ end
 $(_doc_external(:MPI_Issend_c))
 """
 function MPI_Issend_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Issend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Issend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4011,7 +4011,7 @@ end
 $(_doc_external(:MPI_Mrecv_c))
 """
 function MPI_Mrecv_c(buf, count, datatype, message, status)
-    @mpichk ccall((:MPI_Mrecv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Message}, Ptr{MPI_Status}), buf, count, datatype, message, status)
+    @mpichk @ccall libmpi.MPI_Mrecv_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, message::Ptr{MPI_Message}, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4020,7 +4020,7 @@ end
 $(_doc_external(:MPI_Recv_c))
 """
 function MPI_Recv_c(buf, count, datatype, source, tag, comm, status)
-    @mpichk ccall((:MPI_Recv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), buf, count, datatype, source, tag, comm, status)
+    @mpichk @ccall libmpi.MPI_Recv_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4029,7 +4029,7 @@ end
 $(_doc_external(:MPI_Recv_init_c))
 """
 function MPI_Recv_init_c(buf, count, datatype, source, tag, comm, request)
-    @mpichk ccall((:MPI_Recv_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, source, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Recv_init_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, source::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4038,7 +4038,7 @@ end
 $(_doc_external(:MPI_Rsend_c))
 """
 function MPI_Rsend_c(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Rsend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Rsend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -4047,7 +4047,7 @@ end
 $(_doc_external(:MPI_Rsend_init_c))
 """
 function MPI_Rsend_init_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Rsend_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Rsend_init_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4056,7 +4056,7 @@ end
 $(_doc_external(:MPI_Send_c))
 """
 function MPI_Send_c(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Send_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Send_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -4065,7 +4065,7 @@ end
 $(_doc_external(:MPI_Send_init_c))
 """
 function MPI_Send_init_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Send_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Send_init_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4074,7 +4074,7 @@ end
 $(_doc_external(:MPI_Sendrecv_c))
 """
 function MPI_Sendrecv_c(sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, status)
-    @mpichk ccall((:MPI_Sendrecv_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), sendbuf, sendcount, sendtype, dest, sendtag, recvbuf, recvcount, recvtype, source, recvtag, comm, status)
+    @mpichk @ccall libmpi.MPI_Sendrecv_c(sendbuf::MPIPtr, sendcount::MPI_Count, sendtype::MPI_Datatype, dest::Cint, sendtag::Cint, recvbuf::MPIPtr, recvcount::MPI_Count, recvtype::MPI_Datatype, source::Cint, recvtag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4083,7 +4083,7 @@ end
 $(_doc_external(:MPI_Sendrecv_replace_c))
 """
 function MPI_Sendrecv_replace_c(buf, count, datatype, dest, sendtag, source, recvtag, comm, status)
-    @mpichk ccall((:MPI_Sendrecv_replace_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, Cint, Cint, MPI_Comm, Ptr{MPI_Status}), buf, count, datatype, dest, sendtag, source, recvtag, comm, status)
+    @mpichk @ccall libmpi.MPI_Sendrecv_replace_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, sendtag::Cint, source::Cint, recvtag::Cint, comm::MPI_Comm, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4092,7 +4092,7 @@ end
 $(_doc_external(:MPI_Ssend_c))
 """
 function MPI_Ssend_c(buf, count, datatype, dest, tag, comm)
-    @mpichk ccall((:MPI_Ssend_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm), buf, count, datatype, dest, tag, comm)
+    @mpichk @ccall libmpi.MPI_Ssend_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm)::Cint
 end
 
 """
@@ -4101,7 +4101,7 @@ end
 $(_doc_external(:MPI_Ssend_init_c))
 """
 function MPI_Ssend_init_c(buf, count, datatype, dest, tag, comm, request)
-    @mpichk ccall((:MPI_Ssend_init_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, Cint, MPI_Comm, Ptr{MPI_Request}), buf, count, datatype, dest, tag, comm, request)
+    @mpichk @ccall libmpi.MPI_Ssend_init_c(buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, dest::Cint, tag::Cint, comm::MPI_Comm, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4110,7 +4110,7 @@ end
 $(_doc_external(:MPI_Accumulate_c))
 """
 function MPI_Accumulate_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
-    @mpichk ccall((:MPI_Accumulate_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Op, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
+    @mpichk @ccall libmpi.MPI_Accumulate_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win)::Cint
 end
 
 """
@@ -4119,7 +4119,7 @@ end
 $(_doc_external(:MPI_Get_c))
 """
 function MPI_Get_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
-    @mpichk ccall((:MPI_Get_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
+    @mpichk @ccall libmpi.MPI_Get_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, win::MPI_Win)::Cint
 end
 
 """
@@ -4128,7 +4128,7 @@ end
 $(_doc_external(:MPI_Get_accumulate_c))
 """
 function MPI_Get_accumulate_c(origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
-    @mpichk ccall((:MPI_Get_accumulate_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Op, MPI_Win), origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win)
+    @mpichk @ccall libmpi.MPI_Get_accumulate_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, result_addr::MPIPtr, result_count::MPI_Count, result_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win)::Cint
 end
 
 """
@@ -4137,7 +4137,7 @@ end
 $(_doc_external(:MPI_Put_c))
 """
 function MPI_Put_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
-    @mpichk ccall((:MPI_Put_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Win), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win)
+    @mpichk @ccall libmpi.MPI_Put_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, win::MPI_Win)::Cint
 end
 
 """
@@ -4146,7 +4146,7 @@ end
 $(_doc_external(:MPI_Raccumulate_c))
 """
 function MPI_Raccumulate_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
-    @mpichk ccall((:MPI_Raccumulate_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Op, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
+    @mpichk @ccall libmpi.MPI_Raccumulate_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4155,7 +4155,7 @@ end
 $(_doc_external(:MPI_Rget_c))
 """
 function MPI_Rget_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
-    @mpichk ccall((:MPI_Rget_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
+    @mpichk @ccall libmpi.MPI_Rget_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4164,7 +4164,7 @@ end
 $(_doc_external(:MPI_Rget_accumulate_c))
 """
 function MPI_Rget_accumulate_c(origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
-    @mpichk ccall((:MPI_Rget_accumulate_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Op, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, result_addr, result_count, result_datatype, target_rank, target_disp, target_count, target_datatype, op, win, request)
+    @mpichk @ccall libmpi.MPI_Rget_accumulate_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, result_addr::MPIPtr, result_count::MPI_Count, result_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, op::MPI_Op, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4173,7 +4173,7 @@ end
 $(_doc_external(:MPI_Rput_c))
 """
 function MPI_Rput_c(origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
-    @mpichk ccall((:MPI_Rput_c, libmpi), Cint, (MPIPtr, MPI_Count, MPI_Datatype, Cint, MPI_Aint, MPI_Count, MPI_Datatype, MPI_Win, Ptr{MPI_Request}), origin_addr, origin_count, origin_datatype, target_rank, target_disp, target_count, target_datatype, win, request)
+    @mpichk @ccall libmpi.MPI_Rput_c(origin_addr::MPIPtr, origin_count::MPI_Count, origin_datatype::MPI_Datatype, target_rank::Cint, target_disp::MPI_Aint, target_count::MPI_Count, target_datatype::MPI_Datatype, win::MPI_Win, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4182,7 +4182,7 @@ end
 $(_doc_external(:MPI_Win_allocate_c))
 """
 function MPI_Win_allocate_c(size, disp_unit, info, comm, baseptr, win)
-    @mpichk ccall((:MPI_Win_allocate_c, libmpi), Cint, (MPI_Aint, MPI_Aint, MPI_Info, MPI_Comm, MPIPtr, Ptr{MPI_Win}), size, disp_unit, info, comm, baseptr, win)
+    @mpichk @ccall libmpi.MPI_Win_allocate_c(size::MPI_Aint, disp_unit::MPI_Aint, info::MPI_Info, comm::MPI_Comm, baseptr::MPIPtr, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -4191,7 +4191,7 @@ end
 $(_doc_external(:MPI_Win_allocate_shared_c))
 """
 function MPI_Win_allocate_shared_c(size, disp_unit, info, comm, baseptr, win)
-    @mpichk ccall((:MPI_Win_allocate_shared_c, libmpi), Cint, (MPI_Aint, MPI_Aint, MPI_Info, MPI_Comm, MPIPtr, Ptr{MPI_Win}), size, disp_unit, info, comm, baseptr, win)
+    @mpichk @ccall libmpi.MPI_Win_allocate_shared_c(size::MPI_Aint, disp_unit::MPI_Aint, info::MPI_Info, comm::MPI_Comm, baseptr::MPIPtr, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -4200,7 +4200,7 @@ end
 $(_doc_external(:MPI_Win_create_c))
 """
 function MPI_Win_create_c(base, size, disp_unit, info, comm, win)
-    @mpichk ccall((:MPI_Win_create_c, libmpi), Cint, (MPIPtr, MPI_Aint, MPI_Aint, MPI_Info, MPI_Comm, Ptr{MPI_Win}), base, size, disp_unit, info, comm, win)
+    @mpichk @ccall libmpi.MPI_Win_create_c(base::MPIPtr, size::MPI_Aint, disp_unit::MPI_Aint, info::MPI_Info, comm::MPI_Comm, win::Ptr{MPI_Win})::Cint
 end
 
 """
@@ -4209,7 +4209,7 @@ end
 $(_doc_external(:MPI_Win_shared_query_c))
 """
 function MPI_Win_shared_query_c(win, rank, size, disp_unit, baseptr)
-    @mpichk ccall((:MPI_Win_shared_query_c, libmpi), Cint, (MPI_Win, Cint, Ptr{MPI_Aint}, Ptr{MPI_Aint}, MPIPtr), win, rank, size, disp_unit, baseptr)
+    @mpichk @ccall libmpi.MPI_Win_shared_query_c(win::MPI_Win, rank::Cint, size::Ptr{MPI_Aint}, disp_unit::Ptr{MPI_Aint}, baseptr::MPIPtr)::Cint
 end
 
 """
@@ -4218,7 +4218,7 @@ end
 $(_doc_external(:MPI_File_open))
 """
 function MPI_File_open(comm, filename, amode, info, fh)
-    @mpichk ccall((:MPI_File_open, libmpi), Cint, (MPI_Comm, Ptr{Cchar}, Cint, MPI_Info, Ptr{MPI_File}), comm, filename, amode, info, fh)
+    @mpichk @ccall libmpi.MPI_File_open(comm::MPI_Comm, filename::Ptr{Cchar}, amode::Cint, info::MPI_Info, fh::Ptr{MPI_File})::Cint
 end
 
 """
@@ -4227,7 +4227,7 @@ end
 $(_doc_external(:MPI_File_close))
 """
 function MPI_File_close(fh)
-    @mpichk ccall((:MPI_File_close, libmpi), Cint, (Ptr{MPI_File},), fh)
+    @mpichk @ccall libmpi.MPI_File_close(fh::Ptr{MPI_File})::Cint
 end
 
 """
@@ -4236,7 +4236,7 @@ end
 $(_doc_external(:MPI_File_delete))
 """
 function MPI_File_delete(filename, info)
-    @mpichk ccall((:MPI_File_delete, libmpi), Cint, (Ptr{Cchar}, MPI_Info), filename, info)
+    @mpichk @ccall libmpi.MPI_File_delete(filename::Ptr{Cchar}, info::MPI_Info)::Cint
 end
 
 """
@@ -4245,7 +4245,7 @@ end
 $(_doc_external(:MPI_File_set_size))
 """
 function MPI_File_set_size(fh, size)
-    @mpichk ccall((:MPI_File_set_size, libmpi), Cint, (MPI_File, MPI_Offset), fh, size)
+    @mpichk @ccall libmpi.MPI_File_set_size(fh::MPI_File, size::MPI_Offset)::Cint
 end
 
 """
@@ -4254,7 +4254,7 @@ end
 $(_doc_external(:MPI_File_preallocate))
 """
 function MPI_File_preallocate(fh, size)
-    @mpichk ccall((:MPI_File_preallocate, libmpi), Cint, (MPI_File, MPI_Offset), fh, size)
+    @mpichk @ccall libmpi.MPI_File_preallocate(fh::MPI_File, size::MPI_Offset)::Cint
 end
 
 """
@@ -4263,7 +4263,7 @@ end
 $(_doc_external(:MPI_File_get_size))
 """
 function MPI_File_get_size(fh, size)
-    @mpichk ccall((:MPI_File_get_size, libmpi), Cint, (MPI_File, Ptr{MPI_Offset}), fh, size)
+    @mpichk @ccall libmpi.MPI_File_get_size(fh::MPI_File, size::Ptr{MPI_Offset})::Cint
 end
 
 """
@@ -4272,7 +4272,7 @@ end
 $(_doc_external(:MPI_File_get_group))
 """
 function MPI_File_get_group(fh, group)
-    @mpichk ccall((:MPI_File_get_group, libmpi), Cint, (MPI_File, Ptr{MPI_Group}), fh, group)
+    @mpichk @ccall libmpi.MPI_File_get_group(fh::MPI_File, group::Ptr{MPI_Group})::Cint
 end
 
 """
@@ -4281,7 +4281,7 @@ end
 $(_doc_external(:MPI_File_get_amode))
 """
 function MPI_File_get_amode(fh, amode)
-    @mpichk ccall((:MPI_File_get_amode, libmpi), Cint, (MPI_File, Ptr{Cint}), fh, amode)
+    @mpichk @ccall libmpi.MPI_File_get_amode(fh::MPI_File, amode::Ptr{Cint})::Cint
 end
 
 """
@@ -4290,7 +4290,7 @@ end
 $(_doc_external(:MPI_File_set_info))
 """
 function MPI_File_set_info(fh, info)
-    @mpichk ccall((:MPI_File_set_info, libmpi), Cint, (MPI_File, MPI_Info), fh, info)
+    @mpichk @ccall libmpi.MPI_File_set_info(fh::MPI_File, info::MPI_Info)::Cint
 end
 
 """
@@ -4299,7 +4299,7 @@ end
 $(_doc_external(:MPI_File_get_info))
 """
 function MPI_File_get_info(fh, info_used)
-    @mpichk ccall((:MPI_File_get_info, libmpi), Cint, (MPI_File, Ptr{MPI_Info}), fh, info_used)
+    @mpichk @ccall libmpi.MPI_File_get_info(fh::MPI_File, info_used::Ptr{MPI_Info})::Cint
 end
 
 """
@@ -4308,7 +4308,7 @@ end
 $(_doc_external(:MPI_File_set_view))
 """
 function MPI_File_set_view(fh, disp, etype, filetype, datarep, info)
-    @mpichk ccall((:MPI_File_set_view, libmpi), Cint, (MPI_File, MPI_Offset, MPI_Datatype, MPI_Datatype, Ptr{Cchar}, MPI_Info), fh, disp, etype, filetype, datarep, info)
+    @mpichk @ccall libmpi.MPI_File_set_view(fh::MPI_File, disp::MPI_Offset, etype::MPI_Datatype, filetype::MPI_Datatype, datarep::Ptr{Cchar}, info::MPI_Info)::Cint
 end
 
 """
@@ -4317,7 +4317,7 @@ end
 $(_doc_external(:MPI_File_get_view))
 """
 function MPI_File_get_view(fh, disp, etype, filetype, datarep)
-    @mpichk ccall((:MPI_File_get_view, libmpi), Cint, (MPI_File, Ptr{MPI_Offset}, Ptr{MPI_Datatype}, Ptr{MPI_Datatype}, Ptr{Cchar}), fh, disp, etype, filetype, datarep)
+    @mpichk @ccall libmpi.MPI_File_get_view(fh::MPI_File, disp::Ptr{MPI_Offset}, etype::Ptr{MPI_Datatype}, filetype::Ptr{MPI_Datatype}, datarep::Ptr{Cchar})::Cint
 end
 
 """
@@ -4326,7 +4326,7 @@ end
 $(_doc_external(:MPI_File_read_at))
 """
 function MPI_File_read_at(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_at, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_at(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4335,7 +4335,7 @@ end
 $(_doc_external(:MPI_File_read_at_all))
 """
 function MPI_File_read_at_all(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_at_all, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_at_all(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4344,7 +4344,7 @@ end
 $(_doc_external(:MPI_File_write_at))
 """
 function MPI_File_write_at(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_at, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_at(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4353,7 +4353,7 @@ end
 $(_doc_external(:MPI_File_write_at_all))
 """
 function MPI_File_write_at_all(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_at_all, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_at_all(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4362,7 +4362,7 @@ end
 $(_doc_external(:MPI_File_iread_at))
 """
 function MPI_File_iread_at(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_at, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_at(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4371,7 +4371,7 @@ end
 $(_doc_external(:MPI_File_iwrite_at))
 """
 function MPI_File_iwrite_at(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_at, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_at(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4380,7 +4380,7 @@ end
 $(_doc_external(:MPI_File_read))
 """
 function MPI_File_read(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4389,7 +4389,7 @@ end
 $(_doc_external(:MPI_File_read_all))
 """
 function MPI_File_read_all(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_all, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_all(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4398,7 +4398,7 @@ end
 $(_doc_external(:MPI_File_write))
 """
 function MPI_File_write(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4407,7 +4407,7 @@ end
 $(_doc_external(:MPI_File_write_all))
 """
 function MPI_File_write_all(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_all, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_all(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4416,7 +4416,7 @@ end
 $(_doc_external(:MPI_File_iread))
 """
 function MPI_File_iread(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4425,7 +4425,7 @@ end
 $(_doc_external(:MPI_File_iwrite))
 """
 function MPI_File_iwrite(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4434,7 +4434,7 @@ end
 $(_doc_external(:MPI_File_seek))
 """
 function MPI_File_seek(fh, offset, whence)
-    @mpichk ccall((:MPI_File_seek, libmpi), Cint, (MPI_File, MPI_Offset, Cint), fh, offset, whence)
+    @mpichk @ccall libmpi.MPI_File_seek(fh::MPI_File, offset::MPI_Offset, whence::Cint)::Cint
 end
 
 """
@@ -4443,7 +4443,7 @@ end
 $(_doc_external(:MPI_File_get_position))
 """
 function MPI_File_get_position(fh, offset)
-    @mpichk ccall((:MPI_File_get_position, libmpi), Cint, (MPI_File, Ptr{MPI_Offset}), fh, offset)
+    @mpichk @ccall libmpi.MPI_File_get_position(fh::MPI_File, offset::Ptr{MPI_Offset})::Cint
 end
 
 """
@@ -4452,7 +4452,7 @@ end
 $(_doc_external(:MPI_File_get_byte_offset))
 """
 function MPI_File_get_byte_offset(fh, offset, disp)
-    @mpichk ccall((:MPI_File_get_byte_offset, libmpi), Cint, (MPI_File, MPI_Offset, Ptr{MPI_Offset}), fh, offset, disp)
+    @mpichk @ccall libmpi.MPI_File_get_byte_offset(fh::MPI_File, offset::MPI_Offset, disp::Ptr{MPI_Offset})::Cint
 end
 
 """
@@ -4461,7 +4461,7 @@ end
 $(_doc_external(:MPI_File_read_shared))
 """
 function MPI_File_read_shared(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_shared, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_shared(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4470,7 +4470,7 @@ end
 $(_doc_external(:MPI_File_write_shared))
 """
 function MPI_File_write_shared(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_shared, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_shared(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4479,7 +4479,7 @@ end
 $(_doc_external(:MPI_File_iread_shared))
 """
 function MPI_File_iread_shared(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_shared, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_shared(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4488,7 +4488,7 @@ end
 $(_doc_external(:MPI_File_iwrite_shared))
 """
 function MPI_File_iwrite_shared(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_shared, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_shared(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4497,7 +4497,7 @@ end
 $(_doc_external(:MPI_File_read_ordered))
 """
 function MPI_File_read_ordered(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_ordered, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_ordered(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4506,7 +4506,7 @@ end
 $(_doc_external(:MPI_File_write_ordered))
 """
 function MPI_File_write_ordered(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_ordered, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_ordered(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4515,7 +4515,7 @@ end
 $(_doc_external(:MPI_File_seek_shared))
 """
 function MPI_File_seek_shared(fh, offset, whence)
-    @mpichk ccall((:MPI_File_seek_shared, libmpi), Cint, (MPI_File, MPI_Offset, Cint), fh, offset, whence)
+    @mpichk @ccall libmpi.MPI_File_seek_shared(fh::MPI_File, offset::MPI_Offset, whence::Cint)::Cint
 end
 
 """
@@ -4524,7 +4524,7 @@ end
 $(_doc_external(:MPI_File_get_position_shared))
 """
 function MPI_File_get_position_shared(fh, offset)
-    @mpichk ccall((:MPI_File_get_position_shared, libmpi), Cint, (MPI_File, Ptr{MPI_Offset}), fh, offset)
+    @mpichk @ccall libmpi.MPI_File_get_position_shared(fh::MPI_File, offset::Ptr{MPI_Offset})::Cint
 end
 
 """
@@ -4533,7 +4533,7 @@ end
 $(_doc_external(:MPI_File_read_at_all_begin))
 """
 function MPI_File_read_at_all_begin(fh, offset, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_at_all_begin, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype), fh, offset, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_at_all_begin(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4542,7 +4542,7 @@ end
 $(_doc_external(:MPI_File_read_at_all_end))
 """
 function MPI_File_read_at_all_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_read_at_all_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_read_at_all_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4551,7 +4551,7 @@ end
 $(_doc_external(:MPI_File_write_at_all_begin))
 """
 function MPI_File_write_at_all_begin(fh, offset, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_at_all_begin, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype), fh, offset, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_at_all_begin(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4560,7 +4560,7 @@ end
 $(_doc_external(:MPI_File_write_at_all_end))
 """
 function MPI_File_write_at_all_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_write_at_all_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_write_at_all_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4569,7 +4569,7 @@ end
 $(_doc_external(:MPI_File_read_all_begin))
 """
 function MPI_File_read_all_begin(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_all_begin, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_all_begin(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4578,7 +4578,7 @@ end
 $(_doc_external(:MPI_File_read_all_end))
 """
 function MPI_File_read_all_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_read_all_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_read_all_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4587,7 +4587,7 @@ end
 $(_doc_external(:MPI_File_write_all_begin))
 """
 function MPI_File_write_all_begin(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_all_begin, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_all_begin(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4596,7 +4596,7 @@ end
 $(_doc_external(:MPI_File_write_all_end))
 """
 function MPI_File_write_all_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_write_all_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_write_all_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4605,7 +4605,7 @@ end
 $(_doc_external(:MPI_File_read_ordered_begin))
 """
 function MPI_File_read_ordered_begin(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_ordered_begin, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_ordered_begin(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4614,7 +4614,7 @@ end
 $(_doc_external(:MPI_File_read_ordered_end))
 """
 function MPI_File_read_ordered_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_read_ordered_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_read_ordered_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4623,7 +4623,7 @@ end
 $(_doc_external(:MPI_File_write_ordered_begin))
 """
 function MPI_File_write_ordered_begin(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_ordered_begin, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_ordered_begin(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4632,7 +4632,7 @@ end
 $(_doc_external(:MPI_File_write_ordered_end))
 """
 function MPI_File_write_ordered_end(fh, buf, status)
-    @mpichk ccall((:MPI_File_write_ordered_end, libmpi), Cint, (MPI_File, MPIPtr, Ptr{MPI_Status}), fh, buf, status)
+    @mpichk @ccall libmpi.MPI_File_write_ordered_end(fh::MPI_File, buf::MPIPtr, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4641,7 +4641,7 @@ end
 $(_doc_external(:MPI_File_get_type_extent))
 """
 function MPI_File_get_type_extent(fh, datatype, extent)
-    @mpichk ccall((:MPI_File_get_type_extent, libmpi), Cint, (MPI_File, MPI_Datatype, Ptr{MPI_Aint}), fh, datatype, extent)
+    @mpichk @ccall libmpi.MPI_File_get_type_extent(fh::MPI_File, datatype::MPI_Datatype, extent::Ptr{MPI_Aint})::Cint
 end
 
 """
@@ -4650,7 +4650,7 @@ end
 $(_doc_external(:MPI_Register_datarep))
 """
 function MPI_Register_datarep(datarep, read_conversion_fn, write_conversion_fn, dtype_file_extent_fn, extra_state)
-    @mpichk ccall((:MPI_Register_datarep, libmpi), Cint, (Ptr{Cchar}, MPIPtr, MPIPtr, MPIPtr, MPIPtr), datarep, read_conversion_fn, write_conversion_fn, dtype_file_extent_fn, extra_state)
+    @mpichk @ccall libmpi.MPI_Register_datarep(datarep::Ptr{Cchar}, read_conversion_fn::MPIPtr, write_conversion_fn::MPIPtr, dtype_file_extent_fn::MPIPtr, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -4659,7 +4659,7 @@ end
 $(_doc_external(:MPI_File_set_atomicity))
 """
 function MPI_File_set_atomicity(fh, flag)
-    @mpichk ccall((:MPI_File_set_atomicity, libmpi), Cint, (MPI_File, Cint), fh, flag)
+    @mpichk @ccall libmpi.MPI_File_set_atomicity(fh::MPI_File, flag::Cint)::Cint
 end
 
 """
@@ -4668,7 +4668,7 @@ end
 $(_doc_external(:MPI_File_get_atomicity))
 """
 function MPI_File_get_atomicity(fh, flag)
-    @mpichk ccall((:MPI_File_get_atomicity, libmpi), Cint, (MPI_File, Ptr{Cint}), fh, flag)
+    @mpichk @ccall libmpi.MPI_File_get_atomicity(fh::MPI_File, flag::Ptr{Cint})::Cint
 end
 
 """
@@ -4677,7 +4677,7 @@ end
 $(_doc_external(:MPI_File_sync))
 """
 function MPI_File_sync(fh)
-    @mpichk ccall((:MPI_File_sync, libmpi), Cint, (MPI_File,), fh)
+    @mpichk @ccall libmpi.MPI_File_sync(fh::MPI_File)::Cint
 end
 
 """
@@ -4686,7 +4686,7 @@ end
 $(_doc_external(:MPI_File_iread_at_all))
 """
 function MPI_File_iread_at_all(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_at_all, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_at_all(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4695,7 +4695,7 @@ end
 $(_doc_external(:MPI_File_iwrite_at_all))
 """
 function MPI_File_iwrite_at_all(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_at_all, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_at_all(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4704,7 +4704,7 @@ end
 $(_doc_external(:MPI_File_iread_all))
 """
 function MPI_File_iread_all(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_all, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_all(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4713,7 +4713,7 @@ end
 $(_doc_external(:MPI_File_iwrite_all))
 """
 function MPI_File_iwrite_all(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_all, libmpi), Cint, (MPI_File, MPIPtr, Cint, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_all(fh::MPI_File, buf::MPIPtr, count::Cint, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4722,7 +4722,7 @@ end
 $(_doc_external(:MPI_File_read_c))
 """
 function MPI_File_read_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4731,7 +4731,7 @@ end
 $(_doc_external(:MPI_File_read_all_c))
 """
 function MPI_File_read_all_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_all_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_all_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4740,7 +4740,7 @@ end
 $(_doc_external(:MPI_File_read_all_begin_c))
 """
 function MPI_File_read_all_begin_c(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_all_begin_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_all_begin_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4749,7 +4749,7 @@ end
 $(_doc_external(:MPI_File_read_at_c))
 """
 function MPI_File_read_at_c(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_at_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_at_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4758,7 +4758,7 @@ end
 $(_doc_external(:MPI_File_read_at_all_c))
 """
 function MPI_File_read_at_all_c(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_at_all_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_at_all_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4767,7 +4767,7 @@ end
 $(_doc_external(:MPI_File_read_at_all_begin_c))
 """
 function MPI_File_read_at_all_begin_c(fh, offset, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_at_all_begin_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype), fh, offset, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_at_all_begin_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4776,7 +4776,7 @@ end
 $(_doc_external(:MPI_File_read_ordered_c))
 """
 function MPI_File_read_ordered_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_ordered_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_ordered_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4785,7 +4785,7 @@ end
 $(_doc_external(:MPI_File_read_ordered_begin_c))
 """
 function MPI_File_read_ordered_begin_c(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_read_ordered_begin_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_read_ordered_begin_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4794,7 +4794,7 @@ end
 $(_doc_external(:MPI_File_read_shared_c))
 """
 function MPI_File_read_shared_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_read_shared_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_read_shared_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4803,7 +4803,7 @@ end
 $(_doc_external(:MPI_File_write_c))
 """
 function MPI_File_write_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4812,7 +4812,7 @@ end
 $(_doc_external(:MPI_File_write_all_c))
 """
 function MPI_File_write_all_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_all_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_all_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4821,7 +4821,7 @@ end
 $(_doc_external(:MPI_File_write_all_begin_c))
 """
 function MPI_File_write_all_begin_c(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_all_begin_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_all_begin_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4830,7 +4830,7 @@ end
 $(_doc_external(:MPI_File_write_at_c))
 """
 function MPI_File_write_at_c(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_at_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_at_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4839,7 +4839,7 @@ end
 $(_doc_external(:MPI_File_write_at_all_c))
 """
 function MPI_File_write_at_all_c(fh, offset, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_at_all_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, offset, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_at_all_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4848,7 +4848,7 @@ end
 $(_doc_external(:MPI_File_write_at_all_begin_c))
 """
 function MPI_File_write_at_all_begin_c(fh, offset, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_at_all_begin_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype), fh, offset, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_at_all_begin_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4857,7 +4857,7 @@ end
 $(_doc_external(:MPI_File_write_ordered_c))
 """
 function MPI_File_write_ordered_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_ordered_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_ordered_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4866,7 +4866,7 @@ end
 $(_doc_external(:MPI_File_write_ordered_begin_c))
 """
 function MPI_File_write_ordered_begin_c(fh, buf, count, datatype)
-    @mpichk ccall((:MPI_File_write_ordered_begin_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype), fh, buf, count, datatype)
+    @mpichk @ccall libmpi.MPI_File_write_ordered_begin_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype)::Cint
 end
 
 """
@@ -4875,7 +4875,7 @@ end
 $(_doc_external(:MPI_File_write_shared_c))
 """
 function MPI_File_write_shared_c(fh, buf, count, datatype, status)
-    @mpichk ccall((:MPI_File_write_shared_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Status}), fh, buf, count, datatype, status)
+    @mpichk @ccall libmpi.MPI_File_write_shared_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, status::Ptr{MPI_Status})::Cint
 end
 
 """
@@ -4884,7 +4884,7 @@ end
 $(_doc_external(:MPI_File_iread_c))
 """
 function MPI_File_iread_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4893,7 +4893,7 @@ end
 $(_doc_external(:MPI_File_iread_all_c))
 """
 function MPI_File_iread_all_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_all_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_all_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4902,7 +4902,7 @@ end
 $(_doc_external(:MPI_File_iread_at_c))
 """
 function MPI_File_iread_at_c(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_at_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_at_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4911,7 +4911,7 @@ end
 $(_doc_external(:MPI_File_iread_at_all_c))
 """
 function MPI_File_iread_at_all_c(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_at_all_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_at_all_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4920,7 +4920,7 @@ end
 $(_doc_external(:MPI_File_iread_shared_c))
 """
 function MPI_File_iread_shared_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iread_shared_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iread_shared_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4929,7 +4929,7 @@ end
 $(_doc_external(:MPI_File_iwrite_c))
 """
 function MPI_File_iwrite_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4938,7 +4938,7 @@ end
 $(_doc_external(:MPI_File_iwrite_all_c))
 """
 function MPI_File_iwrite_all_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_all_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_all_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4947,7 +4947,7 @@ end
 $(_doc_external(:MPI_File_iwrite_at_c))
 """
 function MPI_File_iwrite_at_c(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_at_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_at_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4956,7 +4956,7 @@ end
 $(_doc_external(:MPI_File_iwrite_at_all_c))
 """
 function MPI_File_iwrite_at_all_c(fh, offset, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_at_all_c, libmpi), Cint, (MPI_File, MPI_Offset, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, offset, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_at_all_c(fh::MPI_File, offset::MPI_Offset, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4965,7 +4965,7 @@ end
 $(_doc_external(:MPI_File_iwrite_shared_c))
 """
 function MPI_File_iwrite_shared_c(fh, buf, count, datatype, request)
-    @mpichk ccall((:MPI_File_iwrite_shared_c, libmpi), Cint, (MPI_File, MPIPtr, MPI_Count, MPI_Datatype, Ptr{MPI_Request}), fh, buf, count, datatype, request)
+    @mpichk @ccall libmpi.MPI_File_iwrite_shared_c(fh::MPI_File, buf::MPIPtr, count::MPI_Count, datatype::MPI_Datatype, request::Ptr{MPI_Request})::Cint
 end
 
 """
@@ -4974,7 +4974,7 @@ end
 $(_doc_external(:MPI_File_get_type_extent_c))
 """
 function MPI_File_get_type_extent_c(fh, datatype, extent)
-    @mpichk ccall((:MPI_File_get_type_extent_c, libmpi), Cint, (MPI_File, MPI_Datatype, Ptr{MPI_Count}), fh, datatype, extent)
+    @mpichk @ccall libmpi.MPI_File_get_type_extent_c(fh::MPI_File, datatype::MPI_Datatype, extent::Ptr{MPI_Count})::Cint
 end
 
 """
@@ -4983,7 +4983,7 @@ end
 $(_doc_external(:MPI_Register_datarep_c))
 """
 function MPI_Register_datarep_c(datarep, read_conversion_fn, write_conversion_fn, dtype_file_extent_fn, extra_state)
-    @mpichk ccall((:MPI_Register_datarep_c, libmpi), Cint, (Ptr{Cchar}, MPIPtr, MPIPtr, MPIPtr, MPIPtr), datarep, read_conversion_fn, write_conversion_fn, dtype_file_extent_fn, extra_state)
+    @mpichk @ccall libmpi.MPI_Register_datarep_c(datarep::Ptr{Cchar}, read_conversion_fn::MPIPtr, write_conversion_fn::MPIPtr, dtype_file_extent_fn::MPIPtr, extra_state::MPIPtr)::Cint
 end
 
 """
@@ -4992,7 +4992,7 @@ end
 $(_doc_external(:MPI_File_f2c))
 """
 function MPI_File_f2c(file)
-    @mpichk ccall((:MPI_File_f2c, libmpi), MPI_File, (MPI_Fint,), file)
+    @mpichk @ccall libmpi.MPI_File_f2c(file::MPI_Fint)::MPI_File
 end
 
 """
@@ -5001,5 +5001,5 @@ end
 $(_doc_external(:MPI_File_c2f))
 """
 function MPI_File_c2f(file)
-    @mpichk ccall((:MPI_File_c2f, libmpi), MPI_Fint, (MPI_File,), file)
+    @mpichk @ccall libmpi.MPI_File_c2f(file::MPI_File)::MPI_Fint
 end


### PR DESCRIPTION
Ref: https://github.com/JuliaParallel/MPI.jl/issues/688#issuecomment-1354010721.  This isn't complete yet, I haven't fixed the `MPIPtr` replacements, but I'm saving the work so far before going to sleep (fixing `@mpicall` was already a fun ride, I hope I got it right) :slightly_smiling_face: 

***Edit***: I'm not really sure how to specify the calling convention in `@ccall`, I haven't touched forcing `stdcall` with msmpi, I asked for help in Slack.

***Edit 2***: https://docs.julialang.org/en/v1.10-dev/manual/calling-c-and-fortran-code/#ccall-interface

> This interface is slightly less convenient but it does allow one to specify a [calling convention](https://docs.julialang.org/en/v1.10-dev/manual/calling-c-and-fortran-code/#calling-convention).

Sigh