### PR TITLE
url updates

### DIFF
--- a/docs/examples/05-job_schedule.jl
+++ b/docs/examples/05-job_schedule.jl
@@ -3,8 +3,8 @@
 # assigns one element to each worker to compute the operation.
 # When the worker is finished, the root sends another element
 # until each element is added 100
-# Inspired on
-# https://www.hpc.ntnu.no/ntnu-hpc-group/vilje/user-guide/software/mpi-and-mpi-io-training-tutorial/basic-mpi/job-queue
+# Inspired on https://www.hpc.ntnu.no/vilje/software/mpi-and-mpi-io-training-tutorial/
+# wget https://www.hpc.ntnu.no/wp-content/uploads/2019/09/mpiexamples.tar.gz
 
 using MPI
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 By default, MPI.jl will download and link against the following MPI implementations:
-- [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi) on Windows
+- [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi) on Windows
 - [MPICH](http://www.mpich.org/) on all other platforms
 
 This is suitable for most single-node use cases, but for larger systems, such as HPC
@@ -32,9 +32,9 @@ standard or later. The following MPI implementations should work out-of-the-box 
 
 - [Open MPI](http://www.open-mpi.org/)
 - [MPICH](http://www.mpich.org/) (v3.1 or later)
-- [Intel MPI](https://software.intel.com/en-us/mpi-library)
-- [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi)
-- [IBM Spectrum MPI](https://www.ibm.com/us-en/marketplace/spectrum-mpi)
+- [Intel MPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/mpi-library.html)
+- [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi)
+- [IBM Spectrum MPI](https://www.ibm.com/products/spectrum-mpi)
 - [MVAPICH](http://mvapich.cse.ohio-state.edu/)
 - [Cray MPICH](https://docs.nersc.gov/development/compilers/wrappers/)
 - [Fujitsu MPI](https://www.fujitsu.com/global/about/resources/publications/technicalreview/2020-03/article07.html#cap-03)
@@ -163,7 +163,7 @@ run on a non-GPU enabled node without needing a separate `LocalPreferences.toml`
 
 The following MPI implementations are provided as JLL packages and automatically obtained when installing MPI.jl:
 
-- `MicrosoftMPI_jll`: [Microsoft MPI](https://docs.microsoft.com/en-us/message-passing-interface/microsoft-mpi) Default for Windows
+- `MicrosoftMPI_jll`: [Microsoft MPI](https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi) Default for Windows
 - `MPICH_jll`: [MPICH](https://www.mpich.org/). Default for all other systems
 - `OpenMPI_jll`: [Open MPI](https://www.open-mpi.org/)
 - `MPItrampoline_jll`: [MPItrampoline](https://github.com/eschnett/MPItrampoline): an MPI forwarding layer.

--- a/docs/src/knownissues.md
+++ b/docs/src/knownissues.md
@@ -109,7 +109,7 @@ For further information see
 
 ## UCX
 
-[UCX](https://www.openucx.org/) is a communication framework used by several MPI implementations.
+[UCX](https://openucx.org/) is a communication framework used by several MPI implementations.
 
 ### Memory cache
 


### PR DESCRIPTION
docs/examples/05-job_schedule.jl

faulty link, so download instead the .tar.gz

```
$ tar xf mpiexamples.tar.gz
$ tree --noreport mpi_examples/basic_mpi/04_job_queue
mpi_examples/basic_mpi/04_job_queue
├── Makefile
├── job.sh
└── src
    └── job_queue.c
$ 
```

docs/src/configuration.md

the link

`https://www.ibm.com/us-en/marketplace/spectrum-mpi`

redirects to

Find a product (`https://www.ibm.com/us-en/products`)

the rest of the pull just deals with ordinary redirects

<hr>

.github/dependabot.yml

didn't bother to deal with this

the link `https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates` redirects to `https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file`