### PR TITLE
Drop DoubleFloat test dep

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -18,7 +17,6 @@ MPIPreferences = {path = "../lib/MPIPreferences"}
 [compat]
 AMDGPU = "0.6, 0.7, 0.8, 0.9, 1, 2"
 CUDA = "3, 4, 5"
-DoubleFloats = "1.4"
 MPIPreferences = "0.1"
 TOML = "< 0.0.1, 1.0"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,6 @@ end
 
 _, backend_name = parse_flags!(ARGS, "--backend"; default="CPU", typ=String)
 
-# load test packages to trigger precompilation
-using DoubleFloats
 @static if backend_name == "CUDA"
     Pkg.add("CUDA")
     ENV["JULIA_MPI_TEST_ARRAYTYPE"] = "CuArray"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ end
 
 _, backend_name = parse_flags!(ARGS, "--backend"; default="CPU", typ=String)
 
+# load test packages to trigger precompilation
 @static if backend_name == "CUDA"
     Pkg.add("CUDA")
     ENV["JULIA_MPI_TEST_ARRAYTYPE"] = "CuArray"

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -9,7 +9,12 @@ const can_do_closures =
     Sys.ARCH !== :aarch64 &&
     !startswith(string(Sys.ARCH), "arm")
 
-using DoubleFloats
+# a non-builtin isbits type, to test automatic datatype/op creation
+struct TestSum
+    hi::Float64
+    lo::Float64
+end
+Base.:+(a::TestSum, b::TestSum) = TestSum(a.hi + b.hi, a.lo + b.lo)
 
 MPI.Init()
 
@@ -122,11 +127,11 @@ end
 
 MPI.Barrier( MPI.COMM_WORLD )
 
-send_arr = [Double64(i)/10 for i = 1:10]
+send_arr = [TestSum(i, i/4) for i = 1:10]
 
 result = MPI.Reduce(send_arr, +, MPI.COMM_WORLD; root=root)
 if rank == root
-    @test result ≈ [Double64(sz*i)/10 for i = 1:10] rtol=sz*eps(Double64)
+    @test result == [TestSum(sz*i, sz*i/4) for i = 1:10]
 else
     @test result === nothing
 end

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -9,7 +9,7 @@ const can_do_closures =
     Sys.ARCH !== :aarch64 &&
     !startswith(string(Sys.ARCH), "arm")
 
-# a non-builtin isbits type, to test automatic datatype/op creation
+# a non-builtin isbits type to test generic MPI.reduce
 struct TestSum
     hi::Float64
     lo::Float64


### PR DESCRIPTION
DoubleFloat was pulling in GenericLinearAlgebra which is a pirate package that is broken on 1.13.

XRef: https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/issues/180 https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/pull/147