### PR TITLE
[CI] Use oneAPI MPI 2021.11.0

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -233,7 +233,7 @@ jobs:
           - container: ghcr.io/juliaparallel/github-actions-buildcache:intel-mpi-jq
             name: "Intel MPI 2019.9.304"
           - container: ghcr.io/juliaparallel/github-actions-buildcache:intel-oneapi-mpi-jq
-            name: "Intel oneAPI MPI 2021.7.0"
+            name: "Intel oneAPI MPI 2021.11.0"
 
       fail-fast: false
 


### PR DESCRIPTION
Container used for CI updated with https://github.com/JuliaParallel/github-actions-buildcache/compare/4a167b45ccf350b6915fbfe55a3421f8b4a22cb4...972c3fdca5acb661a9a7916bac572f56773b289e to use oneAPI MPI 2021.11.0.  This seems to fix #815.