### PR TITLE
use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![codecov.io](https://codecov.io/github/JuliaParallel/MPI.jl/coverage.svg?branch=master)](https://codecov.io/github/JuliaParallel/MPI.jl?branch=master)
 [![Coverage Status](https://coveralls.io/repos/JuliaParallel/MPI.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaParallel/MPI.jl?branch=master)
 
-This provides [Julia](http://julialang.org/) interface to the Message Passing Interface ([MPI](http://www.mpi-forum.org/)), roughly inspired by [mpi4py](https://github.com/mpi4py/mpi4py/).
+This provides [Julia](https://julialang.org/) interface to the Message Passing Interface ([MPI](https://www.mpi-forum.org/)), roughly inspired by [mpi4py](https://github.com/mpi4py/mpi4py/).
 
 Please see the [documentation](https://juliaparallel.github.io/MPI.jl/stable/) for instructions on [configuration](https://juliaparallel.github.io/MPI.jl/stable/configuration/) and [usage](https://juliaparallel.github.io/MPI.jl/stable/usage/).
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,7 +2,7 @@
 
 By default, MPI.jl will download and link against the following MPI implementations:
 - [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi) on Windows
-- [MPICH](http://www.mpich.org/) on all other platforms
+- [MPICH](https://www.mpich.org/) on all other platforms
 
 This is suitable for most single-node use cases, but for larger systems, such as HPC
 clusters or multi-GPU machines, you will probably want to configure against a
@@ -30,12 +30,12 @@ julia --project -e 'using Pkg; Pkg.add("MPIPreferences")'
 MPI.jl requires a shared library installation of a C MPI library, supporting the MPI 3.0
 standard or later. The following MPI implementations should work out-of-the-box with MPI.jl:
 
-- [Open MPI](http://www.open-mpi.org/)
-- [MPICH](http://www.mpich.org/) (v3.1 or later)
+- [Open MPI](https://www.open-mpi.org/)
+- [MPICH](https://www.mpich.org/) (v3.1 or later)
 - [Intel MPI](https://software.intel.com/en-us/mpi-library)
 - [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi)
 - [IBM Spectrum MPI](https://www.ibm.com/us-en/marketplace/spectrum-mpi)
-- [MVAPICH](http://mvapich.cse.ohio-state.edu/)
+- [MVAPICH](https://mvapich.cse.ohio-state.edu/)
 - [Cray MPICH](https://docs.nersc.gov/development/compilers/wrappers/)
 - [Fujitsu MPI](https://www.fujitsu.com/global/about/resources/publications/technicalreview/2020-03/article07.html#cap-03)
 - [HPE MPT/HMPT](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00105727en_us)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,8 @@
 # MPI.jl
 
-This is a basic [Julia](http://julialang.org/) wrapper for the portable message passing
-system Message Passing Interface ([MPI](http://www.mpi-forum.org/)). Inspiration is taken from
-[mpi4py](http://mpi4py.scipy.org), although we generally follow the C and not the C++ MPI API.
+This is a basic [Julia](https://julialang.org/) wrapper for the portable message passing
+system Message Passing Interface ([MPI](https://www.mpi-forum.org/)). Inspiration is taken from
+[mpi4py](https://mpi4py.readthedocs.io/en/stable/), although we generally follow the C and not the C++ MPI API.
 (The C++ MPI API is deprecated.)
 
 If you use MPI.jl in your work, please cite the following paper:


### PR DESCRIPTION
mpi4py's dead link was replaced with it's Read the Docs rather than GitHub Pages link