### PR TITLE
Fix regex matching MPICH version number

### DIFF
--- a/lib/MPIPreferences/Project.toml
+++ b/lib/MPIPreferences/Project.toml
@@ -1,7 +1,7 @@
 name = "MPIPreferences"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 authors = []
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/lib/MPIPreferences/src/MPIPreferences.jl
+++ b/lib/MPIPreferences/src/MPIPreferences.jl
@@ -222,7 +222,7 @@ function identify_implementation_version_abi(version_string::AbstractString)
     if startswith(version_string, "MPICH")
         impl = "MPICH"
         # "MPICH Version:\t%s\n" /  "MPICH2 Version:\t%s\n"
-        if (m = match(r"^MPICH2? Version:\t(\d+.\d+(?:.\d+)?\w*)\n", version_string)) !== nothing
+        if (m = match(r"^MPICH2? Version:\s+(\d+.\d+(?:.\d+)?\w*)\n", version_string)) !== nothing
             version = VersionNumber(m.captures[1])
         end
 


### PR DESCRIPTION
I currently get
```
julia> MPI.MPI_LIBRARY_VERSION_STRING
"MPICH Version:      4.1.1\nMPICH Release date: Mon Mar  6 14:14:15 CST 2023\nMPICH ABI:          15:0:3\nMPICH Device:       ch3:nemesis\nMPICH configure:    --prefix=/workspace/destdir --build=x86_64-linux-musl --host=x86_64-linux-gnu --enable-shared=yes --enable-static=no --with-device=ch3 --disable-dependency-tracking --enable-fast=all,O3 --docdir=/tmp --mandir=/tmp --disable-opencl\nMPICH CC:           cc    -DNDEBUG -DNVALGRIND -O3\nMPICH CXX:          c++   -DNDEBUG -DNVALGRIND -O3\nMPICH F77:          gfortran   -O3\nMPICH FC:           gfortran   -O3\n"

julia> MPI.MPI_LIBRARY_VERSION
v"0.0.0"
```
They are apparently using spaces instead of a tab now, `\s+` should catch both cases. With this patch I get
```
julia> MPI.MPI_LIBRARY_VERSION
v"4.1.1"
```