### PR TITLE
MPIPreferences: Detect `mpi_abi_wrapper` library as MPIABI

### DIFF
--- a/lib/MPIPreferences/Project.toml
+++ b/lib/MPIPreferences/Project.toml
@@ -11,3 +11,9 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 julia = "1.6"
 Libdl = "1"
 Preferences = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/lib/MPIPreferences/src/MPIPreferences.jl
+++ b/lib/MPIPreferences/src/MPIPreferences.jl
@@ -374,6 +374,8 @@ function identify_implementation_version_abi(version_string::AbstractString)
         # https://www.mpich.org/abi/
         impl == "HPE HMPT")
         abi = "MPICH"
+    elseif impl == "MPIABI"
+        abi = "MPIABI"
     elseif impl == "OpenMPI" || impl == "IBMSpectrumMPI" || impl == "FujitsuMPI"
         abi = "OpenMPI"
     elseif impl == "MicrosoftMPI"

--- a/lib/MPIPreferences/src/MPIPreferences.jl
+++ b/lib/MPIPreferences/src/MPIPreferences.jl
@@ -281,8 +281,16 @@ function identify_implementation_version_abi(version_string::AbstractString)
     elseif startswith(version_string, "MPICH") && contains(version_string, "--enable-mpi-abi")
         impl = "MPIABI"
         # This should be the ABI version, not the MPICH version.
-        # MPICH doesn't output the ABI version, but we know it implements v5 (the only ABI version currently specified).
-        version = v"5"
+        # MPICH doesn't output the ABI version, but we know it implements v1 (the only ABI version currently specified).
+        version = v"1"
+
+    elseif startswith(version_string, "mpi_abi_wrapper")
+        impl = "MPIABI"
+        # This should be the ABI version, not the MPICH version.
+        # "mpi_abi_wrapper 1.2.0 (MPI 5.0 standard ABI, MPI_ABI_VERSION 1.0)\nwrapping:\nOpen MPI v5.0.10, package: Debian OpenMPI, ident: 5.0.10, repo rev: v5.0.10, Feb 23, 2026"
+        if (m = match(r"MPI_ABI_VERSION (\d+.\d+)", version_string)) !== nothing
+            version = VersionNumber(m.captures[1])
+        end
 
     elseif startswith(version_string, "Open MPI")
         # Open MPI / Spectrum MPI

--- a/lib/MPIPreferences/test/runtests.jl
+++ b/lib/MPIPreferences/test/runtests.jl
@@ -1,0 +1,60 @@
+using Test
+using MPIPreferences
+
+# Version strings as reported by `MPI_Get_library_version` by the various MPI
+# implementations, and the `(implementation, version, abi)` triple that
+# `identify_implementation_version_abi` should derive from them.
+const version_strings = [
+    # MPICH: "MPICH Version:\t%s\n" / "MPICH2 Version:\t%s\n"
+    "MPICH Version:\t3.4.2\nMPICH Release date:\tWed May 26 15:51:40 CDT 2021\nMPICH Device:\tch3:nemesis\nMPICH configure:\t--prefix=/usr\n" =>
+        ("MPICH", v"3.4.2", "MPICH"),
+    "MPICH Version:\t3.0.4\nMPICH Release date:\tWed Apr 24 10:08:10 CDT 2013\n" =>
+        ("MPICH", v"3.0.4", "unknown"),
+    "MPICH2 Version:\t1.5\nMPICH2 Release date:\tUnreleased development copy\n" =>
+        ("MPICH", v"1.5", "unknown"),
+    # MPICH built with the MPI standard ABI enabled
+    "MPICH Version:\t4.3.0\nMPICH Release date:\tMon Feb 3 09:00:00 CST 2025\nMPICH configure:\t--prefix=/usr --enable-mpi-abi\n" =>
+        ("MPIABI", v"1", "MPIABI"),
+    # mpi_abi_wrapper: a standard-ABI shim in front of another implementation
+    "mpi_abi_wrapper 1.2.0 (MPI 5.0 standard ABI, MPI_ABI_VERSION 1.0)\nwrapping:\nOpen MPI v5.0.10, package: Debian OpenMPI, ident: 5.0.10, repo rev: v5.0.10, Feb 23, 2026" =>
+        ("MPIABI", v"1.0", "MPIABI"),
+    # Open MPI
+    "Open MPI v4.1.1, package: Open MPI conda@8a2bcd3b1b46 Distribution, ident: 4.1.1, repo rev: v4.1.1, Apr 24, 2021\n" =>
+        ("OpenMPI", v"4.1.1", "OpenMPI"),
+    "Open MPI v5.0.0rc12, package: Open MPI root@builder Distribution, ident: 5.0.0rc12, repo rev: v5.0.0rc12, Unreleased developer copy\n" =>
+        ("OpenMPI", v"5.0.0rc12", "OpenMPI"),
+    # IBM Spectrum MPI reports itself as Open MPI
+    "Open MPI v3.1.0, package: IBM Spectrum MPI, ident: 10.03.01.00rtm0, repo rev: IBM_SPECTRUM_MPI_10.03.01.00_2019.04.02, Apr 02, 2019\n" =>
+        ("IBMSpectrumMPI", v"3.1.0", "OpenMPI"),
+    # Microsoft MPI: "Microsoft MPI %u.%u.%u.%u%S"
+    "Microsoft MPI 10.1.12498.18" => ("MicrosoftMPI", v"10.1", "MicrosoftMPI"),
+    # Intel MPI, old and oneAPI style
+    "Intel(R) MPI Library 2019 Update 4 for Linux* OS\n" => ("IntelMPI", v"2019.4", "MPICH"),
+    "Intel(R) MPI Library 2021.6 for Linux* OS\n" => ("IntelMPI", v"2021.6", "MPICH"),
+    "Intel(R) MPI Library 2018 for Linux* OS\n" => ("IntelMPI", v"2018", "MPICH"),
+    # MVAPICH: "MVAPICH2 Version      :\t%s\n"
+    "MVAPICH2 Version      :\t2.3.6\nMVAPICH2 Release date :\tMon March 29 22:00:00 EST 2021\n" =>
+        ("MVAPICH", v"2.3.6", "MPICH"),
+    # Cray MPICH: "MPI VERSION    : CRAY MPICH version 7.7.10 (ANL base 3.2)\n"
+    "MPI VERSION    : CRAY MPICH version 7.7.10 (ANL base 3.2)\nMPI BUILD INFO : Built Fri Oct 18 12:00:00 2019\n" =>
+        ("CrayMPICH", v"7.7.10", "MPICH"),
+    "MPI VERSION    : CRAY MPICH version 8.1.21 (ANL base 3.4a2)\n" =>
+        ("CrayMPICH", v"8.1.21", "MPICH"),
+    # Fujitsu MPI: "FUJITSU MPI Library 4.0.0 (4.0.1fj4.0.0)\0"
+    "FUJITSU MPI Library 4.0.0 (4.0.1fj4.0.0)" => ("FujitsuMPI", v"4.0.0", "OpenMPI"),
+    # MPIwrapper, the library behind MPItrampoline
+    "MPIwrapper Version:\t2.2.2\nMPIwrapper Release date:\t2021-11-01\n" =>
+        ("MPIwrapper", v"2.2.2", "MPItrampoline"),
+    # HPE MPT / HMPT
+    "HPE MPT 2.23  08/26/20 02:54:49-root" => ("HPE MPT", v"2.23", "HPE MPT"),
+    "HPE HMPT 2.23  08/26/20 02:59:48-root" => ("HPE HMPT", v"2.23", "MPICH"),
+    # Anything we don't recognise
+    "Some Other MPI 1.0\n" => ("unknown", v"0", "unknown"),
+    "" => ("unknown", v"0", "unknown"),
+]
+
+@testset "identify_implementation_version_abi" begin
+    @testset "$(repr(first(split(version_string, '\n'))))" for (version_string, expected) in version_strings
+        @test MPIPreferences.identify_implementation_version_abi(version_string) == expected
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,10 @@ if haskey(ENV,"JULIA_MPI_TEST_ABI")
     @test ENV["JULIA_MPI_TEST_ABI"] == MPIPreferences.abi
 end
 
+# Unit tests for MPIPreferences itself.  These don't need to be run with
+# mpiexec, and don't depend on the MPI implementation in use.
+include(joinpath(@__DIR__, "..", "lib", "MPIPreferences", "test", "runtests.jl"))
+
 if Sys.isunix()
     # This test doesn't need to be run with mpiexec.  `mpiexecjl` is currently
     # available only on Unix systems


### PR DESCRIPTION
Also correct the version number of MPICH's MPI ABI build as 1, not 5.

(It's MPI standard 5.0, but MPI ABI standard 1.0, and we care about the ABI standard here.)