### PR TITLE
Fix resize! for (Unsafe)MultiRequest

### DIFF
--- a/src/nonblocking.jl
+++ b/src/nonblocking.jl
@@ -330,9 +330,8 @@ function Base.resize!(mreq::MultiRequest, n::Integer)
     resize!(mreq.buffers, n)
     for i = m+1:n
         # initialize
-        req = mreq[i]
-        req.val = API.MPI_REQUEST_NULL[]
-        req.buffer = nothing
+        mreq.vals[i] = API.MPI_REQUEST_NULL[]
+        mreq.buffers[i] = nothing
     end
     return mreq
 end
@@ -345,8 +344,7 @@ function Base.resize!(mreq::UnsafeMultiRequest, n::Integer)
     resize!(mreq.vals, n)
     for i = m+1:n
         # initialize
-        req = mreq[i]
-        req.val = API.MPI_REQUEST_NULL[]
+        mreq.vals[i] = API.MPI_REQUEST_NULL[]
     end
     return mreq
 end

--- a/test/test_test.jl
+++ b/test/test_test.jl
@@ -66,6 +66,10 @@ inds = MPI.Waitsome(reqs)
 MPI.Waitall(reqs)
 @test MPI.Testall(reqs)
 
+resize!(reqs, 4)
+@test length(reqs) == 4
+@test all(MPI.isnull, reqs)
+
 reqs = MPI.UnsafeMultiRequest(2)
 GC.@preserve send_mesg recv_mesg begin
     MPI.Irecv!(recv_mesg, comm, reqs[1]; source=src, tag=src+32)
@@ -79,6 +83,9 @@ GC.@preserve send_mesg recv_mesg begin
     MPI.Waitall(reqs)
     @test MPI.Testall(reqs)
 end
+resize!(reqs, 4)
+@test length(reqs) == 4
+@test all(MPI.isnull, reqs)
 
 MPI.Finalize()
 @test MPI.Finalized()


### PR DESCRIPTION
This fixes `resize!` for `MultiRequest` and `UnsafeMultiRequest`.

Note that `resize!` was broken for these types since `MultiRequestItem` doesn't have `val` or `buffer` fields.