### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,7 @@
     - label: "Build OpenMPI"
       key: "cuda-build-openmpi"
       agents:
-        queue: "juliagpu"
-        cuda: "*"
+        queue: "cuda"
       env:
         # This is broken for OpenMPI 5 and Julia 1.12, so we stick with OpenMPI 4
         OPENMPI_VER: "4.1"
@@ -60,8 +59,7 @@
             version: "{{matrix.version}}"
             persist_depot_dirs: packages,artifacts,compiled
       agents:
-        queue: "juliagpu"
-        cuda: "*"
+        queue: "cuda"
       if: build.message !~ /\[skip tests\]/
       timeout_in_minutes: 90
       env:
@@ -105,8 +103,7 @@
     - label: "Build OpenMPI"
       key: "rocm-build-openmpi"
       agents:
-        queue: "juliagpu"
-        rocm: "*"
+        queue: "rocm"
       env:
         # This is broken for OpenMPI 5 and Julia 1.12.
         # It is broken for OpenMPI 4 for all versions of Julia. So we use OpenMPI 5 and skip Julia 1.12
@@ -170,8 +167,7 @@
             version: "{{matrix.version}}"
             persist_depot_dirs: packages,artifacts,compiled
       agents:
-        queue: "juliagpu"
-        rocm: "*"
+        queue: "rocm"
       if: build.message !~ /\[skip tests\]/
       timeout_in_minutes: 90
       env:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"` or `queue: "rocm"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)