### PR TITLE
Fix C symbol names for MPI_Datatype Fortran/C handle conversion

### DIFF
--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -152,8 +152,12 @@ for handle in [
     :MPI_Request,
     :MPI_Win,
 ]
-    handle_f2c = Symbol(handle,:_f2c)
-    handle_c2f = Symbol(handle,:_c2f)
+    # The C conversion functions are named after the handle type, except for
+    # `MPI_Datatype`, for which the standard specifies `MPI_Type_f2c` and
+    # `MPI_Type_c2f`.
+    cname = handle === :MPI_Datatype ? :MPI_Type : handle
+    handle_f2c = Symbol(cname,:_f2c)
+    handle_c2f = Symbol(cname,:_c2f)
     @eval begin
         if $handle == Cint
             $handle_f2c(fcomm::Cint) = fcomm
@@ -165,6 +169,15 @@ for handle in [
             function $handle_c2f(comm::$handle)
                 ccall(($(Meta.quot(handle_c2f)), libmpi), Cint, ($handle,), comm)
             end
+        end
+    end
+    if cname !== handle
+        # `MPI_Datatype_f2c`/`MPI_Datatype_c2f` are kept as aliases for
+        # backwards compatibility; they never worked on ABIs with
+        # pointer-valued datatype handles, since no such C symbols exist.
+        @eval begin
+            const $(Symbol(handle,:_f2c)) = $handle_f2c
+            const $(Symbol(handle,:_c2f)) = $handle_c2f
         end
     end
 end

--- a/test/test_f2c.jl
+++ b/test/test_f2c.jl
@@ -1,0 +1,107 @@
+using Test
+using MPI
+
+MPI.Init()
+
+const API = MPI.API
+
+comm = MPI.COMM_WORLD
+
+# On most ABIs (MPICH, MPItrampoline, MicrosoftMPI, HPE MPT, MPI-ABI) the C and
+# Fortran handles share a representation and these conversions are the
+# identity, so the round-trips below are trivially true.  They only exercise the
+# `ccall`s -- and hence the C symbol names -- on ABIs with pointer-valued
+# handles, such as Open MPI.
+
+@testset "MPI_Comm" begin
+    for h in (MPI.COMM_WORLD.val, MPI.COMM_SELF.val)
+        @test API.MPI_Comm_f2c(API.MPI_Comm_c2f(h)) == h
+    end
+end
+
+@testset "MPI_Datatype" begin
+    derived = MPI.Types.create_vector(2, 3, 4, MPI.INT)
+    MPI.Types.commit!(derived)
+    for h in (MPI.INT.val, MPI.DOUBLE.val, derived.val)
+        # The MPI standard names these `MPI_Type_{f2c,c2f}`, not
+        # `MPI_Datatype_{f2c,c2f}`.
+        @test API.MPI_Type_f2c(API.MPI_Type_c2f(h)) == h
+        # Backwards-compatible aliases.
+        @test API.MPI_Datatype_f2c(API.MPI_Datatype_c2f(h)) == h
+    end
+    MPI.free(derived)
+end
+
+@testset "MPI_Errhandler" begin
+    for h in (MPI.ERRORS_RETURN.val, MPI.ERRORS_ARE_FATAL.val)
+        @test API.MPI_Errhandler_f2c(API.MPI_Errhandler_c2f(h)) == h
+    end
+end
+
+@testset "MPI_File" begin
+    # Open on `COMM_SELF` so that each rank gets its own file and no
+    # collective coordination is needed.
+    filename = tempname()
+    fh = MPI.File.open(MPI.COMM_SELF, filename; read=true, write=true, create=true)
+    h = fh.val
+    @test API.MPI_File_f2c(API.MPI_File_c2f(h)) == h
+    MPI.File.close(fh)
+    rm(filename; force=true)
+end
+
+@testset "MPI_Group" begin
+    group = MPI.Comm_group(comm)
+    for h in (group.val, MPI.GROUP_EMPTY.val)
+        @test API.MPI_Group_f2c(API.MPI_Group_c2f(h)) == h
+    end
+    MPI.free(group)
+end
+
+@testset "MPI_Info" begin
+    info = MPI.Info(; init=true)
+    info[:foo] = "bar"
+    h = info.val
+    @test API.MPI_Info_f2c(API.MPI_Info_c2f(h)) == h
+    MPI.free(info)
+end
+
+@testset "MPI_Message" begin
+    # Match a message sent to ourselves so that we hold a real `MPI_Message`.
+    sendbuf = Cint[1, 2, 3]
+    recvbuf = similar(sendbuf)
+    sendreq = MPI.Isend(sendbuf, MPI.COMM_SELF; dest=0, tag=0)
+    msg = MPI.Mprobe(MPI.COMM_SELF; source=0, tag=0)
+    h = msg.val
+    @test API.MPI_Message_f2c(API.MPI_Message_c2f(h)) == h
+    MPI.Mrecv!(recvbuf, msg)
+    MPI.Wait(sendreq)
+    @test recvbuf == sendbuf
+end
+
+@testset "MPI_Op" begin
+    userop = MPI.Op(+, Cint)
+    for h in (MPI.SUM.val, MPI.MAX.val, userop.val)
+        @test API.MPI_Op_f2c(API.MPI_Op_c2f(h)) == h
+    end
+end
+
+@testset "MPI_Request" begin
+    buf = Cint[0]
+    req = MPI.Irecv!(buf, MPI.COMM_SELF; source=0, tag=0)
+    h = req.val
+    @test API.MPI_Request_f2c(API.MPI_Request_c2f(h)) == h
+    MPI.Send(Cint[42], MPI.COMM_SELF; dest=0, tag=0)
+    MPI.Wait(req)
+    @test buf == Cint[42]
+end
+
+@testset "MPI_Win" begin
+    buf = zeros(Cint, 4)
+    win = MPI.Win_create(buf, MPI.COMM_SELF)
+    h = win.val
+    @test API.MPI_Win_f2c(API.MPI_Win_c2f(h)) == h
+    MPI.free(win)
+end
+
+MPI.Finalize()
+@test MPI.Finalized()


### PR DESCRIPTION
## The bug

The handle-conversion wrappers generated in `src/api/api.jl` derived the `ccall` symbol from the Julia handle type name:

```julia
handle_f2c = Symbol(handle, :_f2c)
...
ccall(($(Meta.quot(handle_f2c)), libmpi), $handle, (Cint,), fcomm)
```

For `:MPI_Datatype` that produces `MPI_Datatype_f2c` / `MPI_Datatype_c2f`. The MPI standard names those functions **`MPI_Type_f2c`** and **`MPI_Type_c2f`**, and no implementation exports the `MPI_Datatype_*` spelling, so the calls failed to resolve:

```
could not load symbol "MPI_Datatype_c2f":
dlsym(0x6cf88040, MPI_Datatype_c2f): symbol not found
```

The nine other handle types are unaffected — `MPI_Comm_f2c`, `MPI_Op_c2f` etc. are the real C names.

The bug was latent because of the `if $handle == Cint` branch: where `MPI_Datatype === Cint` the wrappers short-circuit to the identity and never `ccall`. Checking the installed JLL artifacts, that covers fewer ABIs than one might expect:

| ABI | `MPI_Datatype` | `MPI_Type_f2c` exported | `MPI_Datatype_f2c` exported | affected |
|---|---|---|---|---|
| MPICH | `Cint` | yes | no | no (identity) |
| MicrosoftMPI, HPE MPT | `Cint` | — | — | no (identity) |
| Open MPI | `Ptr{Cvoid}` | yes | **no** | **yes** |
| MPItrampoline | `UInt64` | yes | **no** | **yes** |
| MPI-ABI | `Ptr{Cvoid}` | yes | **no** | **yes** |

So this affected three ABIs, not just Open MPI.

## The fix

`MPI_Type_f2c` / `MPI_Type_c2f` are now the primary names, matching C. `MPI_Datatype_f2c` / `MPI_Datatype_c2f` are kept as `const` aliases — `MPI.API` is public, so removing them outright would be breaking.

`git grep MPI_Datatype_f2c` finds no uses inside the repository, so this was an API-surface bug rather than a broken code path in MPI.jl itself.

## Tests

New `test/test_f2c.jl` round-trips a **real** handle of each of the ten handle types through `_c2f` / `_f2c` and asserts `f2c(c2f(h)) == h` — not merely that the call does not throw, so that it stays meaningful on ABIs where the conversions are the identity. Handles used: `COMM_WORLD`/`COMM_SELF`, `INT`/`DOUBLE`/a committed vector type, `ERRORS_RETURN`/`ERRORS_ARE_FATAL`, an open `File`, a `Comm_group`/`GROUP_EMPTY`, a populated `Info`, an `Mprobe`d `Message`, `SUM`/`MAX`/a user-defined `Op`, a pending `Irecv!` `Request`, and a `Win_create`d window. Everything that needs a communicator uses `COMM_SELF`, so the file runs unchanged at any `nprocs`.

**Note:** the datatype part of this is only a regression test on ABIs with non-`Cint` datatype handles — reproduce with `MPIPreferences.use_jll_binary("OpenMPI_jll")` (or `MPItrampoline_jll` / `MPIABI_jll`). On MPICH it passes both before and after.

Verified locally with `-n 1` and `-n 3` on MPICH_jll, OpenMPI_jll and MPItrampoline_jll; all ten testsets pass on each, and the new test fails on Open MPI without the `src/api/api.jl` change.
