### PR TITLE
Use MPIX_Op_create_x for user-defined operators when available

### DIFF
--- a/docs/src/knownissues.md
+++ b/docs/src/knownissues.md
@@ -212,3 +212,7 @@ However they have two limitations:
 * closure cfunctions in Julia are based on LLVM trampolines, which are not supported on ARM architecture.
 
 As an alternative [`MPI.@RegisterOp`](@ref) may be used to statically register reduction operations.
+
+With MPICH ≥ 4.3 neither limitation applies: MPI.jl uses the experimental [`MPIX_Op_create_x`](https://github.com/mpi-forum/mpi-issues/issues/839)
+extension, which passes a context pointer to the callback so that no closure cfunction is needed.
+Whether this is used can be checked with `MPI.API.HAS_MPIX_Op_create_x`.

--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -140,6 +140,40 @@ end
 
 include("generated_api.jl")
 
+# MPICH extension (MPICH ≥ 4.3): user-defined reduction operators with an `extra_state`
+# context pointer and an optional destructor. This is the implementation of the MPI Forum
+# proposal https://github.com/mpi-forum/mpi-issues/issues/839 and is not (yet) part of the
+# MPI standard.
+#
+#   typedef void (MPIX_User_function_x)(void *invec, void *inoutvec, MPI_Count len,
+#                                       MPI_Datatype datatype, void *extra_state);
+#   typedef void (MPIX_Destructor_function)(void *extra_state);
+const MPIX_User_function_x = Cvoid
+const MPIX_Destructor_function = Cvoid
+
+"""
+    HAS_MPIX_Op_create_x :: Bool
+
+Whether the MPI library provides the experimental `MPIX_Op_create_x` function (MPICH ≥ 4.3).
+This is determined when MPI.jl is precompiled.
+"""
+const HAS_MPIX_Op_create_x = !isnothing(dlsym(libmpi_handle, :MPIX_Op_create_x; throw_error=false))
+
+"""
+    MPIX_Op_create_x(user_fn_x, destructor_fn, commute, extra_state, op)
+
+Experimental MPICH extension of `MPI_Op_create` which additionally passes `extra_state` as the
+last argument to `user_fn_x` and calls `destructor_fn(extra_state)` (if not `C_NULL`) when the
+operator is freed. Only available if `MPI.API.HAS_MPIX_Op_create_x` is `true`.
+"""
+function MPIX_Op_create_x(user_fn_x, destructor_fn, commute, extra_state, op)
+    # int MPIX_Op_create_x(MPIX_User_function_x *user_fn_x, MPIX_Destructor_function *destructor_fn,
+    #                      int commute, void *extra_state, MPI_Op *op)
+    @mpichk ccall((:MPIX_Op_create_x, libmpi), Cint,
+                  (Ptr{MPIX_User_function_x}, Ptr{MPIX_Destructor_function}, Cint, Ptr{Cvoid}, Ptr{MPI_Op}),
+                  user_fn_x, destructor_fn, commute, extra_state, op)
+end
+
 for handle in [
     :MPI_Comm,
     :MPI_Datatype,

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -10,6 +10,14 @@ An MPI reduction operator, for use with [Reduce/Scan collective operations](@ref
 Wrap the Julia reduction function `op` for arguments of type `T`. `op` is assumed to be
 associative, and if `iscommutative` is true, assumed to be commutative as well.
 
+## Implementation
+
+With MPICH ≥ 4.3 the operator is registered via the experimental `MPIX_Op_create_x`, which
+passes a context pointer to the callback. This works on all architectures. With other MPI
+libraries a [closure cfunction](https://docs.julialang.org/en/v1/manual/calling-c-and-fortran-code/#Closure-cfunctions)
+is used, which is not supported on all platforms; see [`@RegisterOp`](@ref) for an
+alternative.
+
 ## See also
 
 - [`Reduce!`](@ref)/[`Reduce`](@ref)
@@ -20,7 +28,7 @@ associative, and if `iscommutative` is true, assumed to be commutative as well.
 """
 mutable struct Op
     val::MPI_Op
-    fptr
+    fptr # object that has to be kept alive while the operator is in use (cfunction closure or OpWrapper)
     Op(val::MPI_Op, fptr) = new(val, fptr)
 end
 Base.:(==)(a::Op, b::Op) = a.val == b.val
@@ -76,14 +84,31 @@ function free(op::Op)
     return nothing
 end
 
-struct OpWrapper{F,T}
+# mutable so that a pointer to it can be passed as `extra_state` to `MPIX_Op_create_x`
+mutable struct OpWrapper{F,T}
     f::F
 end
 
-function (w::OpWrapper{F,T})(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t::Ptr{MPI_Datatype}) where {F,T}
-    len = unsafe_load(_len)
+# MPI_User_function: `len` and `datatype` are passed by reference
+function (w::OpWrapper)(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t::Ptr{MPI_Datatype})
+    _reduce!(w, _a, _b, unsafe_load(_len), unsafe_load(t))
+    return nothing
+end
+
+# MPIX_User_function_x: `len` and `datatype` are passed by value, `extra_state` points to the OpWrapper
+function _op_user_fn_x(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, len::MPI_Count, t::MPI_Datatype, extra_state::Ptr{Cvoid})
+    w = unsafe_pointer_to_objref(extra_state)::OpWrapper
+    _reduce!(w, _a, _b, len, t)
+    return nothing
+end
+
+# MPIX_Destructor_function: MPICH rejects a NULL destructor, but there is nothing to do here since
+# the lifetime of the OpWrapper is managed by the `Op` object.
+_op_destructor_noop(extra_state::Ptr{Cvoid}) = nothing
+
+function _reduce!(w::OpWrapper{F,T}, _a::Ptr{Cvoid}, _b::Ptr{Cvoid}, len::Integer, t::MPI_Datatype) where {F,T}
     if !isconcretetype(T)
-        concrete_T = to_type(Datatype(unsafe_load(t))) # Ptr might actually point to a Julia object so we could unsafe_pointer_to_objref?
+        concrete_T = to_type(Datatype(t)) # Ptr might actually point to a Julia object so we could unsafe_pointer_to_objref?
     else
         concrete_T = T
     end
@@ -100,25 +125,38 @@ function (w::OpWrapper{F,T})(_a::Ptr{Cvoid}, _b::Ptr{Cvoid}, _len::Ptr{Cint}, t:
 end
 
 function Op(f, T=Any; iscommutative=false)
-    @static if MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32
-        error("""
-            User-defined reduction operators are not supported on 32-bit Windows.
-            See https://github.com/JuliaParallel/MPI.jl/issues/246 for more details.
-        """)
-    elseif Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) || startswith(lowercase(String(Sys.ARCH)), "arm")
-        error("""
-            User-defined reduction operators are currently not supported on non-Intel architectures.
-            See https://github.com/JuliaParallel/MPI.jl/issues/404 for more details.
-
-            You may want to use `@RegisterOp` to statically register `f`.
-            """)
-    end
     w = OpWrapper{typeof(f),T}(f)
-    fptr = @cfunction($w, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{MPI_Datatype}))
+    @static if API.HAS_MPIX_Op_create_x
+        # MPICH ≥ 4.3: the wrapper is passed as `extra_state`, so a plain (non-closure)
+        # cfunction suffices. This works on all architectures.
+        fptr = @cfunction(_op_user_fn_x, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, MPI_Count, MPI_Datatype, Ptr{Cvoid}))
+        dptr = @cfunction(_op_destructor_noop, Cvoid, (Ptr{Cvoid},))
 
-    op = Op(OP_NULL.val, fptr)
-    # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)
-    API.MPI_Op_create(fptr, iscommutative, op)
+        # `op` keeps `w` alive for as long as the operator exists
+        op = Op(OP_NULL.val, w)
+        # int MPIX_Op_create_x(MPIX_User_function_x *user_fn_x, MPIX_Destructor_function *destructor_fn,
+        #                      int commute, void *extra_state, MPI_Op *op)
+        API.MPIX_Op_create_x(fptr, dptr, iscommutative, pointer_from_objref(w), op)
+    else
+        @static if MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32
+            error("""
+                User-defined reduction operators are not supported on 32-bit Windows.
+                See https://github.com/JuliaParallel/MPI.jl/issues/246 for more details.
+            """)
+        elseif Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) || startswith(lowercase(String(Sys.ARCH)), "arm")
+            error("""
+                User-defined reduction operators are currently not supported on non-Intel architectures.
+                See https://github.com/JuliaParallel/MPI.jl/issues/404 for more details.
+
+                You may want to use `@RegisterOp` to statically register `f`.
+                """)
+        end
+        fptr = @cfunction($w, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{MPI_Datatype}))
+
+        op = Op(OP_NULL.val, fptr)
+        # int MPI_Op_create(MPI_User_function* user_fn, int commute, MPI_Op* op)
+        API.MPI_Op_create(fptr, iscommutative, op)
+    end
 
     finalizer(free, op)
     return op

--- a/test/test_reduce.jl
+++ b/test/test_reduce.jl
@@ -1,13 +1,15 @@
 include("common.jl")
 
-# Closures might not be supported by cfunction
+# Closures might not be supported by cfunction, unless the MPI library provides
+# `MPIX_Op_create_x` (MPICH ≥ 4.3), in which case no closure cfunction is needed.
 const can_do_closures =
     ArrayType === Array &&
-    !(MPI.MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32) &&
-    Sys.ARCH !== :powerpc64le &&
-    Sys.ARCH !== :ppc64le &&
-    Sys.ARCH !== :aarch64 &&
-    !startswith(string(Sys.ARCH), "arm")
+    (MPI.API.HAS_MPIX_Op_create_x ||
+     (!(MPI.MPI_LIBRARY == "MicrosoftMPI" && Sys.WORD_SIZE == 32) &&
+      Sys.ARCH !== :powerpc64le &&
+      Sys.ARCH !== :ppc64le &&
+      Sys.ARCH !== :aarch64 &&
+      !startswith(string(Sys.ARCH), "arm")))
 
 # a non-builtin isbits type to test generic MPI.reduce
 struct TestSum
@@ -126,6 +128,18 @@ for T = [Int]
 end
 
 MPI.Barrier( MPI.COMM_WORLD )
+
+if can_do_closures
+    # closure capturing state: modular addition is associative and commutative
+    m = 5
+    modsum = (x, y) -> mod(x + y, m)
+    result = MPI.Reduce(rank, MPI.Op(modsum, Int; iscommutative=true), MPI.COMM_WORLD; root=root)
+    if isroot
+        @test result == mod(sum(0:sz-1), m)
+    else
+        @test result === nothing
+    end
+end
 
 send_arr = [TestSum(i, i/4) for i = 1:10]
 


### PR DESCRIPTION
## Summary

MPICH ≥ 4.3 ships the experimental [`MPIX_Op_create_x`](https://github.com/pmodels/mpich/blob/main/src/include/mpix.h), which passes a `void *extra_state` context pointer to the user-defined reduction function (the implementation of the MPI Forum proposal [mpi-forum/mpi-issues#839](https://github.com/mpi-forum/mpi-issues/issues/839)):

```c
typedef void (MPIX_User_function_x)(void *a, void *b, MPI_Count len, MPI_Datatype datatype, void *extra_state);
typedef void (MPIX_Destructor_function)(void *extra_state);
int MPIX_Op_create_x(MPIX_User_function_x *user_fn_x, MPIX_Destructor_function *destructor_fn,
                     int commute, void *extra_state, MPI_Op *op);
```

With it, `MPI.Op(f, T)` no longer needs a closure `@cfunction`: the `OpWrapper` is passed as `extra_state` and recovered with `unsafe_pointer_to_objref` inside a plain `@cfunction`. This removes the LLVM-trampoline dependency and should make user-defined reduction operators work on aarch64 / ppc64le / arm (#404) when MPICH is the backend. Other backends keep using the existing closure path unchanged.

## Changes

- `MPI.API.MPIX_Op_create_x` binding and `MPI.API.HAS_MPIX_Op_create_x`, determined with `dlsym` at precompile time (same mechanism `@mpichk` uses for its version checks).
- `Op(f, T)` takes the new path when available, otherwise the existing closure-cfunction path with its platform errors.
- `OpWrapper` becomes `mutable struct` so its address can be taken; both callback signatures share the reduction kernel `_reduce!`. The `T = Any` case now receives the `MPI_Datatype` by value.
- A no-op destructor is passed: MPICH's generated argument checks reject `destructor_fn = NULL` with `MPI_ERR_ARG`, even though `MPIR_Op_free_impl` tolerates it.
- Tests: custom-op tests in `test_reduce.jl` are enabled whenever `HAS_MPIX_Op_create_x`, plus a new test with a state-capturing closure.
- Docs: known-issues section on custom reduction operators.

## Testing

Locally on x86_64 Linux, 3 ranks:

- MPICH_jll 5.0.1 (`HAS_MPIX_Op_create_x == true`): `test_reduce.jl`, `test_allreduce.jl`, `test_scan.jl`, `test_exscan.jl`, `test_onesided.jl` pass. Also checked `Op(f, Any)` with `Int32` and `Vector{Int}` inputs, and freeing the op followed by GC.
- OpenMPI_jll 5.0.10 (`HAS_MPIX_Op_create_x == false`): `test_reduce.jl` passes via the unchanged fallback path.

Not tested: an actual aarch64 machine. CI on macOS aarch64 with MPICH_jll would be the real check for this, which is the main reason this is a draft.

## Open questions

- Should `HAS_MPIX_Op_create_x` be surfaced in `MPI.versioninfo()`?
- Should the fallback path's architecture error be kept as is, or should `Op` suggest switching to MPICH?
- The `Op.fptr` field now holds either a closure `CFunction` or an `OpWrapper`; a rename would be a (minor) breaking change for anyone poking at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
