### PR TITLE
GitHub Actions CI: Increase the timeouts (from 20 minutes to 40 minutes) for the `test-mpitrampoline-jll` and `test-system-brew` jobs

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -135,7 +135,7 @@ jobs:
     - uses: julia-actions/julia-runtest@v1
 
   test-system-brew:
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         os:
@@ -340,7 +340,7 @@ jobs:
 
 
   test-mpitrampoline-jll:
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       matrix:
         os:


### PR DESCRIPTION
These jobs are currently timing out on master. See e.g. #898.

Let's see if they pass once we increase the timeout from 20 minutes to 40 minutes.