### PR TITLE
Add `has_rocm` for OpenMPI

### DIFF
--- a/docs/src/knownissues.md
+++ b/docs/src/knownissues.md
@@ -180,7 +180,7 @@ Make sure to:
   ```
 - Then in Julia, upon loading MPI and CUDA modules, you can check
   - CUDA version: `CUDA.versioninfo()`
-  - If MPI has CUDA: `MPI.has_cuda()`
+  - If MPI has CUDA: [`MPI.has_cuda()`](@ref)
   - If you are using correct MPI library: `MPI.libmpi`
 
 After that, it may be preferred to run the Julia MPI script (as suggested [here](https://discourse.julialang.org/t/cuda-aware-mpi-works-on-system-but-not-for-julia/75060/11)) launching it from a shell script (as suggested [here](https://discourse.julialang.org/t/cuda-aware-mpi-works-on-system-but-not-for-julia/75060/4)).
@@ -197,6 +197,7 @@ Make sure to:
   ```
 - Then in Julia, upon loading MPI and CUDA modules, you can check
   - AMDGPU version: `AMDGPU.versioninfo()`
+  - If MPI has ROCm: [`MPI.has_rocm()`](@ref)
   - If you are using correct MPI implementation: `MPI.identify_implementation()`
 
 After that, [this script](https://gist.github.com/luraess/c228ec08629737888a18c6a1e397643c) can be used to verify if ROCm-aware MPI is functional (modified after the CUDA-aware version from [here](https://discourse.julialang.org/t/cuda-aware-mpi-works-on-system-but-not-for-julia/75060/11)). It may be preferred to run the Julia ROCm-aware MPI script launching it from a shell script (as suggested [here](https://discourse.julialang.org/t/cuda-aware-mpi-works-on-system-but-not-for-julia/75060/4)).

--- a/docs/src/reference/library.md
+++ b/docs/src/reference/library.md
@@ -15,5 +15,6 @@ MPI.MPI_LIBRARY_VERSION_STRING
 MPI.versioninfo
 MPI.has_cuda
 MPI.has_rocm
+MPI.has_gpu
 MPI.identify_implementation
 ```

--- a/docs/src/reference/library.md
+++ b/docs/src/reference/library.md
@@ -14,5 +14,6 @@ MPI.MPI_LIBRARY_VERSION_STRING
 ```@docs
 MPI.versioninfo
 MPI.has_cuda
+MPI.has_rocm
 MPI.identify_implementation
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -98,7 +98,8 @@ should confirm your MPI implementation to have the ROCm support (AMDGPU) enabled
 [alltoall\_test\_rocm\_multigpu.jl](https://gist.github.com/luraess/a47931d7fb668bd4348a2c730d5489f4) should confirm 
 your ROCm-aware MPI implementation to use multiple AMD GPUs (one GPU per rank).
 
-The status of ROCm (AMDGPU) support cannot currently be queried.
+If using OpenMPI, the status of ROCm support can be checked via the
+[`MPI.has_rocm()`](@ref) function.
 
 ## Writing MPI tests
 

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -327,6 +327,8 @@ or `false`.
 
 !!! note
     For OpenMPI or OpenMPI-based implementations you first need to call [Init()](@ref).
+
+See also [`MPI.has_rocm`](@ref) for ROCm support.
 """
 function has_cuda()
     flag = get(ENV, "JULIA_MPI_HAS_CUDA", nothing)
@@ -354,6 +356,8 @@ provides a mechanism to check, so it will return `false` with other implementati
 
 This can be overriden by setting the `JULIA_MPI_HAS_ROCM` environment variable to `true`
 or `false`.
+
+See also [`MPI.has_cuda`](@ref) for CUDA support.
 """
 function has_rocm()
     flag = get(ENV, "JULIA_MPI_HAS_ROCM", nothing)
@@ -369,3 +373,17 @@ function has_rocm()
         return parse(Bool, flag)
     end
 end
+
+"""
+    MPI.has_gpu()
+
+Checks if the MPI implementation is known to have GPU support. Currently this checks for the
+following GPUs:
+
+1. CUDA: via [`MPI.has_cuda`](@ref)
+2. ROCm: via [`MPI.has_rocm`](@ref)
+
+See also [`MPI.has_cuda`](@ref) and [`MPI.has_rocm`](@ref) for more fine-grained
+checks.
+"""
+has_gpu() = has_cuda() || has_rocm()

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -8,14 +8,20 @@ MPI.Init()
 
 @test MPI.has_cuda() isa Bool
 
-if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "CuArray"
+if get(ENV, "JULIA_MPI_TEST_ARRAYTYPE", "") == "CuArray"
     @test MPI.has_cuda()
 end
 
 @test MPI.has_rocm() isa Bool
 
-if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "ROCArray"
+if get(ENV, "JULIA_MPI_TEST_ARRAYTYPE", "") == "ROCArray"
     @test MPI.has_rocm()
+end
+
+@test MPI.has_gpu() isa Bool
+
+if get(ENV, "JULIA_MPI_TEST_ARRAYTYPE", "") == "CuArray" || get(ENV, "JULIA_MPI_TEST_ARRAYTYPE", "") == "ROCArray"
+    @test MPI.has_gpu()
 end
 
 @test !MPI.Finalized()

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -12,6 +12,12 @@ if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "CuArray"
     @test MPI.has_cuda()
 end
 
+@test MPI.has_rocm() isa Bool
+
+if get(ENV,"JULIA_MPI_TEST_ARRAYTYPE","") == "ROCArray"
+    @test MPI.has_rocm()
+end
+
 @test !MPI.Finalized()
 MPI.Finalize()
 @test MPI.Finalized()


### PR DESCRIPTION
See https://docs.open-mpi.org/en/main/man-openmpi/man3/MPIX_Query_rocm_support.3.html#mpix-query-rocm-support

Seems to be available from v5 of OpenMPI