### PR TITLE
Reductions: New function `to_type_raw` which does not allocate

### DIFF
--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -78,10 +78,22 @@ if it doesn't correspond directly.
 """
 function to_type(datatype::Datatype)
     if MPI.Initialized() && !MPI.Finalized()
-        ptr = get_attr(datatype, JULIA_TYPE_PTR_ATTR[])
-        isnothing(ptr) || return unsafe_pointer_to_objref(ptr)
+        return to_type_raw(datatype.val)
     end
     return nothing
+end
+
+# As `to_type`, but taking a raw `MPI_Datatype` handle.  This is called from
+# inside user-defined reduction callbacks, which run on MPI's stack while a
+# reduction is in progress. We avoid creating a `Datatype` object to avoid
+# allocating memory, and also avoid the unnecessary `Initialized`/`Finalized`
+# queries of `to_type`.
+@inline function to_type_raw(handle::MPI_Datatype)
+    flagref = Ref(Cint(0))
+    attrref = Ref{Ptr{Cvoid}}(C_NULL)
+    API.MPI_Type_get_attr(handle, JULIA_TYPE_PTR_ATTR[], attrref, flagref)
+    flagref[] == 0 && return nothing
+    return unsafe_pointer_to_objref(attrref[])
 end
 
 # "native" MPI datatypes

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -83,7 +83,11 @@ end
 function (w::OpWrapper{F,T})(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t::Ptr{MPI_Datatype}) where {F,T}
     len = unsafe_load(_len)
     if !isconcretetype(T)
-        concrete_T = to_type(Datatype(unsafe_load(t))) # Ptr might actually point to a Julia object so we could unsafe_pointer_to_objref?
+        # `to_type_raw` rather than `to_type(Datatype(unsafe_load(t)))`: the
+        # latter builds a `Datatype` on every single invocation of this
+        # callback, and an allocation here is a GC safepoint from inside a live
+        # reduction.
+        concrete_T = to_type_raw(unsafe_load(t))
     else
         concrete_T = T
     end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -82,15 +82,8 @@ end
 
 function (w::OpWrapper{F,T})(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t::Ptr{MPI_Datatype}) where {F,T}
     len = unsafe_load(_len)
-    if !isconcretetype(T)
-        # `to_type_raw` rather than `to_type(Datatype(unsafe_load(t)))`: the
-        # latter builds a `Datatype` on every single invocation of this
-        # callback, and an allocation here is a GC safepoint from inside a live
-        # reduction.
-        concrete_T = to_type_raw(unsafe_load(t))
-    else
-        concrete_T = T
-    end
+    # use `to_type_raw` rather than `to_type(Datatype(unsafe_load(t)))` to avoid allocating
+    concrete_T = isconcretetype(T) ? T : to_type_raw(unsafe_load(t))
     function copy(::Type{T}) where T
         @assert isconcretetype(T)
         a = Ptr{T}(_a)


### PR DESCRIPTION
Inside an MPI reduction operation we have an MPI datatype. The previous code path first created a `Datatype` object from this (which allocates memory), and then retrieved its MPI datatype to get its attributes. The new function `to_type_raw` avoids the allocation.