### PR TITLE
Update AMDGPU compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
 Distributed = "1"
-AMDGPU = "0.6, 0.7, 0.8, 0.9, 1"
+AMDGPU = "0.6, 0.7, 0.8, 0.9, 1, 2"
 CUDA = "3, 4, 5"
 DocStringExtensions = "0.8, 0.9"
 Libdl = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -11,7 +11,7 @@ AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
-AMDGPU = "0.6, 0.7, 0.8, 0.9, 1"
+AMDGPU = "0.6, 0.7, 0.8, 0.9, 1, 2"
 CUDA = "3, 4, 5"
 DoubleFloats = "1.4"
 MPIPreferences = "0.1"


### PR DESCRIPTION
This PR updates compat entries for AMDGPU 2.0 breaking release for both MPI project and test subfolder.

Note that the patch bump was already done so I left things to 0.20.23.