### PR TITLE
Fix definition of `Buffer` methods in GPU pkgextensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MPI"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 authors = []
-version = "0.20.25"
+version = "0.20.26"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -1,7 +1,7 @@
 module AMDGPUExt
 
 using AMDGPU: AMDGPU
-using MPI: MPIPtr, Buffer, Datatype
+using MPI: MPI, MPIPtr, Buffer, Datatype
 
 function Base.cconvert(::Type{MPIPtr}, A::AMDGPU.ROCArray{T}) where T
     A
@@ -19,7 +19,7 @@ function Base.unsafe_convert(::Type{MPIPtr}, V::SubArray{T,N,P,I,true}) where {T
     return reinterpret(MPIPtr, pV)
 end
 
-function Buffer(arr::AMDGPU.ROCArray)
+function MPI.Buffer(arr::AMDGPU.ROCArray)
     Buffer(arr, Cint(length(arr)), Datatype(eltype(arr)))
 end
 

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -1,7 +1,7 @@
 module CUDAExt
 
 using CUDA: CUDA
-using MPI: MPIPtr, Buffer, Datatype
+using MPI: MPI, MPIPtr, Buffer, Datatype
 
 function Base.cconvert(::Type{MPIPtr}, buf::CUDA.CuArray{T}) where T
     Base.cconvert(CUDA.CuPtr{T}, buf) # returns DeviceBuffer
@@ -19,7 +19,7 @@ function Base.unsafe_convert(::Type{MPIPtr}, V::SubArray{T,N,P,I,true}) where {T
     return reinterpret(MPIPtr, pV)
 end
 
-function Buffer(arr::CUDA.CuArray)
+function MPI.Buffer(arr::CUDA.CuArray)
     Buffer(arr, Cint(length(arr)), Datatype(eltype(arr)))
 end
 


### PR DESCRIPTION
This isn't actually broken at the moment (reason why tests passed in #944 :innocent:), but this is the better way to do it