### PR TITLE
Update AMDGPU test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.11"
+version = "0.20.12"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-AMDGPU = "0.3, 0.4"
+AMDGPU = "0.3, 0.4, 0.5"
 CUDA = "3, 4"
 DocStringExtensions = "0.8, 0.9"
 MPIPreferences = "0.1.6"

--- a/test/common.jl
+++ b/test/common.jl
@@ -8,13 +8,7 @@ if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "CuArray"
 elseif get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "ROCArray"
     import AMDGPU
     ArrayType = AMDGPU.ROCArray
-    function synchronize()
-        # TODO: AMDGPU synchronization story is complicated. HSA does not provide a consistent notion of global queues. We need a mechanism for all GPUArrays.jl provided kernels to be synchronized.
-        queue = AMDGPU.default_queue()
-        barrier = AMDGPU.barrier_and!(queue, AMDGPU.active_kernels(queue))
-        # AMDGPU.HIP.hipDeviceSynchronize() # Sync all HIP kernels e.g. BLAS. N.B. this is blocking Julia progress
-        wait(barrier)
-    end
+    synchronize() = AMDGPU.HIP.synchronize()
 else
     ArrayType = Array
     synchronize() = nothing


### PR DESCRIPTION
Modify sync function.

Other infos:
- Since AMDGPU v0.5, we no longer use HSA but HIP as backend. This makes the low-level AMDGPU API much closer to CUDA but introduces breaking changes.
- Also, AMDGPU currently only works properly with Julia 1.9

Given the ☝️, tests should rather only support AMDGPU >= 0.5 and Julia 1.9. For MPI.jl, I don't know how to handle it. I'd lean towards restricting the usage of AMDGPU Ext to Julia 1.9, AMDGPU 0.5...