### PR TITLE
Bump AMDGPU compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.11"
+version = "0.20.12"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-AMDGPU = "0.3, 0.4"
+AMDGPU = "0.3, 0.4, 0.5"
 CUDA = "3, 4"
 DocStringExtensions = "0.8, 0.9"
 MPIPreferences = "0.1.6"


### PR DESCRIPTION
Will be required to support the merge of https://github.com/JuliaGPU/AMDGPU.jl/pull/423 which requires a minor version bump.