### PR TITLE
Alltoall: Correct how InPlace is handled

### DIFF
--- a/src/collective.jl
+++ b/src/collective.jl
@@ -560,7 +560,7 @@ If only one buffer `sendrecvbuf` is used, then data is overwritten.
 $(_doc_external("MPI_Alltoall"))
 """
 function Alltoall!(sendbuf::UBuffer, recvbuf::UBuffer, comm::Comm)
-    if sendbuf.data !== API.MPI_IN_PLACE[] && sendbuf.nchunks !== nothing
+    if !(sendbuf.data isa InPlace) && sendbuf.nchunks !== nothing
         @assert sendbuf.nchunks >= Comm_size(comm)
     end
     if recvbuf.nchunks !== nothing
@@ -607,8 +607,11 @@ Alltoall(sendbuf::UBuffer,  comm::Comm) =
 
 """
     Alltoallv!(sendbuf::VBuffer, recvbuf::VBuffer, comm::Comm)
+    Alltoallv!(sendrecvbuf::VBuffer, comm::Comm)
 
 Similar to [`Alltoall!`](@ref), except with different size chunks per process.
+
+If only one buffer `sendrecvbuf` is used, then data is overwritten.
 
 # See also
 - [`VBuffer`](@ref)
@@ -617,7 +620,7 @@ Similar to [`Alltoall!`](@ref), except with different size chunks per process.
 $(_doc_external("MPI_Alltoallv"))
 """
 function Alltoallv!(sendbuf::VBuffer, recvbuf::VBuffer, comm::Comm)
-    if sendbuf.data !== API.MPI_IN_PLACE[]
+    if !(sendbuf.data isa InPlace)
         @assert length(sendbuf.counts) >= Comm_size(comm)
     end
     @assert length(recvbuf.counts) >= Comm_size(comm)
@@ -631,6 +634,10 @@ function Alltoallv!(sendbuf::VBuffer, recvbuf::VBuffer, comm::Comm)
 
     return recvbuf.data
 end
+Alltoallv!(sendbuf::InPlace, recvbuf::VBuffer, comm::Comm) =
+    Alltoallv!(VBuffer(IN_PLACE), recvbuf, comm)
+Alltoallv!(sendrecvbuf::VBuffer, comm::Comm) =
+    Alltoallv!(IN_PLACE, sendrecvbuf, comm)
 
 
 ### Reduce/Scan

--- a/test/test_alltoallv.jl
+++ b/test/test_alltoallv.jl
@@ -22,9 +22,33 @@ for T in MPITestTypes
     MPI.Alltoallv!(VBuffer(A,send_counts), VBuffer(C,recv_counts), comm)
     @test C == ArrayType{T}(recv_vals)
 
-    # Test assertion on wrong output buffer length
+    # Test assertion on wrong output buffer length
     C = ArrayType{T}(undef, sum(recv_counts)-1)
     @test_throws AssertionError MPI.Alltoallv!(VBuffer(A,send_counts), VBuffer(C,recv_counts), comm)
+
+    # Test assertion on wrong input buffer length
+    C = ArrayType{T}(undef, sum(recv_counts))
+    @test_throws AssertionError MPI.Alltoallv!(VBuffer(A,send_counts[1:end-1]), VBuffer(C,recv_counts), comm)
+
+    # IN_PLACE version.  The in-place layout has to be symmetric: the block rank
+    # `r` holds for peer `p` must be as long as the block rank `p` holds for `r`,
+    # which `counts[j] = rank + j` satisfies.
+    inplace_counts = Cint[rank + j for j in 1:size]
+    inplace_data() = ArrayType{T}(collect(Iterators.flatten(
+        [fill(T(rank), inplace_counts[j]) for j in 1:size])))
+    expected = ArrayType{T}(collect(Iterators.flatten(
+        [fill(T(j-1), rank + j) for j in 1:size])))
+
+    D = inplace_data()
+    synchronize()
+    MPI.Alltoallv!(MPI.IN_PLACE, VBuffer(D, inplace_counts), comm)
+    @test D == expected
+
+    # One-argument IN_PLACE version
+    D = inplace_data()
+    synchronize()
+    MPI.Alltoallv!(VBuffer(D, inplace_counts), comm)
+    @test D == expected
 end
 
 MPI.Finalize()


### PR DESCRIPTION
The previous code used the wrong constant (`API.MPI_IN_PLACE[]` instead of `InPlace`) for the in-place test, which always failed.