### PR TITLE
[CI] Oversubscribe in OpenMPI jobs

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -95,6 +95,8 @@ jobs:
     env:
       JULIA_MPI_TEST_BINARY: OpenMPI_jll
       JULIA_MPI_TEST_ABI: OpenMPI
+      OMPI_MCA_btl_base_warn_component_unused: 0
+      OMPI_MCA_rmaps_base_oversubscribe: true
 
     runs-on: ${{ matrix.os }}
 
@@ -191,6 +193,7 @@ jobs:
     env:
       JULIA_MPI_TEST_BINARY: system
       OMPI_MCA_btl_base_warn_component_unused: 0
+      OMPI_MCA_rmaps_base_oversubscribe: true
 
     steps:
     - name: Checkout
@@ -430,6 +433,7 @@ jobs:
       MPITRAMPOLINE_LIB: /usr/local/lib/libmpiwrapper.so
       MPITRAMPOLINE_MPIEXEC: /usr/bin/mpiexec
       OMPI_MCA_btl_base_warn_component_unused: 0
+      OMPI_MCA_rmaps_base_oversubscribe: true
 
     steps:
     - name: Checkout


### PR DESCRIPTION
This didn't use to be necessary, but probably recent changes in the GitHub Actions runners caused `mpiexec -n 4` to complain about insufficient slots available.