### PR TITLE
Fix ROCm-aware MPI extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.mem
 Manifest.toml
 LocalPreferences.toml
+
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 *.mem
 Manifest.toml
 LocalPreferences.toml
-
-.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-AMDGPU = "0.5"
+AMDGPU = "0.5.7"
 CUDA = "3, 4"
 DocStringExtensions = "0.8, 0.9"
 MPIPreferences = "0.1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-AMDGPU = "0.3, 0.4, 0.5"
+AMDGPU = "0.5"
 CUDA = "3, 4"
 DocStringExtensions = "0.8, 0.9"
 MPIPreferences = "0.1.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.14"
+version = "0.20.15"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -9,7 +9,7 @@ function Base.cconvert(::Type{MPIPtr}, A::AMDGPU.ROCArray{T}) where T
 end
 
 function Base.unsafe_convert(::Type{MPIPtr}, X::AMDGPU.ROCArray{T}) where T
-    reinterpret(MPIPtr, Base.unsafe_convert(Ptr{T}, X.buf.ptr+X.offset))
+    reinterpret(MPIPtr, Base.unsafe_convert(Ptr{T}, X))
 end
 
 # only need to define this for strided arrays: all others can be handled by generic machinery


### PR DESCRIPTION
This PR fixes a bug introduced with a recent update of AMDGPU.jl