### PR TITLE
Implement automatically serializing `gather`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.12"
+version = "0.20.13"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/docs/src/reference/collective.md
+++ b/docs/src/reference/collective.md
@@ -22,6 +22,7 @@ MPI.bcast
 ```@docs
 MPI.Gather!
 MPI.Gather
+MPI.gather
 MPI.Gatherv!
 MPI.Allgather!
 MPI.Allgather

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -321,11 +321,10 @@ function gather(obj, comm::Comm; root::Integer=0)
             MPI.deserialize(view(recvbuf.data, displ+1:displ+count)) for (displ, count) in zip(recvbuf.displs, recvbuf.counts)
         ]
         return objs
+    else
+        Gatherv!(sendbuf, nothing, comm; root = root)
+        return nothing
     end
-
-    Gatherv!(sendbuf, nothing, comm; root = root)
-
-    return nothing
 end
 
 

--- a/test/test_gather.jl
+++ b/test/test_gather.jl
@@ -76,6 +76,25 @@ for T in MPITestTypes
         @test A == ArrayType{T}(repeat(1:sz, inner=4))
     end
 
+    # serializing version
+    C = MPI.gather(T(rank+1), comm; root=root)
+    if isroot
+        @test C isa Vector{T}
+        @test C == Vector{T}(1:sz)
+    else
+        @test C === nothing
+    end
+end
+
+
+objs = ["test", 1, Array{Int}, [1,"test"]]
+obj = objs[mod(rank, length(objs))+1]
+
+C = MPI.gather(obj, comm; root=root)
+if isroot
+    @test C == [objs[mod1(i, length(objs))] for i = 1:sz]
+else
+    @test C === nothing
 end
 
 MPI.Finalize()


### PR DESCRIPTION
Hi,

I implemented an arbitrary-data convenience version of `Gather` for my own project and wanted to make a pull request just in case there is interest for adding it to MPI.jl.

Please let me know if there are any ways I can improve it.