### PR TITLE
Init cooperative wait test for multiple threads

### DIFF
--- a/test/test_cooperative_wait.jl
+++ b/test/test_cooperative_wait.jl
@@ -1,7 +1,7 @@
 # tests for the various kinds of waits
 include("common.jl")
 
-MPI.Init()
+MPI.Init(threadlevel=:multiple)
 
 myrank = MPI.Comm_rank(MPI.COMM_WORLD)
 commsize = MPI.Comm_rank(MPI.COMM_WORLD)


### PR DESCRIPTION
In the cooperative wait test multiple threads are calling MPI functions in a non-serialized way. Thus, MPI needs to be initialized with `threadlevel=:multiple`.