### PR TITLE
[GHA] Update `julia-actions/setup-julia` to v2

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,7 +8,7 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: 1.3
       - name: Pkg.add("CompatHelper")

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v2

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.base_ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: '1'
     # current branch

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         arch: ${{ matrix.julia_arch }}
         version: ${{ matrix.julia_version }}
@@ -108,7 +108,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         arch: ${{ matrix.julia_arch }}
         version: ${{ matrix.julia_version }}
@@ -167,7 +167,7 @@ jobs:
       run: |
         brew install "${{ matrix.mpi }}"
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
         arch: ${{ matrix.julia_arch }}
@@ -223,7 +223,7 @@ jobs:
       env:
         MPI: ${{ matrix.mpi }}
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
 
@@ -266,7 +266,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: "1"
 
@@ -309,7 +309,7 @@ jobs:
       run: msmpisetup.exe -unattend -minimal
       shell: cmd
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
 
@@ -365,7 +365,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
 
@@ -438,7 +438,7 @@ jobs:
       env:
         MPIWrapper: ${{matrix.MPIWrapper}}
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
 
@@ -505,7 +505,7 @@ jobs:
       env:
         MPIWrapper: ${{matrix.MPIWrapper}}
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: ${{ matrix.julia_version }}
 
@@ -557,7 +557,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - uses: julia-actions/setup-julia@v1
+    - uses: julia-actions/setup-julia@v2
       with:
         version: "1"
 


### PR DESCRIPTION
Unclear why Dependabot fails to update this workflow.