### PR TITLE
Print also `mpiexec` and its path in `versioninfo()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.22"
+version = "0.20.23"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -119,4 +119,9 @@ function versioninfo(io::IO=stdout)
     for line in split(Get_library_version(), '\n')
         println(io, "    ", line)
     end
+    println(io, "  MPI launcher: ", mpiexec()[1])
+    mpiexec_path = Sys.which(mpiexec()[1])
+    if !isnothing(mpiexec_path)
+        println(io, "  MPI launcher path: ", mpiexec_path)
+    end
 end


### PR DESCRIPTION
I often want to quickly find out what's the pah of the `mpiexec` associated to the current environment and I'm always disappointed this isn't shown in `versioninfo`, while I appreciate we show the full path of `libmpi`.