### PR TITLE
Only use stdcall calling convention on 32-bit Windows

### DIFF
--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -87,7 +87,7 @@ Base.unsafe_convert(::Type{MPIPtr}, x::SentinelPtr) = reinterpret(MPIPtr, x)
     $(Expr(:block, initexprs...))
 end
 
-const use_stdcall = startswith(basename(libmpi), "msmpi")
+const use_stdcall = startswith(basename(libmpi), "msmpi") && Sys.WORD_SIZE == 32
 
 macro mpicall(expr)
     @assert expr isa Expr && expr.head == :call && expr.args[1] == :ccall


### PR DESCRIPTION
Ref: https://github.com/JuliaParallel/MPI.jl/issues/954#issuecomment-5039547238.