### PR TITLE
Do not call MPI functions directly from finalizers

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -88,6 +88,7 @@ call(hook) = hook()
 
 include("implementations.jl")
 include("error.jl")
+include("deferred_free.jl")
 include("info.jl")
 include("group.jl")
 include("comm.jl")

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -109,6 +109,73 @@ macro mpicall(expr)
     return esc(expr)
 end
 
+# Queue of pending `MPI_*_free` calls enqueued by finalizers of MPI handle objects.
+#
+# Finalizers must not call MPI functions directly: a finalizer can run at any point of
+# the program where the garbage collector is invoked, including concurrently with an
+# MPI call made by another thread (which is permitted only when MPI was initialized
+# with `MPI_THREAD_MULTIPLE`), or in the middle of an MPI call which runs a Julia
+# callback (calling MPI functions inside such callbacks is erroneous).  Instead,
+# finalizers capture the handle to be freed in a closure and enqueue it with
+# `defer_free!`, and the queue is drained by `drain_deferred_frees` before the next
+# MPI call made with `@mpichk`.
+const deferred_frees = Any[]
+const deferred_frees_lock = Base.Threads.SpinLock()
+# Number of enqueued closures, for a race-free fast emptiness check in
+# `drain_deferred_frees` without taking the lock.
+const deferred_frees_count = Base.Threads.Atomic{Int}(0)
+
+"""
+    API.defer_free!(f) -> Bool
+
+Enqueue the closure `f` to be called before the next MPI call made with `@mpichk`.
+Returns whether `f` was enqueued: this function is meant to be called from finalizers,
+which must never block on a lock potentially held by the interrupted task, so when the
+queue lock is contended the closure is not enqueued and the caller should re-register
+its finalizer to retry at the next garbage collection.
+"""
+function defer_free!(@nospecialize(f))
+    trylock(deferred_frees_lock) || return false
+    try
+        push!(deferred_frees, f)
+        Base.Threads.atomic_add!(deferred_frees_count, 1)
+    finally
+        unlock(deferred_frees_lock)
+    end
+    return true
+end
+
+"""
+    API.drain_deferred_frees()
+
+Run all the closures enqueued with [`API.defer_free!`](@ref).  Called before each MPI
+call made with `@mpichk`.
+"""
+function drain_deferred_frees()
+    # fast path, keep it cheap: this runs before every MPI call
+    deferred_frees_count[] == 0 && return nothing
+    # if the lock is contended, another task is already draining the queue
+    trylock(deferred_frees_lock) || return nothing
+    frees = try
+        frees = copy(deferred_frees)
+        empty!(deferred_frees)
+        Base.Threads.atomic_sub!(deferred_frees_count, length(frees))
+        frees
+    finally
+        unlock(deferred_frees_lock)
+    end
+    # Run the closures outside of the lock.  The MPI calls inside the closures
+    # re-enter this function, which terminates quickly because the queue has already
+    # been emptied.  Don't call MPI functions after `MPI_Finalize`: freeing handles is
+    # unnecessary at that point.
+    flag = Ref{Cint}()
+    MPI_Finalized(flag)
+    if flag[] == 0
+        foreach(f -> f(), frees)
+    end
+    return nothing
+end
+
 """
     FeatureLevelError
 
@@ -134,7 +201,10 @@ macro mpichk(expr, min_version=nothing)
 
     expr = macroexpand(@__MODULE__, :(@mpicall($expr)))
     # MPI_SUCCESS is defined to be 0
-    :((errcode = $(esc(expr))) == 0 || throw(MPIError(errcode)))
+    quote
+        drain_deferred_frees()
+        (errcode = $(esc(expr))) == 0 || throw(MPIError(errcode))
+    end
 end
 
 

--- a/src/comm.jl
+++ b/src/comm.jl
@@ -42,6 +42,13 @@ function free(comm::Comm)
     return nothing
 end
 
+function deferred_free_fn(comm::Comm)
+    comm == COMM_NULL && return nothing
+    val = comm.val
+    # int MPI_Comm_free(MPI_Comm *comm)
+    return () -> API.MPI_Comm_free(Ref(val))
+end
+
 
 """
     Comm_rank(comm::Comm)
@@ -90,7 +97,7 @@ $(_doc_external("MPI_Comm_group"))
 function Comm_group(comm::Comm)
     newgroup = Group()
     API.MPI_Comm_group(comm, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     newgroup
 end
 
@@ -105,7 +112,7 @@ $(_doc_external("MPI_Comm_remote_group"))
 function Comm_remote_group(comm::Comm)
     newgroup = Group()
     API.MPI_Comm_remote_group(comm, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     newgroup
 end
 
@@ -123,7 +130,7 @@ $(_doc_external("MPI_Comm_create"))
 function Comm_create(comm::Comm, group::Group)
     newcomm = Comm()
     API.MPI_Comm_create(comm, group, newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     newcomm
 end
 
@@ -141,7 +148,7 @@ $(_doc_external("MPI_Comm_create_group"))
 function Comm_create_group(comm::Comm, group::Group, tag::Integer)
     newcomm = Comm()
     API.MPI_Comm_create_group(comm, group, tag, newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     newcomm
 end
 
@@ -154,7 +161,7 @@ $(_doc_external("MPI_Comm_dup"))
 function Comm_dup(comm::Comm)
     newcomm = Comm()
     API.MPI_Comm_dup(comm, newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     newcomm
 end
 
@@ -177,7 +184,7 @@ function Comm_split(comm::Comm, color::Union{Integer, Nothing}, key::Integer)
     end
     newcomm = Comm()
     API.MPI_Comm_split(comm, color, key, newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     newcomm
 end
 
@@ -211,7 +218,7 @@ function Comm_split_type(comm::Comm, split_type, key::Integer; kwargs...)
     end
     newcomm = Comm()
     API.MPI_Comm_split_type(comm, split_type, key, Info(kwargs...), newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     newcomm
 end
 
@@ -240,7 +247,7 @@ function Comm_spawn(command::String, argv::Vector{String}, nprocs::Integer,
     #                    MPI_Info info, int root, MPI_Comm comm, MPI_Comm *intercomm,
     #                    int array_of_errcodes[])
     API.MPI_Comm_spawn(command, argv, nprocs, Info(kwargs...), 0, comm, intercomm, errors)
-    finalizer(free, intercomm)
+    finalizer(deferred_free, intercomm)
     return intercomm
 end
 
@@ -253,7 +260,7 @@ $(_doc_external("MPI_Intercomm_merge"))
 function Intercomm_merge(intercomm::Comm, flag::Bool)
     newcomm = Comm()
     API.MPI_Intercomm_merge(intercomm, Cint(flag), newcomm)
-    finalizer(free, newcomm)
+    finalizer(deferred_free, newcomm)
     return newcomm
 end
 

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -34,6 +34,13 @@ function free(dt::Datatype)
     return nothing
 end
 
+function deferred_free_fn(dt::Datatype)
+    dt == DATATYPE_NULL && return nothing
+    val = dt.val
+    # int MPI_Type_free(MPI_Type *type)
+    return () -> API.MPI_Type_free(Ref(val))
+end
+
 # attributes
 function create_keyval(::Type{Datatype})
     ref = Ref(Cint(0))
@@ -189,7 +196,7 @@ end
 module Types
 
 import MPI
-import MPI: API, _doc_external, Datatype, MPI_Datatype, MPI_Aint, free
+import MPI: API, _doc_external, Datatype, MPI_Datatype, MPI_Aint, free, deferred_free
 
 function size(dt::Datatype)
     dtsize = Ref{Cint}()
@@ -226,7 +233,7 @@ communication.
 $(_doc_external("MPI_Type_contiguous"))
 """
 function create_contiguous(count::Integer, oldtype::Datatype)
-    finalizer(free, create_contiguous!(Datatype(), count, oldtype))
+    finalizer(deferred_free, create_contiguous!(Datatype(), count, oldtype))
 end
 
 function create_contiguous!(newtype::Datatype, count::Integer, oldtype::Datatype)
@@ -269,7 +276,7 @@ where each segment represents an `Int64`.
 $(_doc_external("MPI_Type_vector"))
 """
 function create_vector(count::Integer, blocklength::Integer, stride::Integer, oldtype::Datatype)
-    finalizer(free, create_vector!(Datatype(), count, blocklength, stride, oldtype))
+    finalizer(deferred_free, create_vector!(Datatype(), count, blocklength, stride, oldtype))
 end
 function create_vector!(newtype::Datatype, count::Integer, blocklength::Integer, stride::Integer, oldtype::Datatype)
     # int MPI_Type_vector(int count, int blocklength, int stride,
@@ -298,7 +305,7 @@ MPI.Types.commit!(datatype)
 $(_doc_external("MPI_Type_create_hvector"))
 """
 function create_hvector(count::Integer, blocklength::Integer, stride::Integer, oldtype::Datatype)
-    finalizer(free, create_hvector!(Datatype(), count, blocklength, stride, oldtype))
+    finalizer(deferred_free, create_hvector!(Datatype(), count, blocklength, stride, oldtype))
 end
 function create_hvector!(newtype::Datatype, count::Integer, blocklength::Integer, stride::Integer, oldtype::Datatype)
     # int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride,
@@ -326,7 +333,7 @@ $(_doc_external("MPI_Type_create_subarray"))
 """
 function create_subarray(sizes, subsizes, offset, oldtype::Datatype;
                          rowmajor=false)
-    finalizer(free, create_subarray!(Datatype(), sizes, subsizes, offset, oldtype; rowmajor=rowmajor))
+    finalizer(deferred_free, create_subarray!(Datatype(), sizes, subsizes, offset, oldtype; rowmajor=rowmajor))
 end
 function create_subarray!(newtype::Datatype, sizes, subsizes, offset, oldtype::Datatype;
                           rowmajor=false)
@@ -359,7 +366,7 @@ communication.
 $(_doc_external("MPI_Type_create_struct"))
 """
 function create_struct(blocklengths, displacements, types)
-    finalizer(free, create_struct!(Datatype(), blocklengths, displacements, types))
+    finalizer(deferred_free, create_struct!(Datatype(), blocklengths, displacements, types))
 end
 function create_struct!(newtype::Datatype, blocklengths, displacements, types)
     @assert (N = length(blocklengths)) == length(displacements) == length(types)
@@ -396,7 +403,7 @@ communication.
 $(_doc_external("MPI_Type_create_resized"))
 """
 function create_resized(oldtype::Datatype, lb::Integer, extent::Integer)
-    finalizer(free, create_resized!(Datatype(), oldtype, lb, extent))
+    finalizer(deferred_free, create_resized!(Datatype(), oldtype, lb, extent))
 end
 function create_resized!(newtype::Datatype, oldtype::Datatype, lb::Integer, extent::Integer)
     # int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb,

--- a/src/deferred_free.jl
+++ b/src/deferred_free.jl
@@ -1,0 +1,37 @@
+"""
+    MPI.deferred_free(obj)
+
+Finalizer for MPI handle objects (communicators, groups, datatypes, operators, infos,
+requests): instead of freeing the underlying MPI handle immediately, enqueue it to be
+freed before the next MPI call.
+
+Finalizers must not call MPI functions directly: a finalizer can run at any point of
+the program where the garbage collector is invoked, including concurrently with an MPI
+call made by another thread (which is permitted only when MPI was initialized with
+[`MPI.THREAD_MULTIPLE`](@ref ThreadLevel)), or in the middle of an MPI call which runs
+a Julia callback, such as a reduction with a user-defined operator (calling MPI
+functions inside such callbacks is erroneous).
+
+Use [`free`](@ref) to immediately free the handle instead.
+"""
+function deferred_free(obj)
+    f = deferred_free_fn(obj)
+    if f !== nothing && !API.defer_free!(f)
+        # the queue lock is contended: re-register the finalizer to retry at the next
+        # garbage collection
+        finalizer(deferred_free, obj)
+    end
+    return nothing
+end
+
+"""
+    MPI.deferred_free_fn(obj) -> Union{Function,Nothing}
+
+Return a closure which frees the MPI handle underlying `obj` without referencing `obj`
+itself, or `nothing` if there is nothing to free (e.g. the handle is null).  The
+closure is called before a later MPI call, after `obj` has been garbage-collected, so
+it must capture the raw handle value, not the object, and it must capture any other
+object which has to be kept alive until the handle is freed (e.g. the communication
+buffer of a request).
+"""
+function deferred_free_fn end

--- a/src/group.jl
+++ b/src/group.jl
@@ -30,6 +30,13 @@ function free(group::Group)
     return nothing
 end
 
+function deferred_free_fn(group::Group)
+    group == GROUP_NULL && return nothing
+    val = group.val
+    # int MPI_Group_free(MPI_Group *group)
+    return () -> API.MPI_Group_free(Ref(val))
+end
+
 """
     Group_size(group::Group)
 
@@ -95,34 +102,34 @@ end
 function Group_difference(group1::Group, group2::Group)
     newgroup = Group()
     API.MPI_Group_difference(group1, group2, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     return newgroup
 end
 
 function Group_intersection(group1::Group, group2::Group)
     newgroup = Group()
     API.MPI_Group_intersection(group1, group2, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     return newgroup
 end
 
 function Group_union(group1::Group, group2::Group)
     newgroup = Group()
     API.MPI_Group_union(group1, group2, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     return newgroup
 end
 
 function Group_excl(group::Group, ranks::Vector{Cint})
     newgroup = Group()
     API.MPI_Group_excl(group, length(ranks), ranks, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     return newgroup
 end
 
 function Group_incl(group::Group, ranks::Vector{Cint})
     newgroup = Group()
     API.MPI_Group_incl(group, length(ranks), ranks, newgroup)
-    finalizer(free, newgroup)
+    finalizer(deferred_free, newgroup)
     return newgroup
 end

--- a/src/info.jl
+++ b/src/info.jl
@@ -40,7 +40,7 @@ function Info(;init=false)
     info = Info(INFO_NULL.val)
     if init
         API.MPI_Info_create(info)
-        finalizer(free, info)
+        finalizer(deferred_free, info)
     end
     return info
 end
@@ -51,6 +51,13 @@ function free(info::Info)
         API.MPI_Info_free(info)
     end
     return nothing
+end
+
+function deferred_free_fn(info::Info)
+    info == INFO_NULL && return nothing
+    val = info.val
+    # int MPI_Info_free(MPI_Info *info)
+    return () -> API.MPI_Info_free(Ref(val))
 end
 
 function Base.setindex!(info::Info, value::AbstractString, key::Symbol)

--- a/src/nonblocking.jl
+++ b/src/nonblocking.jl
@@ -116,6 +116,8 @@ functions:
     `Base.unsafe_convert(::Type{Ptr{MPI_Request}}, req::R)``
 - setbuffer!(req::R, val)`: keep a reference to the communication buffer `val`.
   If `val == nothing`, then clear the reference.
+- `getbuffer(req::R)`: return the current reference to the communication buffer,
+  or `nothing` if the type does not maintain one.
 """
 abstract type AbstractRequest end
 
@@ -164,6 +166,19 @@ function free(req::AbstractRequest)
     return nothing
 end
 
+function deferred_free_fn(req::AbstractRequest)
+    isnull(req) && return nothing
+    val, buf = req.val, getbuffer(req)
+    return () -> begin
+        # int MPI_Request_free(MPI_Request *req)
+        API.MPI_Request_free(Ref(val))
+        # the closure keeps the communication buffer alive until the request has been
+        # freed
+        identity(buf)
+        return nothing
+    end
+end
+
 
 """
     MPI.Request()
@@ -180,10 +195,11 @@ mutable struct Request <: AbstractRequest
 end
 function Request()
     req = Request(API.MPI_REQUEST_NULL[], nothing)
-    return finalizer(free, req)
+    return finalizer(deferred_free, req)
 end
 
 setbuffer!(req::Request, val) = req.buffer = val
+getbuffer(req::Request) = req.buffer
 
 Base.cconvert(::Type{MPI_Request}, request::Request) = request
 Base.unsafe_convert(::Type{MPI_Request}, request::Request) = request.val
@@ -221,9 +237,10 @@ end
 
 function UnsafeRequest()
     req = UnsafeRequest(API.MPI_REQUEST_NULL[])
-    return finalizer(free, req)
+    return finalizer(deferred_free, req)
 end
 setbuffer!(req::UnsafeRequest, val) = nothing
+getbuffer(req::UnsafeRequest) = nothing
 
 Base.cconvert(::Type{MPI_Request}, request::UnsafeRequest) = request
 Base.unsafe_convert(::Type{MPI_Request}, request::UnsafeRequest) = request.val

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -76,6 +76,19 @@ function free(op::Op)
     return nothing
 end
 
+function deferred_free_fn(op::Op)
+    op == OP_NULL && return nothing
+    val, fptr = op.val, op.fptr
+    return () -> begin
+        # int MPI_Op_free(MPI_Op *op)
+        API.MPI_Op_free(Ref(val))
+        # the closure keeps `fptr` (the `@cfunction` of a user-defined operator) alive
+        # until the operator has been freed
+        identity(fptr)
+        return nothing
+    end
+end
+
 struct OpWrapper{F,T}
     f::F
 end
@@ -120,7 +133,7 @@ function Op(f, T=Any; iscommutative=false)
     # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)
     API.MPI_Op_create(fptr, iscommutative, op)
 
-    finalizer(free, op)
+    finalizer(deferred_free, op)
     return op
 end
 
@@ -175,7 +188,7 @@ macro RegisterOp(f, T)
                 # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)
                 $API.MPI_Op_create($(name_fptr)[], iscommutative, op)
 
-                finalizer($free, op)
+                finalizer($deferred_free, op)
             end
         end
     end

--- a/src/topology.jl
+++ b/src/topology.jl
@@ -51,7 +51,7 @@ function Cart_create(comm::Comm, dims; periodic = map(_->false, dims), reorder=f
     # int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[],
     #                     const int periods[], int reorder, MPI_Comm *comm_cart)
     API.MPI_Cart_create(comm, length(dims), dims, periodic, reorder, comm_cart)
-    comm_cart != COMM_NULL && finalizer(free, comm_cart)
+    comm_cart != COMM_NULL && finalizer(deferred_free, comm_cart)
     comm_cart
 end
 
@@ -168,7 +168,7 @@ function Cart_sub(comm::Comm, remain_dims)
     comm_sub = Comm()
     # int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *comm_new)
     API.MPI_Cart_sub(comm, remain_dims, comm_sub)
-    comm_sub != COMM_NULL && finalizer(free, comm_sub)
+    comm_sub != COMM_NULL && finalizer(deferred_free, comm_sub)
     comm_sub
 end
 

--- a/test/test_deferred_free.jl
+++ b/test/test_deferred_free.jl
@@ -1,0 +1,61 @@
+include("common.jl")
+
+MPI.Init()
+
+# Finalizers of MPI handle objects must not call MPI functions directly: they enqueue
+# the freeing of the underlying handle, and the queue is drained before the next MPI
+# call.  See `MPI.deferred_free`.
+
+# create unreferenced MPI handle objects to be garbage-collected
+function make_garbage()
+    comm = MPI.Comm_dup(MPI.COMM_WORLD)
+    group = MPI.Comm_group(MPI.COMM_WORLD)
+    dt = MPI.Types.create_contiguous(2, MPI.Datatype(Int))
+    info = MPI.Info(:mpi_jl_test_key => "true")
+    return nothing
+end
+
+@testset "deferred free" begin
+    # null handles have nothing to free
+    @test MPI.deferred_free_fn(MPI.COMM_NULL) === nothing
+    @test MPI.deferred_free_fn(MPI.GROUP_NULL) === nothing
+    @test MPI.deferred_free_fn(MPI.DATATYPE_NULL) === nothing
+    @test MPI.deferred_free_fn(MPI.INFO_NULL) === nothing
+    @test MPI.deferred_free_fn(MPI.Request()) === nothing
+    # non-null handles produce a closure
+    let comm = MPI.Comm_dup(MPI.COMM_WORLD)
+        @test MPI.deferred_free_fn(comm) isa Function
+        MPI.free(comm)  # explicit free is immediate
+        @test comm == MPI.COMM_NULL
+        # after an explicit free the finalizer has nothing to enqueue
+        @test MPI.deferred_free_fn(comm) === nothing
+    end
+
+    # garbage-collecting MPI handle objects enqueues the frees without calling MPI
+    count_before = MPI.API.deferred_frees_count[]
+    make_garbage()
+    GC.gc()
+    count_after = MPI.API.deferred_frees_count[]
+    @test count_after > count_before
+    # the queue is drained by the next MPI call
+    MPI.Barrier(MPI.COMM_WORLD)
+    @test MPI.API.deferred_frees_count[] == 0
+    @test isempty(MPI.API.deferred_frees)
+
+    # completed requests are finalized without enqueueing anything: their handle is
+    # already null after the wait
+    let sbuf = Float64[1.0], rbuf = Float64[0.0]
+        rank = MPI.Comm_rank(MPI.COMM_WORLD)
+        size = MPI.Comm_size(MPI.COMM_WORLD)
+        dst = mod(rank + 1, size)
+        src = mod(rank - 1, size)
+        rreq = MPI.Irecv!(rbuf, MPI.COMM_WORLD; source=src, tag=0)
+        sreq = MPI.Isend(sbuf, MPI.COMM_WORLD; dest=dst, tag=0)
+        MPI.Waitall([sreq, rreq])
+        @test MPI.deferred_free_fn(sreq) === nothing
+        @test MPI.deferred_free_fn(rreq) === nothing
+    end
+end
+
+MPI.Finalize()
+@test MPI.Finalized()


### PR DESCRIPTION
@vchuravy does this address your concerns in https://github.com/JuliaParallel/MPI.jl/pull/955#discussion_r3630535612?

However I'm not happy at all about the implementation, as it adds a new function call before each MPI call.  Benchmark:
```julia
using MPI
MPI.Init()

const comm = MPI.COMM_WORLD

function bench_rank(n)
    acc = 0
    for _ in 1:n
        acc += MPI.Comm_rank(comm)
    end
    return acc
end

function bench_get_count(n)
    # MPI_Get_count on a fabricated status: another cheap local @mpichk call
    status = MPI.Status(0, 0, 0, 0, 0)
    acc = 0
    for _ in 1:n
        acc += MPI.Get_count(status, UInt8)
    end
    return acc
end

const N = 10_000_000
bench_rank(1); bench_get_count(1)  # compile

for (name, f) in ("Comm_rank" => bench_rank, "Get_count" => bench_get_count)
    best = minimum((@elapsed f(N)) for _ in 1:5)
    println(name, ": ", round(best / N * 1e9, digits=2), " ns/call")
end

# allocations on the hot path must be zero
alloc = @allocated bench_rank(1000)
println("allocations for 1000 calls: ", alloc, " bytes")

MPI.Finalize()
```
on `master`, with 2 ranks:
```
Comm_rank: 3.88 ns/call
Comm_rank: 3.88 ns/call
Get_count: 5.56 ns/call
Get_count: 5.59 ns/call
allocations for 1000 calls: 0 bytes
allocations for 1000 calls: 0 bytes
```
on this branch:
```
Comm_rank: 5.5 ns/call
Comm_rank: 5.5 ns/call
Get_count: 15.7 ns/call
Get_count: 15.77 ns/call
allocations for 1000 calls: 0 bytes
allocations for 1000 calls: 0 bytes
```
The overhead is non-negligible (although of the order of ~nanoseconds)


> Finalizers can run at any point of the program where the garbage
> collector is invoked, including concurrently with an MPI call made by
> another thread (which is permitted only when MPI was initialized with
> `MPI_THREAD_MULTIPLE`), or in the middle of an MPI call which runs a
> Julia callback, such as a reduction with a user-defined operator
> (calling MPI functions inside such callbacks is erroneous).
> 
> Instead of calling the corresponding `MPI_*_free` function directly,
> the finalizers of MPI handle objects (communicators, groups, datatypes,
> operators, infos, requests) now capture the raw handle value in a
> closure and enqueue it, and the queue is drained before the next MPI
> call made with `@mpichk`: the fast path of the drain is a single atomic
> counter check, and enqueueing from a finalizer uses `trylock`, followed
> by re-registration of the finalizer when the lock is contended, as
> finalizers must never block on a lock.  This design is similar to how
> PythonCall.jl defers the freeing of Python objects from finalizers to
> the next time the GIL is held.
> 
> Explicit calls to `MPI.free` keep freeing the handle immediately.  The
> finalizers of `Win` and `FileHandle` objects are unchanged: freeing
> those handles is a synchronizing/collective operation, which deferral
> would not make safe.