### PR TITLE
test_io_shared: Replace sync/skip workarounds with barriers

### DIFF
--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -15,12 +15,28 @@ fh = MPI.File.open(comm, filename, read=true, write=true, create=true)
 MPI.File.set_view!(fh, 0, MPI.Datatype(Int64), MPI.Datatype(Int64))
 MPI.File.write_at_all(fh, rank*2, ArrayType([Int64(rank+1) for i = 1:2]))
 
-# The file is in the default non-atomic mode, in which data written by one
-# process becomes visible to another only after the writer has called
-# `File.sync`, the two have synchronized, and the reader has called `File.sync`
-# as well (MPI standard, "File Consistency").  `File.sync` is collective, so all
-# ranks call it on both sides of the barrier.  Without the barrier, rank 0 can
-# read before the other ranks' writes have landed.
+# Synchronizing parallel MPI writes/reads requires a bit of a dance.
+#
+# The file is in the default non-atomic mode, in which data written by
+# one process becomes visible to other processes only after *first*
+# the writer has called `File.sync`, and *then* (afterwards) the
+# reader has called `File.sync`. To ensure the "first" ... "then" bit,
+# i.e. to ensure that the writer's `File.sync` happens before the
+# reader's `File.sync`, the two processes need to use e.g. an MPI
+# barrier (MPI standard, "File Consistency").
+#
+# `File.sync` is a collective operation, so all ranks must call it
+# whenever it is called, in this case on both sides of the barrier.
+# Without the barrier, one rank could read before the other ranks'
+# writes have finished.
+#
+# Terminology isn't really helpful here. There is `File.sync`, which
+# synchronizes a process's view of the file with the actual content of
+# the file, and there is an MPI `Barrier`, which synchronizes the MPI
+# processes with each other. That's two different kinds of
+# synchronization. Tongue-in-cheek: We need to barrier-synchronize
+# between the two file-synchronizations.
+
 MPI.File.sync(fh)
 MPI.Barrier(comm)
 MPI.File.sync(fh)

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -15,6 +15,14 @@ fh = MPI.File.open(comm, filename, read=true, write=true, create=true)
 MPI.File.set_view!(fh, 0, MPI.Datatype(Int64), MPI.Datatype(Int64))
 MPI.File.write_at_all(fh, rank*2, ArrayType([Int64(rank+1) for i = 1:2]))
 
+# The file is in the default non-atomic mode, in which data written by one
+# process becomes visible to another only after the writer has called
+# `File.sync`, the two have synchronized, and the reader has called `File.sync`
+# as well (MPI standard, "File Consistency").  `File.sync` is collective, so all
+# ranks call it on both sides of the barrier.  Without the barrier, rank 0 can
+# read before the other ranks' writes have landed.
+MPI.File.sync(fh)
+MPI.Barrier(comm)
 MPI.File.sync(fh)
 
 # Noncollective read
@@ -31,6 +39,9 @@ if rank == sz-1
     MPI.File.write_at(fh, 0, ArrayType([Int64(-1) for i = 1:2]))
 end
 
+# Same sync/barrier/sync sequence as above before reading the overwritten data.
+MPI.File.sync(fh)
+MPI.Barrier(comm)
 MPI.File.sync(fh)
 
 # Collective read

--- a/test/test_io_shared.jl
+++ b/test/test_io_shared.jl
@@ -1,28 +1,11 @@
 include("common.jl")
 
-# Syncing parallel MPI I/O is a bit involved:
-function sync(comm, fh)
-    # First ensure that all local changes are flushed ...
-    MPI.File.sync(fh)
-    # ... then wait for all other process to finish doing that ...
-    MPI.Barrier(comm)
-    # ... then make sure we see all changes that the other processes made.
-    MPI.File.sync(fh)
-end
-
-# Find MPI vendor
-library_version = MPI.Get_library_version()
-# Peel off MPItrampoline if present
-if startswith(library_version, "MPIwrapper ")
-    library_version = join(split(library_version, "\n")[2:end], "\n")
-end
-if startswith(library_version, "MPICH ")
-    vendor = :MPICH
-elseif startswith(library_version, "Open MPI ")
-    vendor = :OpenMPI
-else
-    vendor = nothing
-end
+# The shared file pointer is modified by every shared-pointer I/O call
+# (write_shared, write_ordered, read_ordered, ...) and reset by set_view!
+# and seek_shared.  MPI_File_get_position_shared is *not* collective, so a
+# query on one rank races against the next pointer-modifying call on a
+# faster rank unless the two are ordered with a barrier.  MPI_File_sync
+# only flushes file data and plays no role here.
 
 MPI.Init()
 
@@ -31,7 +14,6 @@ rank = MPI.Comm_rank(comm)
 sz = MPI.Comm_size(comm)
 filename = MPI.bcast(tempname(), 0, comm)
 
-# Collective write
 fh = MPI.File.open(comm, filename, read=true, write=true, create=true)
 @test MPI.File.get_position_shared(fh) == 0
 
@@ -39,55 +21,53 @@ if !MPI.File.get_atomicity(fh)
     MPI.File.set_atomicity(fh, true)
 end
 @test MPI.File.get_atomicity(fh)
-sync(comm, fh)
+MPI.Barrier(comm)
 
 header = "my header"
 
 if rank == 0
     MPI.File.write_shared(fh, header)
 end
-sync(comm, fh)
+MPI.Barrier(comm)
 
 offset = MPI.File.get_position_shared(fh)
 @test offset == sizeof(header)
 byte_offset = MPI.File.get_byte_offset(fh, offset)
 @test byte_offset == offset
+MPI.Barrier(comm)
 
 MPI.File.set_view!(fh, byte_offset, MPI.Datatype(Int64), MPI.Datatype(Int64))
-sync(comm, fh)
-# https://github.com/JuliaParallel/MPI.jl/issues/555
-# https://github.com/JuliaParallel/MPI.jl/issues/879
-@test MPI.File.get_position_shared(fh) == 0 skip = Sys.isapple() || (vendor == :MPICH && Sys.isunix()) || Sys.iswindows()
+@test MPI.File.get_position_shared(fh) == 0
+MPI.Barrier(comm)
 
 MPI.File.write_ordered(fh, fill(Int64(rank), rank+1))
-sync(comm, fh)
-# https://github.com/JuliaParallel/MPI.jl/issues/879
-@test MPI.File.get_position_shared(fh) == sum(1:sz) skip = Sys.isapple()
+@test MPI.File.get_position_shared(fh) == sum(1:sz)
+MPI.Barrier(comm)
 
 MPI.File.seek_shared(fh, 0)
 @test MPI.File.get_position_shared(fh) == 0
-sync(comm, fh)
+MPI.Barrier(comm)
 
 buf = zeros(Int64, rank+1)
 MPI.File.read_ordered!(fh, buf)
 @test buf == fill(Int64(rank), rank+1)
-sync(comm, fh)
-
-# https://github.com/JuliaParallel/MPI.jl/issues/555
-@test MPI.File.get_position_shared(fh) == sum(1:sz) skip = Sys.iswindows()
+@test MPI.File.get_position_shared(fh) == sum(1:sz)
+MPI.Barrier(comm)
 
 MPI.File.set_view!(fh, 0, MPI.Datatype(UInt8), MPI.Datatype(UInt8))
-sync(comm, fh)
+@test MPI.File.get_position_shared(fh) == 0
+MPI.Barrier(comm)
+
 MPI.File.seek_shared(fh, 0)
 @test MPI.File.get_position_shared(fh) == 0
-sync(comm, fh)
+MPI.Barrier(comm)
 
 if rank == sz-1
     buf = Array{UInt8}(undef, sizeof(header))
     MPI.File.read_shared!(fh, buf)
     @test String(buf) == header
 end
-sync(comm, fh)
+MPI.Barrier(comm)
 
 @test MPI.File.get_position_shared(fh) == sizeof(header)
 

--- a/test/test_io_shared.jl
+++ b/test/test_io_shared.jl
@@ -4,8 +4,7 @@ include("common.jl")
 # (write_shared, write_ordered, read_ordered, ...) and reset by set_view!
 # and seek_shared.  MPI_File_get_position_shared is *not* collective, so a
 # query on one rank races against the next pointer-modifying call on a
-# faster rank unless the two are ordered with a barrier.  MPI_File_sync
-# only flushes file data and plays no role here.
+# faster rank unless the two are ordered with a barrier.
 
 MPI.Init()
 

--- a/test/test_io_subarray.jl
+++ b/test/test_io_subarray.jl
@@ -31,6 +31,10 @@ disp = sizeof(data) * sz
 MPI.File.set_view!(fh, disp, etype, filetype)
 MPI.File.write(fh, data)
 
+# Unlike `test_io.jl`, every rank reads back only the bytes it wrote itself,
+# through the same file handle.  The MPI standard guarantees that such accesses
+# by a single process are sequentially consistent, so no barrier is needed
+# between the writes and the reads; the sync is not required for correctness.
 MPI.File.sync(fh)
 
 # Noncollective read


### PR DESCRIPTION
test_io_shared: Replace sync/skip workarounds with the barriers actually needed

The flakiness (#555 on Windows, #879 on macOS, and the Ubuntu failures seen in #926) was a data race in the test itself, not a library bug.

MPI_File_get_position_shared is not collective, but every other shared file pointer call in this test moves the pointer: write_ordered and read_ordered increment it, seek_shared and set_view reset it. ROMIO and OMPIO both perform the reset on rank 0 (ROMIO's set_view: on every rank that has the hidden .shfp file open) *before* their internal barrier, and write_ordered increments the counter on rank 0 as soon as rank 0 enters the call. So a fast rank entering the next operation clobbers the pointer while a slow rank is still inside `@test get_position_shared(fh) == ...`. That is exactly the `0 == 10` / `0 == 3` reported in the issues.

The fix is a plain MPI.Barrier after each block of position checks and before the next shared-pointer operation. MPI_File_sync only flushes file data (ROMIO keeps the pointer in a side file, OMPIO in shared memory) and plays no role; the old sync/Barrier/sync wrapper only helped through its embedded Barrier. With atomicity enabled the header data needs no sync either, only ordering.

The vendor detection and the Apple/MPICH/Windows `skip=` clauses were masking the same race and are removed. Reproduced locally on macOS with MPICH 4.3.1, MPICH_jll 5.x, OpenMPI_jll 5.0.10 and MPItrampoline_jll: 30-60% failure rate without the barriers, 0 failures in 80 runs with them.

Fixes #555, fixes #879.

(Thumbs pressed that this works!)