### PR TITLE
Docs: update to Documenter v1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,6 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,7 +50,8 @@ DocMeta.setdocmeta!(MPI, :DocTestSetup, :(using MPI); recursive=true)
 makedocs(
     sitename = "MPI.jl",
     format = Documenter.HTML(
-        prettyurls = get(ENV, "CI", nothing) == "true"
+        prettyurls = get(ENV, "CI", nothing) == "true",
+        size_threshold_ignore = ["reference/api.md"],
     ),
     modules = [MPI, MPIPreferences],
     pages = Any[
@@ -77,7 +78,6 @@ makedocs(
         ],
         "refindex.md",
     ],
-    strict = true,
 )
 
 deploydocs(


### PR DESCRIPTION
Update docs/make.jl for the recent Documenter 1.0 release.