### PR TITLE
Do not load start up file when running tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ testfiles = sort(filter(istest, readdir(testdir)))
 
 @testset "$f" for f in testfiles
     mpiexec() do mpirun
-        cmd(n=nprocs) = `$mpirun -n $n $(Base.julia_cmd()) $(joinpath(testdir, f))`
+        cmd(n=nprocs) = `$mpirun -n $n $(Base.julia_cmd()) --startup-file=no $(joinpath(testdir, f))`
         if f == "test_spawn.jl"
             # Some command as the others, but always use a single process
             run(cmd(1))

--- a/test/test_spawn.jl
+++ b/test/test_spawn.jl
@@ -9,7 +9,7 @@ exename = joinpath(Sys.BINDIR, Base.julia_exename())
 @test isfile(exename)
 errors = Vector{Cint}(undef, N-1)
 # Ensure using consistent flags when spawning subprocesses by using same arguments as `Base.julia_cmd`.
-intercomm = MPI.Comm_spawn(exename, vcat(Base.julia_cmd()[2:end], joinpath(@__DIR__, "spawned_worker.jl")), N-1, MPI.COMM_WORLD, errors)
+intercomm = MPI.Comm_spawn(exename, vcat(Base.julia_cmd()[2:end], "--startup-file=no", joinpath(@__DIR__, "spawned_worker.jl")), N-1, MPI.COMM_WORLD, errors)
 @test errors == zeros(Cint,N-1)
 world_comm = MPI.Intercomm_merge(intercomm, false)
 


### PR DESCRIPTION
This was already done in https://github.com/JuliaParallel/MPI.jl/blob/6cb0fb07d0105f0017fd393d24d92aa35ddc0b89/test/mpiexecjl.jl#L24 but not in a couple of other places.  Fix #708.  CC @KristofferC 