### PR TITLE
Clean up string return values

### DIFF
--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -100,8 +100,7 @@ function _string_from_buffer(buf::Vector{UInt8}, len::Integer)
     # Never grow: a `len` beyond what the library was handed would pad the
     # string with uninitialized bytes. Also tolerates an unset `resultlen`.
     resize!(buf, clamp(len, 0, length(buf)))
-    resize!(buf, something(findlast(!=(0x00), buf), 0))
-    return String(buf)
+    return chopsuffix(String(buf), "\0")
 end
 
 include("implementations.jl")

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -86,16 +86,13 @@ function (hook::LoadTimeHookSetVal)()
 end
 call(hook) = hook()
 
-"""
-    _string_from_buffer(buf::Vector{UInt8}, len::Integer) :: String
-
-Build a `String` from the first `len` bytes of `buf`, dropping any trailing NUL
-bytes. Consumes `buf`.
-
-MPI's string-returning functions set `resultlen` to the number of characters
-written, *excluding* the terminating NUL. Open MPI's `MPI_Get_library_version`
-includes it, so trim instead of letting a NUL into the string.
-"""
+# Build a `String` from the first `len` bytes of `buf`, dropping any trailing
+# NUL bytes. Consumes `buf`.
+#
+# MPI's string-returning functions set `resultlen` to the number of characters
+# written, *excluding* the terminating NUL. Open MPI's
+# `MPI_Get_library_version` includes it, so trim instead of letting a NUL into
+# the string.
 function _string_from_buffer(buf::Vector{UInt8}, len::Integer)
     # Never grow: a `len` beyond what the library was handed would pad the
     # string with uninitialized bytes. Also tolerates an unset `resultlen`.

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -86,6 +86,24 @@ function (hook::LoadTimeHookSetVal)()
 end
 call(hook) = hook()
 
+"""
+    _string_from_buffer(buf::Vector{UInt8}, len::Integer) :: String
+
+Build a `String` from the first `len` bytes of `buf`, dropping any trailing NUL
+bytes. Consumes `buf`.
+
+MPI's string-returning functions set `resultlen` to the number of characters
+written, *excluding* the terminating NUL. Open MPI's `MPI_Get_library_version`
+includes it, so trim instead of letting a NUL into the string.
+"""
+function _string_from_buffer(buf::Vector{UInt8}, len::Integer)
+    # Never grow: a `len` beyond what the library was handed would pad the
+    # string with uninitialized bytes. Also tolerates an unset `resultlen`.
+    resize!(buf, clamp(len, 0, length(buf)))
+    resize!(buf, something(findlast(!=(0x00), buf), 0))
+    return String(buf)
+end
+
 include("implementations.jl")
 include("error.jl")
 include("info.jl")

--- a/src/MPI.jl
+++ b/src/MPI.jl
@@ -100,7 +100,8 @@ function _string_from_buffer(buf::Vector{UInt8}, len::Integer)
     # Never grow: a `len` beyond what the library was handed would pad the
     # string with uninitialized bytes. Also tolerates an unset `resultlen`.
     resize!(buf, clamp(len, 0, length(buf)))
-    return chopsuffix(String(buf), "\0")
+    resize!(buf, something(findlast(!=(0x00), buf), 0))
+    return String(buf)
 end
 
 include("implementations.jl")

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -61,7 +61,7 @@ function get_name(datatype::Datatype)
     buffer = Array{UInt8}(undef, API.MPI_MAX_OBJECT_NAME)
     lenref = Ref{Cint}()
     API.MPI_Type_get_name(datatype, buffer, lenref)
-    return String(resize!(buffer, lenref[]))
+    return _string_from_buffer(buffer, lenref[])
 end
 
 # datatype attribute to store Julia type

--- a/src/error.jl
+++ b/src/error.jl
@@ -4,6 +4,5 @@ function error_string(err::MPIError)
     str_buf = Vector{UInt8}(undef, API.MPI_MAX_ERROR_STRING)
     # int MPI_Error_string(int errorcode, char *string, int *resultlen)
     API.MPI_Error_string(err.code, str_buf, len_ref)
-    resize!(str_buf, len_ref[])
-    return String(str_buf)
+    return _string_from_buffer(str_buf, len_ref[])
 end

--- a/src/implementations.jl
+++ b/src/implementations.jl
@@ -15,8 +15,7 @@ function Get_library_version()
 
     API.MPI_Get_library_version(buf, buflen)
     @assert buflen[] < 8192
-    resize!(buf, buflen[])
-    return String(buf)
+    return _string_from_buffer(buf, buflen[])
 end
 
 """

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -11,5 +11,5 @@ function Get_processor_name()
     name_len = Ref{Cint}(0)
     API.MPI_Get_processor_name(proc_name, name_len)
     @assert name_len[] <= API.MPI_MAX_PROCESSOR_NAME
-    GC.@preserve proc_name unsafe_string(pointer(proc_name))
+    return _string_from_buffer(proc_name, name_len[])
 end


### PR DESCRIPTION
Open MPI sometimes include a trailing NUL into string values it returns. C doesn't see this. Remove all trailing NULs explicitly.