### PR TITLE
Correct f2c/c2f handle conversions

### DIFF
--- a/src/api/api.jl
+++ b/src/api/api.jl
@@ -157,22 +157,36 @@ for handle in [
     handle_f2c = Symbol(cname,:_f2c)
     handle_c2f = Symbol(cname,:_c2f)
     @eval begin
-        if $handle == Cint
-            $handle_f2c(fcomm::Cint) = fcomm
-            $handle_c2f(comm::Cint) = comm
-        else
+        if !isnothing(dlsym(libmpi_handle, $(Meta.quot(handle_f2c)); throw_error=false)) &&
+           !isnothing(dlsym(libmpi_handle, $(Meta.quot(handle_c2f)); throw_error=false))
+            # Call the library's own conversion functions whenever it exports them
             function $handle_f2c(fcomm::Cint)
-                ccall(($(Meta.quot(handle_f2c)), libmpi), $handle, (Cint,), fcomm)
+                @mpicall ccall(($(Meta.quot(handle_f2c)), libmpi), $handle, (Cint,), fcomm)
             end
             function $handle_c2f(comm::$handle)
-                ccall(($(Meta.quot(handle_c2f)), libmpi), Cint, ($handle,), comm)
+                @mpicall ccall(($(Meta.quot(handle_c2f)), libmpi), Cint, ($handle,), comm)
             end
+        elseif $handle === Cint || $handle === Cuint
+            # The library has no such functions.  Before MPI 4.1 the standard
+            # allowed these conversions to be macros, and MPICH before 4.2 as
+            # well as its derivatives (Microsoft MPI, MVAPICH, Intel MPI, Cray
+            # MPICH, HPE MPT) did that.
+            #
+            # Luckily we know that MPICH uses the same internal
+            # representation for C and Fortran handles, so the
+            # conversion is a no-op.
+            $handle_f2c(fcomm::Cint) = fcomm % $handle
+            $handle_c2f(comm::$handle) = comm % Cint
+        else
+            $handle_f2c(fcomm::Cint) =
+                error($(string(handle_f2c)), " is not exported by this MPI library")
+            $handle_c2f(comm::$handle) =
+                error($(string(handle_c2f)), " is not exported by this MPI library")
         end
     end
     if cname !== handle
-        # `MPI_Datatype_f2c`/`MPI_Datatype_c2f` are kept as aliases for
-        # backwards compatibility; they never worked on ABIs with
-        # pointer-valued datatype handles, since no such C symbols exist.
+        # Keep `MPI_Datatype_f2c`/`MPI_Datatype_c2f` as aliases for
+        # backwards compatibility
         @eval begin
             const $(Symbol(handle,:_f2c)) = $handle_f2c
             const $(Symbol(handle,:_c2f)) = $handle_c2f

--- a/test/test_f2c.jl
+++ b/test/test_f2c.jl
@@ -5,13 +5,13 @@ MPI.Init()
 
 const API = MPI.API
 
-comm = MPI.COMM_WORLD
-
-# On most ABIs (MPICH, MPItrampoline, MicrosoftMPI, HPE MPT, MPI-ABI) the C and
-# Fortran handles share a representation and these conversions are the
-# identity, so the round-trips below are trivially true.  They only exercise the
-# `ccall`s -- and hence the C symbol names -- on ABIs with pointer-valued
-# handles, such as Open MPI.
+# The conversions call the library's `MPI_*_f2c`/`MPI_*_c2f` functions wherever
+# it exports them.  MPICH before 4.2 and its derivatives (Microsoft MPI, MVAPICH,
+# Intel MPI, Cray MPICH, HPE MPT) export only the `MPI_File` and `MPI_Status`
+# ones and define the others as header macros casting the integer handle, which
+# `src/api/api.jl` reproduces.  The round-trips below therefore exercise the C
+# symbol names wherever they exist; they are only non-trivial where handles are
+# pointers, such as Open MPI.
 
 @testset "MPI_Comm" begin
     for h in (MPI.COMM_WORLD.val, MPI.COMM_SELF.val)
@@ -50,7 +50,7 @@ end
 end
 
 @testset "MPI_Group" begin
-    group = MPI.Comm_group(comm)
+    group = MPI.Comm_group(MPI.COMM_WORLD)
     for h in (group.val, MPI.GROUP_EMPTY.val)
         @test API.MPI_Group_f2c(API.MPI_Group_c2f(h)) == h
     end
@@ -96,8 +96,11 @@ end
 end
 
 @testset "MPI_Win" begin
+    # Note: On our Debian CI setup, Open MPI 4.1 has no one-sided
+    # component that can serve a window on a single-process
+    # communicator. We thus use `COMM_WORLD` instead.
     buf = zeros(Cint, 4)
-    win = MPI.Win_create(buf, MPI.COMM_SELF)
+    win = MPI.Win_create(buf, MPI.COMM_WORLD)
     h = win.val
     @test API.MPI_Win_f2c(API.MPI_Win_c2f(h)) == h
     MPI.free(win)


### PR DESCRIPTION
- Use conversion functions where available
- Use no-op conversions only where functions are not available
- Correct Windows ABI
- Make f2c tests work with our Open MPI setup

This should resolve the recent Windows build failures.