### PR TITLE
Avoid segmentation faults in threaded code when using Intel MPI

### DIFF
--- a/docs/src/knownissues.md
+++ b/docs/src/knownissues.md
@@ -94,6 +94,14 @@ ENV["UCX_ERROR_SIGNALS"] = "SIGILL,SIGBUS,SIGFPE"
 ```
 at `__init__`. If set externally, it should be modified to exclude `SIGSEGV` from the list.
 
+Similarly, Intel MPI would error if the above signal is raised ([#725](https://github.com/JuliaParallel/MPI.jl/issues/725)), resulting in a segmentation fault error like
+```
+[6950] signal (11.-6): Segmentation fault
+in expression starting at /home/runner/work/MPI.jl/MPI.jl/test/test_threads.jl:18
+ijl_gc_enable at /cache/build/default-amdci4-6/julialang/julia-release-1-dot-9/src/gc.c:3222
+```
+MPI.jl works around this problem by setting the environment variable `IPATH_NO_BACKTRACE` to `1`, unless already defined.
+
 ## CUDA-aware MPI
 
 ### Memory pool

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -142,6 +142,10 @@ function __init__()
         # default is "SIGILL,SIGSEGV,SIGBUS,SIGFPE"
         ENV["UCX_ERROR_SIGNALS"] = "SIGILL,SIGBUS,SIGFPE"
     end
+    # Similar problem with Intel MPI (issue #725).
+    if !haskey(ENV, "IPATH_NO_BACKTRACE")
+        ENV["IPATH_NO_BACKTRACE"] = "1"
+    end
 
     if MPIPreferences.binary == "MPItrampoline_jll" && !haskey(ENV, "MPITRAMPOLINE_MPIEXEC")
         ENV["MPITRAMPOLINE_MPIEXEC"] = API.MPItrampoline_jll.mpich_mpiexec_path


### PR DESCRIPTION
This is supposed to fix #725.  I haven't tested this locally, but now that Intel MPI CI is actually working (#741) and can reproduce the segmentation fault reported, we can see how this goes.