### PR TITLE
CUDA CI no longer has version tag

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,11 +48,13 @@
       matrix:
         setup:
           version:
-            # - "1.6"
-            # - "1.7"
-            # - "1.8"
-            # - "1.9"
+            - "1.6"
+            - "1.7"
+            - "1.8"
+            - "1.9"
             - "1.10"
+      concurrency: 3
+      concurrency_group: mpi_cuda
       plugins:
         - JuliaCI/julia#v1:
             version: "{{matrix.version}}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,7 +53,7 @@
             - "1.8"
             - "1.9"
             - "1.10"
-      concurrency: 3
+      concurrency: 1
       concurrency_group: mpi_cuda
       plugins:
         - JuliaCI/julia#v1:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,55 +44,18 @@
 
     - wait
 
-    - label: "Tests -- Julia 1.6"
+    - label: "Tests -- Julia {{matrix.version}}"
+      matrix:
+        setup:
+          version:
+            - "1.6"
+            - "1.7"
+            - "1.8"
+            - "1.9"
+            - "1.10"
       plugins:
         - JuliaCI/julia#v1:
-            version: "1.6"
-            persist_depot_dirs: packages,artifacts,compiled
-      agents:
-        queue: "juliagpu"
-        cuda: "11.0"
-      if: build.message !~ /\[skip tests\]/
-      timeout_in_minutes: 60
-      env:
-        JULIA_MPI_TEST_NPROCS: 2
-        JULIA_MPI_PATH: "${BUILDKITE_BUILD_CHECKOUT_PATH}/openmpi"
-        OMPI_ALLOW_RUN_AS_ROOT: 1
-        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
-        OMPI_MCA_btl_vader_single_copy_mechanism: 'none' # https://github.com/open-mpi/ompi/issues/4948
-        OPAL_PREFIX: "${BUILDKITE_BUILD_CHECKOUT_PATH}/openmpi" # Should we set this for the user?
-        JULIA_CUDA_MEMORY_POOL: "none"
-      commands: |
-        echo "--- Configure MPI"
-        buildkite-agent artifact download --step "cuda-build-openmpi" mpi-prefix.tar.gz .
-        mkdir -p $${JULIA_MPI_PATH}
-        tar -zxf mpi-prefix.tar.gz --strip-components 1 -C $${JULIA_MPI_PATH}
-        export PATH=$${JULIA_MPI_PATH}/bin:$${PATH}
-        export LD_LIBRARY_PATH=$${JULIA_MPI_PATH}/lib:$${LD_LIBRARY_PATH}
-
-        echo "--- Setup Julia packages"
-        julia --color=yes --project=. -e '
-            import Pkg
-            Pkg.develop(; path = joinpath(pwd(), "lib", "MPIPreferences"))
-            '
-        julia --color=yes --project=test -e '
-            using Pkg
-            Pkg.develop(path="lib/MPIPreferences")
-            using MPIPreferences
-            MPIPreferences.use_system_binary(export_prefs=true)
-            rm("test/Manifest.toml")
-            '
-
-        echo "+++ Run tests"
-        julia --color=yes --project=. -e '
-           import Pkg
-           Pkg.test("MPI"; test_args=["--backend=CUDA"])
-           '
-
-    - label: "Tests -- Julia latest"
-      plugins:
-        - JuliaCI/julia#v1:
-            version: "1"
+            version: "{{matrix.version}}"
             persist_depot_dirs: packages,artifacts,compiled
       agents:
         queue: "juliagpu"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,10 +48,10 @@
       matrix:
         setup:
           version:
-            - "1.6"
-            - "1.7"
-            - "1.8"
-            - "1.9"
+            # - "1.6"
+            # - "1.7"
+            # - "1.8"
+            # - "1.9"
             - "1.10"
       plugins:
         - JuliaCI/julia#v1:
@@ -61,7 +61,7 @@
         queue: "juliagpu"
         cuda: "*"
       if: build.message !~ /\[skip tests\]/
-      timeout_in_minutes: 60
+      timeout_in_minutes: 90
       env:
         JULIA_MPI_TEST_NPROCS: 2
         JULIA_MPI_PATH: "${BUILDKITE_BUILD_CHECKOUT_PATH}/openmpi"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
       key: "cuda-build-openmpi"
       agents:
         queue: "juliagpu"
-        cuda: "11.0"
+        cuda: "*"
       env:
         OPENMPI_VER: "4.1"
         OPENMPI_VER_FULL: "4.1.4"
@@ -96,7 +96,7 @@
             persist_depot_dirs: packages,artifacts,compiled
       agents:
         queue: "juliagpu"
-        cuda: "11.0"
+        cuda: "*"
       if: build.message !~ /\[skip tests\]/
       timeout_in_minutes: 60
       env:

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -324,6 +324,9 @@ provides a mechanism to check, so it will return `false` with other implementati
 
 This can be overriden by setting the `JULIA_MPI_HAS_CUDA` environment variable to `true`
 or `false`.
+
+!!! note
+    For OpenMPI or OpenMPI-based implementations you first need to call [Init()](@ref).
 """
 function has_cuda()
     flag = get(ENV, "JULIA_MPI_HAS_CUDA", nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,6 @@ using DoubleFloats
     Running CUDA tests. Ensure that your MPI implementation is
     CUDA-aware using `MPI.has_cuda` before reporting issues.
     """
-    end
 elseif backend_name == "AMDGPU"
     Pkg.add("AMDGPU")
     ENV["JULIA_MPI_TEST_ARRAYTYPE"] = "ROCArray"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,15 +39,10 @@ using DoubleFloats
     CUDA.precompile_runtime()
     ArrayType = CUDA.CuArray
 
-    MPI.Init()
-    if !MPI.has_cuda()
-        @error """
-        Your MPI implementation may not support CUDA.
-        To force running the tests anyway set the environment
-        variable `JULIA_MPI_HAS_CUDA=true`.
-        """
-        MPI.versioninfo()
-        exit(1)
+    @info """
+    Running CUDA tests. Ensure that your MPI implementation is
+    CUDA-aware using `MPI.has_cuda` before reporting issues.
+    """
     end
 elseif backend_name == "AMDGPU"
     Pkg.add("AMDGPU")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,17 @@ using DoubleFloats
     end
     CUDA.precompile_runtime()
     ArrayType = CUDA.CuArray
+
+    MPI.Init()
+    if !MPI.has_cuda()
+        @error """
+        Your MPI implementation may not support CUDA.
+        To force running the tests anyway set the environment
+        variable `JULIA_MPI_HAS_CUDA=true`.
+        """
+        MPI.versioninfo()
+        exit(1)
+    end
 elseif backend_name == "AMDGPU"
     Pkg.add("AMDGPU")
     ENV["JULIA_MPI_TEST_ARRAYTYPE"] = "ROCArray"


### PR DESCRIPTION
Since https://github.com/JuliaGPU/buildkite/commit/ed35a7903835c0ee89493898821eca0ec38efefb CUDA agent no longer have a version tag.
