### PR TITLE
Root window buffers via IdSet, not Set

### DIFF
--- a/src/onesided.jl
+++ b/src/onesided.jl
@@ -158,7 +158,7 @@ function Win_create_dynamic(comm::Comm; kwargs...)
     # int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win)
     API.MPI_Win_create_dynamic(Info(kwargs...), comm, win)
     finalizer(free, win)
-    win.object = Set()
+    win.object = Base.IdSet{Any}()
     return win
 end
 

--- a/test/test_onesided.jl
+++ b/test/test_onesided.jl
@@ -128,5 +128,31 @@ MPI.Win_detach!(win, buf)
 MPI.free(win)
 MPI.free(address_win)
 
+# Attached buffers must be rooted by identity, not by value: two distinct
+# arrays with equal contents must each be kept alive on their own.
+let win = MPI.Win_create_dynamic(comm)
+    a = zeros(10)
+    b = zeros(10)                       # equal to `a`, but a different object
+    MPI.Win_attach!(win, a)
+    MPI.Win_attach!(win, b)
+    @test length(win.object) == 2
+    @test any(x -> x === a, win.object)
+    @test any(x -> x === b, win.object)
+
+    # Detaching `b` must not un-root `a`, which is still attached.
+    MPI.Win_detach!(win, b)
+    @test length(win.object) == 1
+    @test any(x -> x === a, win.object)
+
+    weak_a = WeakRef(a)
+    a = nothing
+    GC.gc(); GC.gc()
+    @test weak_a.value !== nothing       # still attached, must not be collected
+
+    MPI.Win_detach!(win, weak_a.value)
+    @test isempty(win.object)
+    MPI.free(win)
+end
+
 MPI.Finalize()
 @test MPI.Finalized()

--- a/test/test_onesided.jl
+++ b/test/test_onesided.jl
@@ -132,7 +132,7 @@ MPI.free(address_win)
 # arrays with equal contents must each be kept alive on their own.
 let win = MPI.Win_create_dynamic(comm)
     a = zeros(10)
-    b = zeros(10)                       # equal to `a`, but a different object
+    b = copy(a)
     MPI.Win_attach!(win, a)
     MPI.Win_attach!(win, b)
     @test length(win.object) == 2


### PR DESCRIPTION
Two different arrays with the same value are considered equal by `Set`, which is not good. Use `IdSet` instead.