### PR TITLE
File_open: Correct semantics for exclusive access

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -33,18 +33,26 @@ Open the file identified by `filename`. This is a collective operation on `comm`
 
 Supported keywords are as follows:
  - `read`, `write`, `create`, `append` have the same behaviour and defaults as `Base.open`.
+ - `exclusive`: fail if the file already exists (default: `false`). Requires creating the
+   file, i.e. `write=true` and `create` not disabled.
  - `sequential`: file will only be accessed sequentially (default: `false`)
  - `uniqueopen`: file will not be concurrently opened elsewhere (default: `false`)
  - `deleteonclose`: delete file on close (default: `false`)
 
 Any additional keywords are passed via an [`Info`](@ref) object, and are implementation dependent.
 
+!!! note
+    Unlike `Base.open`, opening for writing does not truncate the file: MPI has no
+    truncate-on-open mode, so `truncate` is not among the supported keywords. Writing a
+    short record over a longer existing file leaves the tail in place; use
+    `MPI.API.MPI_File_set_size(file, 0)` after opening if you need the file truncated.
+
 # External links
 $(_doc_external("MPI_File_open"))
 """
 function open(comm::Comm, filename::AbstractString;
               read=nothing, write=nothing, create=nothing, append=nothing,
-              sequential=false, uniqueopen=false, deleteonclose=false,
+              exclusive=false, sequential=false, uniqueopen=false, deleteonclose=false,
               infokws...)
     flags = Base.open_flags(read=read, write=write, create=create, truncate=nothing, append=append)
     amode = if flags.read
@@ -52,7 +60,17 @@ function open(comm::Comm, filename::AbstractString;
     else
         flags.write ? MPI.API.MPI_MODE_WRONLY[] : zero(Cint)
     end
-    flags.write && (amode |= flags.create ? MPI.API.MPI_MODE_CREATE[] : MPI.API.MPI_MODE_EXCL[])
+    # `MPI_MODE_EXCL` means "error if creating a file that already exists", so it
+    # is only meaningful together with `MPI_MODE_CREATE`; on its own it is as
+    # undefined as POSIX `O_EXCL` without `O_CREAT`.  Both are erroneous in
+    # conjunction with `MPI_MODE_RDONLY` (MPI-5.0 §14.2.1), hence `flags.write`.
+    if flags.write && flags.create
+        amode |= MPI.API.MPI_MODE_CREATE[]
+        exclusive && (amode |= MPI.API.MPI_MODE_EXCL[])
+    elseif exclusive
+        throw(ArgumentError(
+            "`exclusive=true` only applies when the file is created; pass `write=true` and do not set `create=false`"))
+    end
     flags.append && (amode |= MPI.API.MPI_MODE_APPEND[])
     sequential && (amode |= MPI.API.MPI_MODE_SEQUENTIAL[])
     uniqueopen && (amode |= MPI.API.MPI_MODE_UNIQUE_OPEN[])

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -38,3 +38,39 @@ data = zeros(Int64, 1)
 MPI.File.read_at_all!(fh, rank*2, data)
 @test data == [rank == 0 ? -1 : rank+1]
 close(fh)
+
+# `MPI_MODE_EXCL` must only ever be emitted alongside `MPI_MODE_CREATE`.
+
+# Opening an existing file for writing without creating it must work: it must
+# not silently become "fail if the file exists".
+let path = MPI.bcast(tempname(), 0, comm)
+    rank == 0 && Base.write(path, zeros(UInt8, 64))
+    MPI.Barrier(comm)
+    fh = MPI.File.open(comm, path; write=true, create=false)
+    close(fh)
+    MPI.Barrier(comm)
+    rank == 0 && rm(path; force=true)
+end
+
+# `exclusive=true` creates the file, and fails if it is already there.
+let path = MPI.bcast(tempname(), 0, comm)
+    fh = MPI.File.open(comm, path; write=true, exclusive=true)
+    close(fh)
+    MPI.Barrier(comm)
+    @test_throws MPI.MPIError MPI.File.open(comm, path; write=true, exclusive=true)
+    MPI.Barrier(comm)
+    # ... whereas the default is not exclusive.
+    fh = MPI.File.open(comm, path; write=true, create=true)
+    close(fh)
+    MPI.Barrier(comm)
+    rank == 0 && rm(path; force=true)
+end
+
+# `exclusive` is meaningless without creation, and must be rejected rather than
+# quietly emitting `MPI_MODE_EXCL` on its own.
+let path = MPI.bcast(tempname(), 0, comm)
+    @test_throws ArgumentError MPI.File.open(comm, path; write=true, create=false, exclusive=true)
+    @test_throws ArgumentError MPI.File.open(comm, path; read=true, exclusive=true)
+end
+MPI.Barrier(comm)
+


### PR DESCRIPTION
Correct the way the amode `MPI_MODE_EXCL` is determined. There needs to be an explicit keyword argument for this because this cannot be determined from the other keyword arguments.

The previous logic said "assume exclusive if the file is not created", but this doesn't make sense: "exclusive" means "error if the file already exists", which only makes sense if the file is to be created and should not overwrite an existing file.