### PR TITLE
[mpiexecjl] Return exit code of the mpiexec process

### DIFF
--- a/bin/mpiexecjl
+++ b/bin/mpiexecjl
@@ -61,7 +61,12 @@ fi
 SCRIPT='
 using MPI
 ENV["JULIA_PROJECT"] = dirname(Base.active_project())
-mpiexec(exe -> run(`$exe $ARGS`))
+proc = run(pipeline(`$(mpiexec()) $(ARGS)`; stdout, stderr); wait=false)
+wait(proc)
+if !iszero(proc.exitcode)
+   @error "The MPI process failed" proc
+end
+exit(proc.exitcode)
 '
 
 if [ -n "${PROJECT_ARG}" ]; then

--- a/test/mpiexecjl.jl
+++ b/test/mpiexecjl.jl
@@ -34,5 +34,10 @@ using MPI
         # Without arguments, or only with the `--project` option, the wrapper will fail
         @test !withenv(() -> success(`$(mpiexecjl) --project=$(dir)`), env...)
         @test !withenv(() -> success(`$(mpiexecjl)`), env...)
+        # Test that the wrapper exits with the same exit code as the MPI process
+        exit_code = 10
+        p = run(`$(mpiexecjl) -n $(nprocs) --project=$(dir) $(julia) --startup-file=no -e "exit($(exit_code))"`; wait=false)
+        wait(p)
+        @test p.exitcode == exit_code
     end
 end


### PR DESCRIPTION
Should fix #833.  I don't have the time to write tests now though, so opening as draft.  @cohensbw could you please test this?  With this PR I get
```console
% mpiexecjl -np 2 --project julia --color=yes -e 'exit(2)'; echo $?
2
```