### PR TITLE
Always ensure consistency of new MPI datatypes

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -446,8 +446,10 @@ function create!(newtype::Datatype, ::Type{T}) where {T}
     types = Datatype[]
 
     if isprimitivetype(T)
-        # primitive type
-        szrem = sz = sizeof(T)
+        # This is a primitive type.  Create a type which has size an integer multiple of its
+        # alignment on the Julia side: <https://github.com/JuliaParallel/MPI.jl/issues/853>.
+        al = Base.datatype_alignment(T)
+        szrem = sz = cld(sizeof(T), al) * al
         disp = 0
         for (i,basetype) in (8 => Datatype(UInt64), 4 => Datatype(UInt32), 2 => Datatype(UInt16), 1 => Datatype(UInt8))
             if sz == i

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -149,7 +149,7 @@ end
 
 function Datatype(::Type{T}) where {T}
     global created_datatypes
-    get!(created_datatypes, T) do
+    datatype = get!(created_datatypes, T) do
         datatype = Datatype()
         # lazily initialize so that it can be safely precompiled
         function init()
@@ -162,6 +162,15 @@ function Datatype(::Type{T}) where {T}
         init()
         datatype
     end
+
+    # Make sure the "aligned" size of the type matches the MPI "extent".
+    sz = sizeof(T)
+    al = Base.datatype_alignment(T)
+    mpi_extent = Types.extent(datatype)
+    aligned_size = (0, cld(sz,al)*al)
+    @assert mpi_extent == aligned_size "The MPI extent of type $(T) ($(mpi_extent[2])) does not match the size expected by Julia ($(aligned_size[2]))"
+
+    return datatype
 end
 
 function Base.show(io::IO, datatype::Datatype)


### PR DESCRIPTION
Also:

* skip test of custom primitive type of size 80 on 32-bit systems in Julia v1.12+, as the MPI extent doesn't match Julia's aligned size
* add a test for a new primitive datatype larger than 64 bits which should work on 32-bit systems

With this PR, on a 32-bit linux I get

```julia-repl
julia> using MPI

julia> MPI.Init();

julia> primitive type Primitive80 80 end

julia> MPI.Datatype(Primitive80)
ERROR: AssertionError: The MPI extent of type Primitive80 (12) does not match the size expected by Julia (16)
Stacktrace:
 [1] MPI.Datatype(::Type{Primitive80})
   @ MPI ~/.julia/packages/MPI/FiDGt/src/datatypes.jl:171
 [2] top-level scope
   @ REPL[4]:1
```

which should be better than silently getting incorrect results at runtime.

Fix #853.

@simonbyrne @vchuravy can you see cases where the consistency test added inside the constructor of the `MPI.Datatype` can cause problems?