### PR TITLE
some explicit precompile statements and precompile-friendly loadtime hooks

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -167,9 +167,9 @@ using PrecompileTools: @compile_workload
     # are likely to be called from anyone using MPI in Julia. Thus, it is reasonable
     # to compile them ahead of time instead of compiling them in parallel for each
     # run.
-    Base.precompile(Tuple{typeof(Init)})
-    Base.precompile(Tuple{typeof(Comm_size), Comm})
-    Base.precompile(Tuple{typeof(Comm_size), Comm})
+    Base.precompile(Init, ())
+    Base.precompile(Comm_size, (Comm,))
+    Base.precompile(Comm_size, (Comm,))
 end
 
 end

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -53,7 +53,7 @@ end
 function run_load_time_hooks()
     @assert !_finished_loading[]
     _finished_loading[] = true
-    foreach(hook -> hook(), _mpi_load_time_hooks)
+    foreach(call, _mpi_load_time_hooks)
     empty!(_mpi_load_time_hooks)
     nothing
 end
@@ -66,6 +66,7 @@ function (hook::LoadTimeHookSetVal)()
     hook.dst.val = hook.src[]
     return nothing
 end
+call(hook) = hook()
 
 include("implementations.jl")
 include("error.jl")
@@ -89,7 +90,7 @@ include("misc.jl")
 include("deprecated.jl")
 
 if !isdefined(Base, :get_extension)
-    using Requires
+    using Requires: @require
 end
 
 function __init__()
@@ -160,8 +161,15 @@ using PrecompileTools: @compile_workload
     @compile_workload begin
         # Running the load time hooks here shaves off a significant amount of loading time,
         # see also https://github.com/JuliaParallel/MPI.jl/pull/728
-        foreach(hook -> hook(), _mpi_load_time_hooks)
+        foreach(call, _mpi_load_time_hooks)
     end
+    # We insert some explicit precompile statements here. The corresponding methods
+    # are likely to be called from anyone using MPI in Julia. Thus, it is reasonable
+    # to compile them ahead of time instead of compiling them in parallel for each
+    # run.
+    Base.precompile(Tuple{typeof(Init)})
+    Base.precompile(Tuple{typeof(Comm_size), Comm})
+    Base.precompile(Tuple{typeof(Comm_size), Comm})
 end
 
 end


### PR DESCRIPTION
On my system, I get the following results.

Current `master`:
```
$ julia --project=. -e 'import Pkg; Pkg.precompile(); @time @eval using MPI'
Precompiling project...
  1 dependency successfully precompiled in 3 seconds. 13 already precompiled.
  0.068064 seconds (60.26 k allocations: 4.630 MiB, 51.31% compilation time)
```

This PR:
```
$ julia --project=. -e 'import Pkg; Pkg.precompile(); @time @eval using MPI'
Precompiling project...
  1 dependency successfully precompiled in 3 seconds. 13 already precompiled.
  0.038507 seconds (57.11 k allocations: 4.375 MiB, 6.25% compilation time)
```