### PR TITLE
Detect MVAPICH 3

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -523,6 +523,8 @@ jobs:
         include:
           - container: ghcr.io/juliaparallel/github-actions-buildcache:mvapich2-jq
             name: "MVAPICH 2.3.7"
+          - container: ghcr.io/juliaparallel/github-actions-buildcache:mvapich3-jq
+            name: "MVAPICH 3.0b"
 
       fail-fast: false
 

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -536,6 +536,9 @@ jobs:
       JULIA_MPI_TEST_BINARY: system
       JULIA_MPI_TEST_EXCLUDE: test_spawn.jl
       MV2_SMP_USE_CMA: 0
+      # Work around issue with affinity not set.  Ref:
+      # https://github.com/JuliaParallel/MPI.jl/pull/810#issuecomment-1920255386
+      MVP_ENABLE_AFFINITY: 0
 
     steps:
     - name: Checkout

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -524,7 +524,7 @@ jobs:
           - container: ghcr.io/juliaparallel/github-actions-buildcache:mvapich2-jq
             name: "MVAPICH 2.3.7"
           - container: ghcr.io/juliaparallel/github-actions-buildcache:mvapich3-jq
-            name: "MVAPICH 3.0b"
+            name: "MVAPICH 3.0"
 
       fail-fast: false
 

--- a/lib/MPIPreferences/src/MPIPreferences.jl
+++ b/lib/MPIPreferences/src/MPIPreferences.jl
@@ -297,7 +297,7 @@ function identify_implementation_version_abi(version_string::AbstractString)
             end
         end
 
-    elseif startswith(version_string, "MVAPICH2")
+    elseif startswith(version_string, "MVAPICH")
         impl = "MVAPICH"
         # "MVAPICH2 Version      :\t%s\n")
         if (m = match(r"^MVAPICH2? Version\s*:\t(\S*)\n", version_string)) !== nothing


### PR DESCRIPTION
I recently started working on a cluster using [MVAPICH version 3.0rc](http://mvapich.cse.ohio-state.edu/static/media/mvapich/quick.html), yet MPIPreferences.jl couldn't correctly detect it as the version string changed. Here is a sample of it, taken from the output of `MPIPreferences.identify_abi("libmpi")`:
```
MVAPICH Version        :	3.0rc
MVAPICH Release date   :	11/09/2023
MVAPICH ABI            :	13:12:1
MVAPICH Device         :	ch4:ucx
MVAPICH configure      :	--prefix=/packages/mvapich/mvapich-3.0rc-ucx CC=gcc CXX=g++ FC=gfortran F77=gfortran --with-device=ch4:ucx --with-ucx=/usr/local/packages/ucx/ucx-git-01192024 --disable-rdma-cm --disable-mcast --enable-fast=O3 --enable-debuginfo --enable-cxx --enable-mpit-pvars=all MPICHLIB_CFLAGS=-Werror=implicit-function-declaration -Werror=discarded-qualifiers -Werror=incompatible-pointer-types CFLAGS=-Wall -pipe -fPIC -fopenmp CXXFLAGS=-fPIC -fopenmp LDFLAGS=-fopenmp FFLAGS=-fPIC -fallow-argument-mismatch -fopenmp FCFLAGS=-fPIC -fallow-argument-mismatch -fopenmp
MVAPICH CC             :	gcc -Wall -pipe -fPIC -fopenmp -Werror=implicit-function-declaration -Werror=discarded-qualifiers -Werror=incompatible-pointer-types  -O3
MVAPICH CXX            :	g++ -fPIC -fopenmp  -O3
MVAPICH F77            :	gfortran -fPIC -fallow-argument-mismatch -fopenmp  -O3
MVAPICH FC             :	gfortran -fPIC -fallow-argument-mismatch -fopenmp  -O3
MPICH Custom Information:	@MVAPICH_CUSTOM_STRING@
```

The fix removes only a single character. By looking at the version regex, MVAPICH version 2 shouldn't be affected.