### PR TITLE
CI: Update unit tests from `ubuntu-20.04` to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -205,7 +205,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       JULIA_MPI_TEST_BINARY: system
@@ -406,7 +406,7 @@ jobs:
 
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       JULIA_MPI_TEST_BINARY: MPItrampoline_jll


### PR DESCRIPTION
Alternative to #899 (closes #899).

See #899 for motivation.