### PR TITLE
simplify topology code, use MPI.UNWEIGHTED instead of nothing

### DIFF
--- a/docs/src/reference/topology.md
+++ b/docs/src/reference/topology.md
@@ -1,5 +1,6 @@
 # Topology
 
+## Cartesian
 ```@docs
 MPI.Dims_create
 MPI.Cart_create
@@ -9,6 +10,12 @@ MPI.Cart_rank
 MPI.Cart_shift
 MPI.Cart_sub
 MPI.Cartdim_get
+```
+
+## Graph topology
+
+```@docs
+MPI.UNWEIGHTED
 MPI.Dist_graph_create
 MPI.Dist_graph_create_adjacent
 MPI.Dist_graph_neighbors_count

--- a/test/test_neighbor_comm.jl
+++ b/test/test_neighbor_comm.jl
@@ -30,7 +30,7 @@ let
     src2, srcw2, dst2, dstw2 = MPI.Dist_graph_neighbors(graph_comm)
     @test src == src2 == Cint[prev_rank]
     @test dst == dst2 == Cint[next_rank]
-    @test srcw2 === dstw2 === nothing
+    @test srcw2 === dstw2 === MPI.UNWEIGHTED
 end
 
 # Weighted graph


### PR DESCRIPTION
This is a slight tweak to #707 use `MPI.UNWEIGHTED` instead of `nothing` (as that is what is used in the constructors).
Also simplifies the code so that the mutating versions return the same as the allocating.

cc @fredrikekre