### PR TITLE
Implement automatically serializing `scatter`

### DIFF
--- a/docs/src/reference/collective.md
+++ b/docs/src/reference/collective.md
@@ -36,6 +36,7 @@ MPI.Neighbor_allgatherv!
 ```@docs
 MPI.Scatter!
 MPI.Scatter
+MPI.scatter
 MPI.Scatterv!
 ```
 


### PR DESCRIPTION
Thanks for merging the `gather` pull request! I went ahead and implemented `scatter` as well!

The current version does a tiny amount of unnecessary work by serializing `objs[root + 1]`, which is never sent. I figured saving this might not be worth the additional complexity. Happy to implement it that way though.