### PR TITLE
[CI] Run Intel MPI jobs on `ubuntu-latest`

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -543,6 +543,7 @@ jobs:
 
     env:
       JULIA_MPI_TEST_BINARY: MPItrampoline_jll
+      JULIA_MPI_TEST_ABI: MPItrampoline
       MPITRAMPOLINE_LIB: /usr/local/lib/libmpiwrapper.so
       MPITRAMPOLINE_MPIEXEC: /home/runner/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/bin/mpiexec
 
@@ -615,6 +616,15 @@ jobs:
       run: |
         using Pkg
         Pkg.develop(path="lib/MPIPreferences")
+
+    - name: use MPItrampoline_jll
+      shell: julia --color=yes --project=test {0}
+      run: |
+        using Pkg
+        Pkg.develop(path="lib/MPIPreferences")
+        using MPIPreferences
+        MPIPreferences.use_jll_binary("MPItrampoline_jll", export_prefs=true)
+        rm("test/Manifest.toml")
 
     # We can't use the usual actions here as we need to ensure the environment variables are set
     - name: "Build package"

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -223,7 +223,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       JULIA_MPI_TEST_BINARY: system
@@ -539,7 +539,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       JULIA_MPI_BINARY: MPItrampoline_jll

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -542,7 +542,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      JULIA_MPI_BINARY: MPItrampoline_jll
+      JULIA_MPI_TEST_BINARY: MPItrampoline_jll
       MPITRAMPOLINE_LIB: /usr/local/lib/libmpiwrapper.so
       MPITRAMPOLINE_MPIEXEC: /home/runner/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/bin/mpiexec
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -223,7 +223,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-18.04  # 20.04 not supported
+    runs-on: ubuntu-20.04
 
     env:
       JULIA_MPI_TEST_BINARY: system
@@ -539,7 +539,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-18.04  # 20.04 not supported
+    runs-on: ubuntu-20.04
 
     env:
       JULIA_MPI_BINARY: MPItrampoline_jll


### PR DESCRIPTION
`ubuntu-18.04` isn't supported anymore in GitHub Actions, we aren't running Intel MPI CI jobs at all at the moment.

Opening as draft to see whether this works, because the comments say "20.04 not supported".