### PR TITLE
Fix a couple of bugs detected by JET

### DIFF
--- a/src/collective.jl
+++ b/src/collective.jl
@@ -909,8 +909,11 @@ function Neighbor_alltoall!(sendbuf::UBuffer, recvbuf::UBuffer, graph_comm::Comm
     return recvbuf.data
 end
 
+# The MPI standard does not allow `MPI_IN_PLACE` in neighborhood collectives,
+# and implementations are not required to detect the error (e.g. MPICH
+# crashes), so reject it in the wrapper.
 Neighbor_alltoall!(sendbuf::InPlace, recvbuf::UBuffer, graph_comm::Comm) =
-    Neighbor_alltoall!(UBuffer(IN_PLACE), recvbuf, graph_comm)
+    throw(ArgumentError("MPI_IN_PLACE is not allowed in neighborhood collectives"))
 Neighbor_alltoall!(sendrecvbuf::UBuffer, graph_comm::Comm) =
     Neighbor_alltoall!(IN_PLACE, sendrecvbuf, graph_comm)
 Neighbor_alltoall(sendbuf::UBuffer, graph_comm::Comm) =
@@ -962,6 +965,11 @@ Neighbor_allgather!(sendbuf::Union{Ref,AbstractArray}, recvbuf::AbstractArray, g
     Neighbor_allgather!(sendbuf, UBuffer(recvbuf, length(sendbuf)), graph_comm)
 
 
+# The MPI standard does not allow `MPI_IN_PLACE` in neighborhood collectives,
+# and implementations are not required to detect the error (e.g. MPICH
+# crashes), so reject it in the wrapper.
+Neighbor_allgather!(sendbuf::InPlace, recvbuf::UBuffer, graph_comm::Comm) =
+    throw(ArgumentError("MPI_IN_PLACE is not allowed in neighborhood collectives"))
 Neighbor_allgather!(sendrecvbuf::UBuffer, graph_comm::Comm) =
     Neighbor_allgather!(IN_PLACE, sendrecvbuf, graph_comm)
 
@@ -990,5 +998,10 @@ Neighbor_allgatherv!(sendbuf::Union{Ref,AbstractArray}, recvbuf::AbstractArray, 
     Neighbor_allgatherv!(sendbuf, VBuffer(recvbuf, length(sendbuf)), graph_comm)
 
 
+# The MPI standard does not allow `MPI_IN_PLACE` in neighborhood collectives,
+# and implementations are not required to detect the error (e.g. MPICH
+# crashes), so reject it in the wrapper.
+Neighbor_allgatherv!(sendbuf::InPlace, recvbuf::VBuffer, graph_comm::Comm) =
+    throw(ArgumentError("MPI_IN_PLACE is not allowed in neighborhood collectives"))
 Neighbor_allgatherv!(sendrecvbuf::VBuffer, graph_comm::Comm) =
     Neighbor_allgatherv!(IN_PLACE, sendrecvbuf, graph_comm)

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -912,7 +912,7 @@ end
 Neighbor_alltoall!(sendbuf::InPlace, recvbuf::UBuffer, graph_comm::Comm) =
     Neighbor_alltoall!(UBuffer(IN_PLACE), recvbuf, graph_comm)
 Neighbor_alltoall!(sendrecvbuf::UBuffer, graph_comm::Comm) =
-    Neighbor_alltoall!(IN_PLACE, sendrecvbuf, comm)
+    Neighbor_alltoall!(IN_PLACE, sendrecvbuf, graph_comm)
 Neighbor_alltoall(sendbuf::UBuffer, graph_comm::Comm) =
     Neighbor_alltoall!(sendbuf, similar(sendbuf), graph_comm)
 

--- a/src/collective.jl
+++ b/src/collective.jl
@@ -182,6 +182,10 @@ function scatter(objs::Union{AbstractVector, Nothing}, comm::Comm; root::Integer
     isroot = Comm_rank(comm) == root
 
     if isroot
+        if isnothing(objs)
+            throw(ArgumentError("Argument objs must not be `nothing` on the root rank."))
+        end
+
         if length(objs) != Comm_size(comm)
             throw(ArgumentError("Length of argument objs ($(length(objs))) != number of ranks in comm ($(Comm_size(comm)))."))
         end

--- a/test/test_neighbor_allgather.jl
+++ b/test/test_neighbor_allgather.jl
@@ -18,6 +18,11 @@ try
     MPI.Neighbor_allgather!(send, recv, graph_comm)
 
     @test sort(recv) == collect(0:rank).^2
+
+    # The MPI standard does not allow `MPI_IN_PLACE` in neighborhood
+    # collectives, so the wrapper rejects it.
+    @test_throws ArgumentError MPI.Neighbor_allgather!(UBuffer(recv, 1), graph_comm)
+    @test_throws ArgumentError MPI.Neighbor_allgather!(MPI.IN_PLACE, UBuffer(recv, 1), graph_comm)
 catch e
     if isa(e, MPI.FeatureLevelError)
         @test_broken e.min_version <= MPI.Get_version()

--- a/test/test_neighbor_allgatherv.jl
+++ b/test/test_neighbor_allgatherv.jl
@@ -21,6 +21,11 @@ try
     MPI.Neighbor_allgatherv!(send, VBuffer(recv, recv_count), graph_comm)
 
     @test sort(recv) == [j for j ∈ 0:rank for i ∈ 0:j]
+
+    # The MPI standard does not allow `MPI_IN_PLACE` in neighborhood
+    # collectives, so the wrapper rejects it.
+    @test_throws ArgumentError MPI.Neighbor_allgatherv!(VBuffer(recv, recv_count), graph_comm)
+    @test_throws ArgumentError MPI.Neighbor_allgatherv!(MPI.IN_PLACE, VBuffer(recv, recv_count), graph_comm)
 catch e
     if isa(e, MPI.FeatureLevelError)
         @test_broken e.min_version <= MPI.Get_version()

--- a/test/test_neighbor_alltoall.jl
+++ b/test/test_neighbor_alltoall.jl
@@ -25,21 +25,10 @@ try
     @test sort(recv2[1:(rank + 1)]) == collect(0:rank).^2
 
     # The MPI standard does not allow `MPI_IN_PLACE` in neighborhood
-    # collectives, so implementations are expected to error, but the error
-    # must come from the MPI library, not from the Julia wrapper.
-    @test try
-        MPI.Neighbor_alltoall!(UBuffer(fill(-1, rank + 1), 1), graph_comm)
-        true
-    catch e
-        if e isa MPI.MPIError
-            true
-        else
-            io = IOBuffer()
-            Base.showerror(io, e)
-            @error String(take!(io))
-            false
-        end
-    end
+    # collectives, and implementations are not required to detect the error
+    # (MPICH crashes with a segfault), so the wrapper rejects it.
+    @test_throws ArgumentError MPI.Neighbor_alltoall!(UBuffer(fill(-1, rank + 1), 1), graph_comm)
+    @test_throws ArgumentError MPI.Neighbor_alltoall!(MPI.IN_PLACE, UBuffer(fill(-1, rank + 1), 1), graph_comm)
 catch e
     if isa(e, MPI.FeatureLevelError)
         @test_broken e.min_version <= MPI.Get_version()

--- a/test/test_neighbor_alltoall.jl
+++ b/test/test_neighbor_alltoall.jl
@@ -19,6 +19,27 @@ try
     MPI.Neighbor_alltoall!(UBuffer(send,1), UBuffer(recv,1), graph_comm);
 
     @test sort(recv) == collect(0:rank).^2
+
+    # Allocating variant
+    recv2 = MPI.Neighbor_alltoall(UBuffer(send, 1), graph_comm)
+    @test sort(recv2[1:(rank + 1)]) == collect(0:rank).^2
+
+    # The MPI standard does not allow `MPI_IN_PLACE` in neighborhood
+    # collectives, so implementations are expected to error, but the error
+    # must come from the MPI library, not from the Julia wrapper.
+    @test try
+        MPI.Neighbor_alltoall!(UBuffer(fill(-1, rank + 1), 1), graph_comm)
+        true
+    catch e
+        if e isa MPI.MPIError
+            true
+        else
+            io = IOBuffer()
+            Base.showerror(io, e)
+            @error String(take!(io))
+            false
+        end
+    end
 catch e
     if isa(e, MPI.FeatureLevelError)
         @test_broken e.min_version <= MPI.Get_version()

--- a/test/test_scatter.jl
+++ b/test/test_scatter.jl
@@ -52,5 +52,9 @@ if isroot
     @test objs_gathered == objs_sized
 end
 
+if isroot
+    @test_throws ArgumentError MPI.scatter(nothing, comm; root)
+end
+
 MPI.Finalize()
 @test MPI.Finalized()


### PR DESCRIPTION
Couple of bugs with simple fixes spotted with JET (now that it works: #957):
```
┌ scatter(objs::Union{Nothing, AbstractVector}, comm::MPI.Comm; root::Integer) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:193
│┌ iterate(e::Base.Iterators.Enumerate{Nothing}) @ Base.Iterators ./iterators.jl:196
││┌ iterate(e::Base.Iterators.Enumerate{Nothing}, state::Tuple{Int64}) @ Base.Iterators ./iterators.jl:197
│││ no matching method found `iterate(::Nothing)`: n = Base.Iterators.iterate(tuple((e::Base.Iterators.Enumerate{Nothing}).itr::Nothing)::Tuple{Nothing}, rest...)
││└────────────────────
┌ scatter(objs::Union{Nothing, AbstractVector}, comm::MPI.Comm) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:181
│┌ scatter(objs::Nothing, comm::MPI.Comm; root::Int64) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:185
││ no matching method found `length(::Nothing)`: MPI.length(objs::Nothing)
│└────────────────────
[...]
┌ Neighbor_alltoall!(sendrecvbuf::UBuffer, graph_comm::MPI.Comm) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:910
│ `MPI.comm` is not defined: MPI.comm
└────────────────────
```

Unfortunately the MPI programming model based on conditionals doesn't play nicely with JET, which is [unable to handle exhaustive branches](https://github.com/aviatesk/JET.jl/issues/801).  That's the cause of
```
┌ bcast(obj::Any, comm::MPI.Comm; root::Integer) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:86
│┌ bcast(obj::Any, root::Integer, comm::MPI.Comm) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:99
││ local variable `buf` may be undefined: buf::Vector{UInt8}
│└────────────────────
│┌ bcast(obj::Any, root::Integer, comm::MPI.Comm) @ MPI /home/mose/.julia/packages/MPI/FC7iL/src/collective.jl:101
││ local variable `buf` may be undefined: buf::Vector{UInt8}
│└────────────────────
```
https://github.com/JuliaParallel/MPI.jl/blob/e572552341e183ae2ffbdc85a361d4f696a34170/src/collective.jl#L91-L101
`buf` is always defined before line 99, but JET/the compiler doesn't see that.  I don't see a simple solution to this without duplicating the call to `Bcast!(count, root, comm)`.