### PR TITLE
[CI] Set `DYLD_FALLBACK_LIBRARY_PATH` in tests with Homebrew MPI

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -135,15 +135,26 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
+        os:
+          - macos-13
+          - macos-14
         mpi:
           - mpich
           - openmpi
         julia_version:
           - "1"
+        julia_arch:
+          - "x64"
+          - "aarch64"
+        exclude:
+          - os: macos-13
+            julia_arch: "aarch64"
+          - os: macos-14
+            julia_arch: "x64"
 
       fail-fast: false
 
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     env:
       JULIA_MPI_TEST_BINARY: system
       ZES_ENABLE_SYSMAN: 1  # https://github.com/open-mpi/ompi/issues/10142
@@ -153,13 +164,16 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install MPI via homebrew
-      run: brew install $MPI
+      run: |
+        brew install "${MPI}"
+        echo "DYLD_FALLBACK_LIBRARY_PATH=$(brew --prefix ${MPI})/lib" >> "${GITHUB_ENV}"
       env:
         MPI: ${{ matrix.mpi }}
 
     - uses: julia-actions/setup-julia@v1
       with:
         version: ${{ matrix.julia_version }}
+        arch: ${{ matrix.julia_arch }}
 
     - uses: julia-actions/cache@v1
     - name: add MPIPreferences

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
         julia_version:
@@ -42,7 +42,7 @@ jobs:
           - "nightly"
         julia_arch: [x64, x86]
         exclude:
-          - os: macos-latest
+          - os: macos-13
             julia_arch: x86
         include:
           - os: macos-14
@@ -84,7 +84,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
         julia_version:
           - "1.6"
@@ -92,7 +92,7 @@ jobs:
           - "nightly"
         julia_arch: [x64, x86]
         exclude:
-          - os: macos-latest
+          - os: macos-13
             julia_arch: x86
 
       fail-fast: false
@@ -341,7 +341,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
         mpi: [mpitrampoline]
         julia_version:
@@ -352,7 +352,7 @@ jobs:
           - x64
           - x86
         exclude:
-          - os: macos-latest
+          - os: macos-13
             julia_arch: x86
 
       fail-fast: false


### PR DESCRIPTION
Without this, in some situations libmpi may not be found by Julia.

This should fix #828.  Close #829.